### PR TITLE
Add adaptive performance hook

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -83,6 +83,7 @@ import FpsDisplay, { PerformanceAlert } from './components/ui/FpsDisplay';
 // Configuration and utilities (unchanged)
 import * as defaultConfig from './crystalConfig';
 import { useDeviceProfile } from './hooks/useDeviceProfile';
+import { useAdaptivePerformance } from './hooks/useAdaptivePerformance';
 
 // Simple mobile detection (unchanged)
 const isMobileDevice = () => {
@@ -162,7 +163,7 @@ function App() {
   });
   
   const [postProcessingConfig, setPostProcessingConfig] = useState(config.postProcessing);
-  
+
   // Performance config (unchanged)
   const [performanceConfig, setPerformanceConfig] = useState(() => {
     return {
@@ -172,6 +173,9 @@ function App() {
       renderScale: 0.7
     };
   });
+
+  // Adaptive performance based on runtime FPS
+  const { currentPerformanceConfig } = useAdaptivePerformance(performanceConfig);
 
   // Performance management (unchanged)
   const [lastAppliedProfile, setLastAppliedProfile] = useState(null);
@@ -215,11 +219,11 @@ function App() {
   
   React.useEffect(() => {
     if (updateExternalPerformanceConfig && hasInitialized && initialProfileApplied) {
-      updateExternalPerformanceConfig(performanceConfig);
+      updateExternalPerformanceConfig(currentPerformanceConfig);
     } else if (devicePerformanceProfile && !hasInitialized) {
       setHasInitialized(true);
     }
-  }, [performanceConfig, updateExternalPerformanceConfig, hasInitialized, devicePerformanceProfile, initialProfileApplied]);
+  }, [currentPerformanceConfig, updateExternalPerformanceConfig, hasInitialized, devicePerformanceProfile, initialProfileApplied]);
 
   // UI Hide Toggle Keyboard Listener
   React.useEffect(() => {
@@ -405,7 +409,7 @@ function App() {
           iceOpalConfig={iceOpalConfig}
           effectsEnabled={effectsEnabled}
           postProcessingConfig={postProcessingConfig}
-          performanceConfig={performanceConfig}
+          performanceConfig={currentPerformanceConfig}
           config={config}
           canvasProps={canvasProps}
           environmentProps={environmentProps}
@@ -471,7 +475,7 @@ function App() {
           />
           
           <PerformanceControls
-            performanceConfig={performanceConfig}
+            performanceConfig={currentPerformanceConfig}
             onConfigUpdate={handlePerformanceConfigUpdate}
             visible={true}
           />

--- a/src/hooks/useAdaptivePerformance.js
+++ b/src/hooks/useAdaptivePerformance.js
@@ -1,0 +1,88 @@
+// src/hooks/useAdaptivePerformance.js
+// Hook to adapt performance settings based on FPS measurements
+
+import { useState, useEffect, useRef } from 'react';
+import { useFPSMonitorDOM } from '../components/ui/FpsDisplay';
+
+/**
+ * Adaptive performance hook
+ * @param {Object} baseConfig - starting performance configuration
+ * @param {Object} options - configuration options
+ *    threshold: FPS threshold before downgrading
+ *    lowTierProfile: config applied when FPS is low
+ *    restoreThreshold: FPS required to restore high settings
+ *    lowFpsDuration: ms to wait before applying downgrade
+ *    highFpsDuration: ms to wait before restoring
+ */
+export const useAdaptivePerformance = (
+  baseConfig = {},
+  {
+    threshold = 55,
+    lowTierProfile = { usePBR: false, textureQuality: 'low', renderScale: 0.7 },
+    restoreThreshold = 60,
+    lowFpsDuration = 3000,
+    highFpsDuration = 5000
+  } = {}
+) => {
+  const { avgFps } = useFPSMonitorDOM();
+
+  // Track the current effective configuration
+  const [currentPerformanceConfig, setCurrentPerformanceConfig] = useState(baseConfig);
+
+  // Save the base config so we can restore
+  const [basePerformanceConfig, setBasePerformanceConfig] = useState(baseConfig);
+
+  const lowFpsStart = useRef(null);
+  const highFpsStart = useRef(null);
+  const downgraded = useRef(false);
+
+  // Update stored base config when it changes externally
+  useEffect(() => {
+    setBasePerformanceConfig(baseConfig);
+    if (!downgraded.current) {
+      setCurrentPerformanceConfig(baseConfig);
+    }
+  }, [baseConfig]);
+
+  // Monitor FPS and adjust configuration
+  useEffect(() => {
+    const now = Date.now();
+
+    if (avgFps > 0 && avgFps < threshold) {
+      if (lowFpsStart.current === null) {
+        lowFpsStart.current = now;
+      }
+      if (now - lowFpsStart.current > lowFpsDuration && !downgraded.current) {
+        setCurrentPerformanceConfig(prev => ({ ...prev, ...lowTierProfile }));
+        downgraded.current = true;
+        highFpsStart.current = null;
+      }
+    } else {
+      lowFpsStart.current = null;
+
+      if (downgraded.current && avgFps >= restoreThreshold) {
+        if (highFpsStart.current === null) {
+          highFpsStart.current = now;
+        }
+        if (now - highFpsStart.current > highFpsDuration) {
+          setCurrentPerformanceConfig(basePerformanceConfig);
+          downgraded.current = false;
+          highFpsStart.current = null;
+        }
+      } else {
+        highFpsStart.current = null;
+      }
+    }
+  }, [avgFps, threshold, lowTierProfile, restoreThreshold, lowFpsDuration, highFpsDuration, basePerformanceConfig]);
+
+  // Allow manual config updates
+  const updatePerformanceConfig = (config) => {
+    setBasePerformanceConfig(config);
+    setCurrentPerformanceConfig(config);
+    downgraded.current = false;
+    lowFpsStart.current = null;
+    highFpsStart.current = null;
+  };
+
+  return { currentPerformanceConfig, updatePerformanceConfig };
+};


### PR DESCRIPTION
## Summary
- add `useAdaptivePerformance` hook using FPS monitor
- use hook in `App.jsx` to auto-adjust performance settings

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68634ae765ec8328aba85103ae995727