### PR TITLE
Fix no-snap speed handling

### DIFF
--- a/src/components/layout/ScrollablePortfolio.jsx
+++ b/src/components/layout/ScrollablePortfolio.jsx
@@ -25,7 +25,9 @@ const ScrollablePortfolio = ({
         container.classList.remove('fast-snap', 'medium-snap', 'slow-snap', 'extra-slow-snap', 'no-snap');
         
         // Add the new speed class
-        const speedClass = `${snapSpeed}-snap`;
+        const speedClass = snapSpeed === 'no-snap'
+            ? 'no-snap'
+            : `${snapSpeed}-snap`;
         container.classList.add(speedClass);
         
         console.log('🎯 Applied snap speed:', snapSpeed);


### PR DESCRIPTION
## Summary
- update scroll snap speed logic in `ScrollablePortfolio` so that `no-snap` maps to `no-snap` CSS class

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684118947cbc83289c6ac5cc2756c310