### PR TITLE
Add initial performance test hook

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -83,7 +83,7 @@ import FpsDisplay, { PerformanceAlert } from './components/ui/FpsDisplay';
 // Configuration and utilities (unchanged)
 import * as defaultConfig from './crystalConfig';
 import { useDeviceProfile } from './hooks/useDeviceProfile';
-import { useAdaptivePerformance } from './hooks/useAdaptivePerformance';
+import { useInitialPerformanceTest } from './hooks/useInitialPerformanceTest';
 
 // Simple mobile detection (unchanged)
 const isMobileDevice = () => {
@@ -174,56 +174,35 @@ function App() {
     };
   });
 
-  // Adaptive performance based on runtime FPS
-  const { currentPerformanceConfig, updatePerformanceConfig } = useAdaptivePerformance(performanceConfig);
+  // Initial performance test based on FPS
+  const { performanceConfig: initialPerformanceConfig, isTesting: isPerfTesting } =
+    useInitialPerformanceTest(deviceProfile);
+
+  React.useEffect(() => {
+    if (initialPerformanceConfig) {
+      setPerformanceConfig(initialPerformanceConfig);
+    }
+  }, [initialPerformanceConfig]);
 
   // Performance management (unchanged)
-  const [lastAppliedProfile, setLastAppliedProfile] = useState(null);
   const [initialProfileApplied, setInitialProfileApplied] = useState(false);
   
-  // Performance profile application (unchanged)
+  // Mark initialization when performance config is applied
   React.useEffect(() => {
-    if (devicePerformanceProfile && !isDetecting) {
-      const profileKey = JSON.stringify({
-        useNormalMaps: devicePerformanceProfile.useNormalMaps,
-        textureQuality: devicePerformanceProfile.textureQuality,
-        usePBR: devicePerformanceProfile.usePBR,
-        renderScale: devicePerformanceProfile.renderScale
-      });
-      
-      if (lastAppliedProfile !== profileKey) {
-        const newConfig = {
-          useNormalMaps: devicePerformanceProfile.useNormalMaps,
-          textureQuality: devicePerformanceProfile.textureQuality,
-          usePBR: devicePerformanceProfile.usePBR,
-          renderScale: devicePerformanceProfile.renderScale
-        };
-        
-        setPerformanceConfig(newConfig);
-        setLastAppliedProfile(profileKey);
-        setInitialProfileApplied(true);
-        
-        if (devicePerformanceProfile.postProcessing) {
-          setEffectsEnabled({
-            bloom: devicePerformanceProfile.postProcessing.bloom || false,
-            chromaticAberration: devicePerformanceProfile.postProcessing.chromaticAberration || false,
-            noise: devicePerformanceProfile.postProcessing.noise || true,
-            vignette: devicePerformanceProfile.postProcessing.vignette || false
-          });
-        }
-      }
+    if (initialPerformanceConfig && !initialProfileApplied) {
+      setInitialProfileApplied(true);
     }
-  }, [devicePerformanceProfile, isDetecting, lastAppliedProfile]);
+  }, [initialPerformanceConfig, initialProfileApplied]);
 
   const [hasInitialized, setHasInitialized] = useState(false);
   
   React.useEffect(() => {
     if (updateExternalPerformanceConfig && hasInitialized && initialProfileApplied) {
-      updateExternalPerformanceConfig(currentPerformanceConfig);
-    } else if (devicePerformanceProfile && !hasInitialized) {
+      updateExternalPerformanceConfig(performanceConfig);
+    } else if (initialPerformanceConfig && !hasInitialized) {
       setHasInitialized(true);
     }
-  }, [currentPerformanceConfig, updateExternalPerformanceConfig, hasInitialized, devicePerformanceProfile, initialProfileApplied]);
+  }, [performanceConfig, updateExternalPerformanceConfig, hasInitialized, initialPerformanceConfig, initialProfileApplied]);
 
   // UI Hide Toggle Keyboard Listener
   React.useEffect(() => {
@@ -333,8 +312,7 @@ function App() {
   const handlePerformanceConfigUpdate = useCallback((newConfig) => {
     console.log("🔧 Manual performance config update:", newConfig);
     setPerformanceConfig(newConfig);
-    updatePerformanceConfig(newConfig);
-  }, [updatePerformanceConfig]);
+  }, []);
 
   const toggleUI = useCallback(() => {
     setShowUI(!showUI);
@@ -398,7 +376,7 @@ function App() {
       )}
 
       {/* NEW: Master Animation Coordinator - Single source of truth for all animations */}
-      {!isDetecting && (
+      {!isDetecting && !isPerfTesting && (
         <MasterAnimationCoordinator
           debugMode={process.env.NODE_ENV === 'development'}
           onAnimationStateChange={handleAnimationStateChange}
@@ -411,7 +389,7 @@ function App() {
             iceOpalConfig={iceOpalConfig}
             effectsEnabled={effectsEnabled}
             postProcessingConfig={postProcessingConfig}
-            performanceConfig={currentPerformanceConfig}
+            performanceConfig={performanceConfig}
             config={config}
             canvasProps={canvasProps}
             environmentProps={environmentProps}
@@ -478,7 +456,7 @@ function App() {
           />
           
           <PerformanceControls
-            performanceConfig={currentPerformanceConfig}
+            performanceConfig={performanceConfig}
             onConfigUpdate={handlePerformanceConfigUpdate}
             visible={true}
           />

--- a/src/hooks/useAdaptivePerformance.js
+++ b/src/hooks/useAdaptivePerformance.js
@@ -1,107 +1,17 @@
 // src/hooks/useAdaptivePerformance.js
-// Hook to adapt performance settings based on FPS measurements
+// Simplified hook: stores performance config without continuous FPS adaptation
 
-import { useState, useEffect, useRef } from 'react';
-import { useFPSMonitorDOM } from '../components/ui/FpsDisplay';
+import { useState, useEffect } from 'react';
 
-/**
- * Adaptive performance hook
- * @param {Object} baseConfig - starting performance configuration
- * @param {Object} options - configuration options
- *    threshold: FPS threshold before downgrading
- *    lowTierProfile: config applied when FPS is low
- *    restoreThreshold: FPS required to restore high settings
- *    lowFpsDuration: ms to wait before applying downgrade
- *    highFpsDuration: ms to wait before restoring
- */
-export const useAdaptivePerformance = (
-  baseConfig = {},
-  {
-    threshold = 48,
-    lowTierProfile = { usePBR: false, textureQuality: 'low', renderScale: 0.7 },
-    restoreThreshold = 60,
-    lowFpsDuration = 5000,
-    highFpsDuration = 5000,
-    pbrChangeDelay = 5000
-  } = {}
-) => {
-  const { avgFps } = useFPSMonitorDOM();
-
-  // Track the current effective configuration
+export const useAdaptivePerformance = (baseConfig = {}) => {
   const [currentPerformanceConfig, setCurrentPerformanceConfig] = useState(baseConfig);
 
-  // Save the base config so we can restore
-  const [basePerformanceConfig, setBasePerformanceConfig] = useState(baseConfig);
-
-  const lowFpsStart = useRef(null);
-  const highFpsStart = useRef(null);
-  const pbrChangeStart = useRef(null);
-  const downgraded = useRef(false);
-  const lastSwitchTime = useRef(0);
-
-  // Update stored base config when it changes externally
   useEffect(() => {
-    setBasePerformanceConfig(baseConfig);
     setCurrentPerformanceConfig(baseConfig);
   }, [baseConfig]);
 
-  // Monitor FPS and adjust configuration
-  useEffect(() => {
-    const now = Date.now();
-
-    if (avgFps > 0 && avgFps < threshold) {
-      if (lowFpsStart.current === null) {
-        lowFpsStart.current = now;
-      }
-
-      if (now - lowFpsStart.current > lowFpsDuration && !downgraded.current) {
-        const { usePBR, ...rest } = lowTierProfile;
-        setCurrentPerformanceConfig(prev => ({ ...prev, ...rest }));
-        downgraded.current = true;
-        lastSwitchTime.current = now;
-        highFpsStart.current = null;
-        pbrChangeStart.current = now;
-      }
-
-      if (downgraded.current && currentPerformanceConfig.usePBR &&
-          now - pbrChangeStart.current > pbrChangeDelay) {
-        setCurrentPerformanceConfig(prev => ({ ...prev, usePBR: lowTierProfile.usePBR }));
-      }
-    } else {
-      lowFpsStart.current = null;
-
-      if (downgraded.current && avgFps >= restoreThreshold) {
-        if (highFpsStart.current === null) {
-          highFpsStart.current = now;
-        }
-        if (now - highFpsStart.current > highFpsDuration) {
-          const { usePBR } = currentPerformanceConfig;
-          setCurrentPerformanceConfig({ ...basePerformanceConfig, usePBR });
-          downgraded.current = false;
-          lastSwitchTime.current = now;
-          highFpsStart.current = null;
-          pbrChangeStart.current = now;
-        }
-      } else {
-        highFpsStart.current = null;
-      }
-
-      if (!downgraded.current && !currentPerformanceConfig.usePBR &&
-          avgFps >= restoreThreshold &&
-          now - pbrChangeStart.current > pbrChangeDelay) {
-        setCurrentPerformanceConfig(prev => ({ ...prev, usePBR: basePerformanceConfig.usePBR }));
-        pbrChangeStart.current = null;
-      }
-    }
-  }, [avgFps, threshold, lowTierProfile, restoreThreshold, lowFpsDuration, highFpsDuration, basePerformanceConfig, pbrChangeDelay, currentPerformanceConfig.usePBR]);
-
-  // Allow manual config updates
   const updatePerformanceConfig = (config) => {
-    setBasePerformanceConfig(config);
     setCurrentPerformanceConfig(config);
-    downgraded.current = false;
-    lowFpsStart.current = null;
-    highFpsStart.current = null;
   };
 
   return { currentPerformanceConfig, updatePerformanceConfig };

--- a/src/hooks/useInitialPerformanceTest.js
+++ b/src/hooks/useInitialPerformanceTest.js
@@ -1,0 +1,43 @@
+import { useState, useEffect, useRef } from 'react';
+import { useFPSMonitorDOM } from '../components/ui/FpsDisplay';
+import { getPerformanceProfile } from '../utils/deviceProfiles';
+
+/**
+ * Run a short FPS sampling test on startup and return
+ * a performance configuration based on the results.
+ * @param {Object} deviceProfile - profile from useDeviceProfile
+ * @param {Object} options - configuration options
+ *    duration: length of the sampling period in ms
+ */
+export const useInitialPerformanceTest = (
+  deviceProfile,
+  { duration = 4000 } = {}
+) => {
+  const { avgFps } = useFPSMonitorDOM();
+  const [performanceConfig, setPerformanceConfig] = useState(null);
+  const [testing, setTesting] = useState(true);
+  const startRef = useRef(null);
+
+  useEffect(() => {
+    if (!deviceProfile) return;
+
+    if (startRef.current === null) {
+      startRef.current = performance.now();
+    }
+
+    if (testing && performance.now() - startRef.current >= duration) {
+      const fpsTier = avgFps >= 50 ? 'high' : avgFps >= 30 ? 'medium' : 'low';
+      const order = { low: 0, medium: 1, high: 2 };
+      const baseTier = deviceProfile.performanceTier || 'medium';
+      const finalTier = order[fpsTier] < order[baseTier] ? fpsTier : baseTier;
+      const finalConfig = getPerformanceProfile({
+        ...deviceProfile,
+        performanceTier: finalTier
+      });
+      setPerformanceConfig(finalConfig);
+      setTesting(false);
+    }
+  }, [avgFps, deviceProfile, duration, testing]);
+
+  return { performanceConfig, isTesting: testing };
+};


### PR DESCRIPTION
## Summary
- add new `useInitialPerformanceTest` hook
- simplify `useAdaptivePerformance`
- integrate initial performance test with App

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6863612254648328b74c1a857fc3037d