### PR TITLE
Ensure crystal scene resets on PBR toggle

### DIFF
--- a/src/components/layout/Fixed3DCanvas.jsx
+++ b/src/components/layout/Fixed3DCanvas.jsx
@@ -182,7 +182,8 @@ const Fixed3DCanvas = ({
           />
           
           {/* UPDATED: Crystal Scene with ref for accessing debug state */}
-          <UnifiedCrystalScene 
+          <UnifiedCrystalScene
+            key={performanceConfig?.usePBR}
             ref={crystalSceneRef} // NEW: Ref to access debug state and methods
             animationData={animationData}
             config={config}


### PR DESCRIPTION
## Summary
- remount `UnifiedCrystalScene` when the PBR flag changes so all materials rebuild

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68634893d4dc83289f0785d92da9adf0