### PR TITLE
Fix crystal reform animation sequence

### DIFF
--- a/src/components/three/UnifiedCrystalScene.jsx
+++ b/src/components/three/UnifiedCrystalScene.jsx
@@ -30,6 +30,7 @@ const UnifiedCrystalScene = ({
   // FIXED: Animation coordination
   const lastAnimationState = useRef(null);
   const reformStartTime = useRef(null);
+  const reformTimeouts = useRef([]);
   
   // Component state
   const [showWholeCrystal, setShowWholeCrystal] = useState(true);
@@ -98,6 +99,10 @@ const UnifiedCrystalScene = ({
         });
       }
 
+      // Clear any pending reform timeouts when state changes
+      reformTimeouts.current.forEach(clearTimeout);
+      reformTimeouts.current = [];
+
       // Handle visibility changes based on animation state
       switch (currentState) {
         case 'hero':
@@ -133,10 +138,18 @@ const UnifiedCrystalScene = ({
           break;
           
         case 'reforming_crystal':
-          // FIXED: This is when we switch from facets to whole crystal
-          setShowWholeCrystal(true);
-          setShowFacets(false);
-          reformStartTime.current = clock.getElapsedTime(); // Track reform start
+          // Show facets moving back to center then reveal whole crystal
+          setShowWholeCrystal(false);
+          setShowFacets(true);
+          reformStartTime.current = clock.getElapsedTime();
+
+          // Reveal whole crystal slightly before facets disappear
+          reformTimeouts.current.push(
+            setTimeout(() => setShowWholeCrystal(true), config.timing.reform.crystalAppearTime)
+          );
+          reformTimeouts.current.push(
+            setTimeout(() => setShowFacets(false), config.timing.reform.facetsDisappearTime)
+          );
           break;
           
         case 'reforming_camera':
@@ -247,6 +260,13 @@ const UnifiedCrystalScene = ({
       }
     }
   });
+
+  // Cleanup any pending timeouts on unmount
+  useEffect(() => {
+    return () => {
+      reformTimeouts.current.forEach(clearTimeout);
+    };
+  }, []);
 
   /**
    * Get facet color by index

--- a/src/hooks/useUnifiedAnimationController.js
+++ b/src/hooks/useUnifiedAnimationController.js
@@ -413,16 +413,21 @@ export const useUnifiedAnimationController = (options = {}) => {
       if (zoneChanged && !animationState.isTransitioning) {
         
         if (currentZone.zone === 'hero') {
-          // Direct to hero - no animation needed since it's the start
-          setAnimationState(prev => ({
-            ...prev,
-            state: ANIMATION_STATES.HERO,
-            crystalForm: 'whole',
-            cameraState: 'hero',
-            focusedFacet: null,
-            isTransitioning: false
-          }));
-        } 
+          if (animationState.crystalForm === 'exploded') {
+            // Coming from exploded state - play reform sequence
+            startReformSequence();
+          } else {
+            // Already whole - just reset state
+            setAnimationState(prev => ({
+              ...prev,
+              state: ANIMATION_STATES.HERO,
+              crystalForm: 'whole',
+              cameraState: 'hero',
+              focusedFacet: null,
+              isTransitioning: false
+            }));
+          }
+        }
         else if (currentZone.zone === 'overview') {
           if (lastZone.current === 'hero') {
             // FIXED: Hero to overview - trigger coordinated explosion


### PR DESCRIPTION
## Summary
- animate facets during `reforming_crystal` instead of instant swap
- handle cleanup of reform timers
- trigger reform when scrolling back to hero

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6842554ef5488328b241a8e1ec901674