### PR TITLE
Fix reform sequence zone handling

### DIFF
--- a/src/hooks/useUnifiedAnimationController.js
+++ b/src/hooks/useUnifiedAnimationController.js
@@ -475,6 +475,11 @@ export const useUnifiedAnimationController = (options = {}) => {
           }
         }
 
+      }
+
+      // Always track the latest zone so we don't retrigger when a
+      // transition finishes after the zone already changed
+      if (zoneChanged) {
         lastZone.current = currentZone.zone;
       }
 

--- a/src/hooks/useUnifiedAnimationController.js
+++ b/src/hooks/useUnifiedAnimationController.js
@@ -241,6 +241,7 @@ export const useUnifiedAnimationController = (options = {}) => {
   const animationSequence = useRef(null);
   const animationPhase = useRef(null);  // Track which phase of animation we're in
   const lastZone = useRef('hero');
+  const sequenceTarget = useRef(null);  // Track target zone for active sequence
   const lastProject = useRef(null);
   const updateThrottle = useRef({
     timeout: null,
@@ -313,6 +314,7 @@ export const useUnifiedAnimationController = (options = {}) => {
    */
   const startReformSequence = useCallback((target = 'about') => {
     clearAnimationSequence();
+    sequenceTarget.current = target;
     
     if (debugMode) {
       console.log('🎬 Starting coordinated reform sequence');
@@ -350,8 +352,13 @@ export const useUnifiedAnimationController = (options = {}) => {
             state: target === 'hero'
               ? ANIMATION_STATES.HERO
               : ANIMATION_STATES.ABOUT,
+            cameraState: target,
             isTransitioning: false
           }));
+
+          // Ensure zone tracking matches the final position
+          lastZone.current = target;
+          sequenceTarget.current = null;
           
           if (debugMode) {
             console.log('✅ Reform sequence complete - crystal reformed and camera stable');

--- a/src/hooks/useUnifiedAnimationController.js
+++ b/src/hooks/useUnifiedAnimationController.js
@@ -102,10 +102,10 @@ export const ANIMATION_CONFIG = {
     explosionDuration: 1200,     // Crystal explodes + camera to overview
     explosionSettle: 300,        // Final settling time
     
-    // Reform sequence - overview/projects to about
+    // Reform sequence - return crystal to whole (hero or about)
     reformPrepare: 500,          // Move to pre-reform position
     reformDuration: 1000,        // Crystal reforms
-    reformCameraMove: 800,       // Camera moves to final about position
+    reformCameraMove: 800,       // Camera moves to final position
     reformSettle: 200,           // Final settling
     
     // Project transitions
@@ -307,9 +307,11 @@ export const useUnifiedAnimationController = (options = {}) => {
   }, [clearAnimationSequence, config, debugMode]);
 
   /**
-   * FIXED: Coordinated reform sequence (overview/projects to about)
+   * FIXED: Coordinated reform sequence
+   * Now accepts a target ("hero" or "about") so the final camera
+   * position matches the zone that triggered the sequence.
    */
-  const startReformSequence = useCallback(() => {
+  const startReformSequence = useCallback((target = 'about') => {
     clearAnimationSequence();
     
     if (debugMode) {
@@ -334,18 +336,20 @@ export const useUnifiedAnimationController = (options = {}) => {
       }));
 
       animationSequence.current = setTimeout(() => {
-        // Phase 3: Camera moves to final about position
+        // Phase 3: Camera moves to final target position
         setAnimationState(prev => ({
           ...prev,
           state: ANIMATION_STATES.REFORMING_CAMERA,
-          cameraState: 'about'  // FIXED: Now camera moves to final position
+          cameraState: target  // Move camera to the requested final zone
         }));
 
         animationSequence.current = setTimeout(() => {
           // Phase 4: Final settle
           setAnimationState(prev => ({
             ...prev,
-            state: ANIMATION_STATES.ABOUT,
+            state: target === 'hero'
+              ? ANIMATION_STATES.HERO
+              : ANIMATION_STATES.ABOUT,
             isTransitioning: false
           }));
           
@@ -414,8 +418,8 @@ export const useUnifiedAnimationController = (options = {}) => {
         
         if (currentZone.zone === 'hero') {
           if (animationState.crystalForm === 'exploded') {
-            // Coming from exploded state - play reform sequence
-            startReformSequence();
+            // Coming from exploded state - play reform sequence back to hero
+            startReformSequence('hero');
           } else {
             // Already whole - just reset state
             setAnimationState(prev => ({
@@ -455,9 +459,9 @@ export const useUnifiedAnimationController = (options = {}) => {
           }));
         }
         else if (currentZone.zone === 'about') {
-          // FIXED: About section - trigger coordinated reform
+          // FIXED: About section - trigger coordinated reform to about
           if (animationState.crystalForm === 'exploded') {
-            startReformSequence();
+            startReformSequence('about');
           } else {
             // Already reformed
             setAnimationState(prev => ({

--- a/src/hooks/useUnifiedAnimationController.js
+++ b/src/hooks/useUnifiedAnimationController.js
@@ -356,8 +356,7 @@ export const useUnifiedAnimationController = (options = {}) => {
             isTransitioning: false
           }));
 
-          // Ensure zone tracking matches the final position
-          lastZone.current = target;
+          // Animation complete, clear sequence target
           sequenceTarget.current = null;
           
           if (debugMode) {
@@ -418,6 +417,12 @@ export const useUnifiedAnimationController = (options = {}) => {
 
       if (debugMode && zoneChanged) {
         console.log(`🗺️ Zone transition: ${lastZone.current} → ${currentZone.zone}`);
+      }
+
+      // Track the latest zone immediately so any running sequences
+      // use the new target if a user scrolls during the animation
+      if (zoneChanged) {
+        lastZone.current = currentZone.zone;
       }
 
       // FIXED: Only trigger animations on actual zone changes and when not already transitioning
@@ -484,11 +489,7 @@ export const useUnifiedAnimationController = (options = {}) => {
 
       }
 
-      // Always track the latest zone so we don't retrigger when a
-      // transition finishes after the zone already changed
-      if (zoneChanged) {
-        lastZone.current = currentZone.zone;
-      }
+
 
       // Handle project changes within projects zone
       if (currentZone.zone === 'projects' && projectChanged && activeProject.project) {

--- a/src/hooks/useUnifiedAnimationController.js
+++ b/src/hooks/useUnifiedAnimationController.js
@@ -409,8 +409,26 @@ export const useUnifiedAnimationController = (options = {}) => {
 
     const runUpdates = () => {
       const progress = throttle.latestProgress;
-      const currentZone = calculateCurrentZone(progress, config);
+      let currentZone = calculateCurrentZone(progress, config);
       const activeProject = calculateActiveProject(progress, config);
+
+      // If a reform sequence is currently running, lock the zone to the
+      // sequence target so interim scroll position changes don't trigger
+      // additional reform sequences or zone flips. This prevents the camera
+      // pop that occurred when the calculated zone briefly switched to
+      // "about" right as the reform animation finished.
+      if (
+        animationState.isTransitioning &&
+        sequenceTarget.current &&
+        [
+          ANIMATION_STATES.PREPARING_REFORM,
+          ANIMATION_STATES.REFORMING_CRYSTAL,
+          ANIMATION_STATES.REFORMING_CAMERA,
+          ANIMATION_STATES.REFORM_SETTLING
+        ].includes(animationState.state)
+      ) {
+        currentZone = { ...currentZone, zone: sequenceTarget.current };
+      }
       
       const zoneChanged = currentZone.zone !== lastZone.current;
       const projectChanged = activeProject.project !== lastProject.current;


### PR DESCRIPTION
## Summary
- allow reform sequence to target either hero or about
- correct comments and adjust callers to specify the desired zone

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68425b1e07dc8328bb98873cdd4c570b