### PR TITLE
Fix manual performance overrides after adaptive downgrade

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -175,7 +175,7 @@ function App() {
   });
 
   // Adaptive performance based on runtime FPS
-  const { currentPerformanceConfig } = useAdaptivePerformance(performanceConfig);
+  const { currentPerformanceConfig, updatePerformanceConfig } = useAdaptivePerformance(performanceConfig);
 
   // Performance management (unchanged)
   const [lastAppliedProfile, setLastAppliedProfile] = useState(null);
@@ -333,7 +333,8 @@ function App() {
   const handlePerformanceConfigUpdate = useCallback((newConfig) => {
     console.log("🔧 Manual performance config update:", newConfig);
     setPerformanceConfig(newConfig);
-  }, []);
+    updatePerformanceConfig(newConfig);
+  }, [updatePerformanceConfig]);
 
   const toggleUI = useCallback(() => {
     setShowUI(!showUI);

--- a/src/hooks/useAdaptivePerformance.js
+++ b/src/hooks/useAdaptivePerformance.js
@@ -39,9 +39,7 @@ export const useAdaptivePerformance = (
   // Update stored base config when it changes externally
   useEffect(() => {
     setBasePerformanceConfig(baseConfig);
-    if (!downgraded.current) {
-      setCurrentPerformanceConfig(baseConfig);
-    }
+    setCurrentPerformanceConfig(baseConfig);
   }, [baseConfig]);
 
   // Monitor FPS and adjust configuration


### PR DESCRIPTION
## Summary
- expose `updatePerformanceConfig` from `useAdaptivePerformance`
- ensure prop changes update current performance config
- use the new updater in `App` so UI changes update materials

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68635361348883288c8f550d0726af39