### PR TITLE
Improve adaptive performance timing

### DIFF
--- a/src/components/layout/Fixed3DCanvas.jsx
+++ b/src/components/layout/Fixed3DCanvas.jsx
@@ -183,7 +183,6 @@ const Fixed3DCanvas = ({
           
           {/* UPDATED: Crystal Scene with ref for accessing debug state */}
           <UnifiedCrystalScene
-            key={performanceConfig?.usePBR}
             ref={crystalSceneRef} // NEW: Ref to access debug state and methods
             animationData={animationData}
             config={config}

--- a/src/hooks/useAdaptivePerformance.js
+++ b/src/hooks/useAdaptivePerformance.js
@@ -17,11 +17,12 @@ import { useFPSMonitorDOM } from '../components/ui/FpsDisplay';
 export const useAdaptivePerformance = (
   baseConfig = {},
   {
-    threshold = 55,
+    threshold = 48,
     lowTierProfile = { usePBR: false, textureQuality: 'low', renderScale: 0.7 },
     restoreThreshold = 60,
-    lowFpsDuration = 3000,
-    highFpsDuration = 5000
+    lowFpsDuration = 5000,
+    highFpsDuration = 5000,
+    pbrChangeDelay = 5000
   } = {}
 ) => {
   const { avgFps } = useFPSMonitorDOM();
@@ -34,6 +35,7 @@ export const useAdaptivePerformance = (
 
   const lowFpsStart = useRef(null);
   const highFpsStart = useRef(null);
+  const pbrChangeStart = useRef(null);
   const downgraded = useRef(false);
 
   // Update stored base config when it changes externally
@@ -50,10 +52,18 @@ export const useAdaptivePerformance = (
       if (lowFpsStart.current === null) {
         lowFpsStart.current = now;
       }
+
       if (now - lowFpsStart.current > lowFpsDuration && !downgraded.current) {
-        setCurrentPerformanceConfig(prev => ({ ...prev, ...lowTierProfile }));
+        const { usePBR, ...rest } = lowTierProfile;
+        setCurrentPerformanceConfig(prev => ({ ...prev, ...rest }));
         downgraded.current = true;
         highFpsStart.current = null;
+        pbrChangeStart.current = now;
+      }
+
+      if (downgraded.current && currentPerformanceConfig.usePBR &&
+          now - pbrChangeStart.current > pbrChangeDelay) {
+        setCurrentPerformanceConfig(prev => ({ ...prev, usePBR: lowTierProfile.usePBR }));
       }
     } else {
       lowFpsStart.current = null;
@@ -63,15 +73,24 @@ export const useAdaptivePerformance = (
           highFpsStart.current = now;
         }
         if (now - highFpsStart.current > highFpsDuration) {
-          setCurrentPerformanceConfig(basePerformanceConfig);
+          const { usePBR } = currentPerformanceConfig;
+          setCurrentPerformanceConfig({ ...basePerformanceConfig, usePBR });
           downgraded.current = false;
           highFpsStart.current = null;
+          pbrChangeStart.current = now;
         }
       } else {
         highFpsStart.current = null;
       }
+
+      if (!downgraded.current && !currentPerformanceConfig.usePBR &&
+          avgFps >= restoreThreshold &&
+          now - pbrChangeStart.current > pbrChangeDelay) {
+        setCurrentPerformanceConfig(prev => ({ ...prev, usePBR: basePerformanceConfig.usePBR }));
+        pbrChangeStart.current = null;
+      }
     }
-  }, [avgFps, threshold, lowTierProfile, restoreThreshold, lowFpsDuration, highFpsDuration, basePerformanceConfig]);
+  }, [avgFps, threshold, lowTierProfile, restoreThreshold, lowFpsDuration, highFpsDuration, basePerformanceConfig, pbrChangeDelay, currentPerformanceConfig.usePBR]);
 
   // Allow manual config updates
   const updatePerformanceConfig = (config) => {


### PR DESCRIPTION
## Summary
- raise default `lowFpsDuration` and lower FPS `threshold`
- defer PBR changes until FPS remains low/high for longer
- avoid re-mounting the crystal scene when `usePBR` changes

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68635569c8f083289243edf00afd7c5a