### PR TITLE
Delay 3D initialization until device and performance profiling complete

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -79,6 +79,7 @@ import PostProcessingControls from './components/ui/PostProcessingControls';
 import PerformanceControls from './components/ui/PerformanceControls';
 import AccessibilityInstructions from './components/ui/AccessibilityInstructions';
 import FpsDisplay, { PerformanceAlert } from './components/ui/FpsDisplay';
+import Loader from './components/ui/Loader';
 
 // Configuration and utilities (unchanged)
 import * as defaultConfig from './crystalConfig';
@@ -174,6 +175,10 @@ function App() {
     };
   });
 
+  // Ready state - becomes true after device profiling and initial performance
+  // test complete
+  const [isReady, setIsReady] = useState(false);
+
   // Initial performance test based on FPS
   const { performanceConfig: initialPerformanceConfig, isTesting: isPerfTesting } =
     useInitialPerformanceTest(deviceProfile);
@@ -195,6 +200,13 @@ function App() {
   }, [initialPerformanceConfig, initialProfileApplied]);
 
   const [hasInitialized, setHasInitialized] = useState(false);
+
+  // When device profiling and initial performance test complete, mark ready
+  React.useEffect(() => {
+    if (!isDetecting && !isPerfTesting && initialPerformanceConfig && !isReady) {
+      setIsReady(true);
+    }
+  }, [isDetecting, isPerfTesting, initialPerformanceConfig, isReady]);
   
   React.useEffect(() => {
     if (updateExternalPerformanceConfig && hasInitialized && initialProfileApplied) {
@@ -324,6 +336,7 @@ function App() {
 
   return (
     <>
+      {!isReady && <Loader />}
       {/* UI Hide Toggle Button - Always Visible */}
       <button
         onClick={() => setHideAllUI(!hideAllUI)}
@@ -376,7 +389,7 @@ function App() {
       )}
 
       {/* NEW: Master Animation Coordinator - Single source of truth for all animations */}
-      {!isDetecting && !isPerfTesting && (
+      {isReady && (
         <MasterAnimationCoordinator
           debugMode={process.env.NODE_ENV === 'development'}
           onAnimationStateChange={handleAnimationStateChange}

--- a/src/components/ui/Loader.jsx
+++ b/src/components/ui/Loader.jsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+const Loader = () => {
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        width: '100vw',
+        height: '100vh',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: '#050505',
+        color: '#64ffda',
+        fontSize: '1.2rem',
+        zIndex: 100000
+      }}
+    >
+      Loading...
+    </div>
+  );
+};
+
+export default Loader;


### PR DESCRIPTION
## Summary
- add a small Loader component for displaying a loading screen
- introduce `isReady` state in `App` and set it once device profile and performance testing finish
- delay mounting of `MasterAnimationCoordinator`/`Fixed3DCanvas` until ready
- show the loader overlay while initialization runs

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686362c652688328a4a782b13556a52c