### PR TITLE
Add customizable loading screen and manual performance test hook

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -79,7 +79,7 @@ import PostProcessingControls from './components/ui/PostProcessingControls';
 import PerformanceControls from './components/ui/PerformanceControls';
 import AccessibilityInstructions from './components/ui/AccessibilityInstructions';
 import FpsDisplay, { PerformanceAlert } from './components/ui/FpsDisplay';
-import Loader from './components/ui/Loader';
+import LoadingScreen from './components/ui/LoadingScreen';
 
 // Configuration and utilities (unchanged)
 import * as defaultConfig from './crystalConfig';
@@ -180,8 +180,20 @@ function App() {
   const [isReady, setIsReady] = useState(false);
 
   // Initial performance test based on FPS
-  const { performanceConfig: initialPerformanceConfig, isTesting: isPerfTesting } =
-    useInitialPerformanceTest(deviceProfile);
+  const {
+    performanceConfig: initialPerformanceConfig,
+    isTesting: isPerfTesting,
+    startTest: startPerfTest,
+  } = useInitialPerformanceTest(deviceProfile, {
+    autoStart: false,
+    onComplete: setPerformanceConfig,
+  });
+
+  React.useEffect(() => {
+    if (deviceProfile && !initialPerformanceConfig && !isPerfTesting) {
+      startPerfTest();
+    }
+  }, [deviceProfile, initialPerformanceConfig, isPerfTesting, startPerfTest]);
 
   React.useEffect(() => {
     if (initialPerformanceConfig) {
@@ -336,7 +348,7 @@ function App() {
 
   return (
     <>
-      {!isReady && <Loader />}
+      {!isReady && <LoadingScreen />}
       {/* UI Hide Toggle Button - Always Visible */}
       <button
         onClick={() => setHideAllUI(!hideAllUI)}

--- a/src/components/ui/LoadingScreen.jsx
+++ b/src/components/ui/LoadingScreen.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+const LoadingScreen = ({
+  style = {},
+  className = '',
+  text = 'Loading...',
+}) => {
+  return (
+    <div
+      className={className}
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        width: '100vw',
+        height: '100vh',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        backgroundColor: '#050505',
+        color: '#64ffda',
+        fontSize: '1.2rem',
+        zIndex: 100000,
+        ...style,
+      }}
+    >
+      {text}
+    </div>
+  );
+};
+
+export default LoadingScreen;

--- a/src/hooks/useInitialPerformanceTest.js
+++ b/src/hooks/useInitialPerformanceTest.js
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { useFPSMonitorDOM } from '../components/ui/FpsDisplay';
 import { getPerformanceProfile } from '../utils/deviceProfiles';
 
@@ -11,33 +11,46 @@ import { getPerformanceProfile } from '../utils/deviceProfiles';
  */
 export const useInitialPerformanceTest = (
   deviceProfile,
-  { duration = 4000 } = {}
+  { duration = 4000, autoStart = true, onComplete } = {}
 ) => {
   const { avgFps } = useFPSMonitorDOM();
   const [performanceConfig, setPerformanceConfig] = useState(null);
-  const [testing, setTesting] = useState(true);
+  const [testing, setTesting] = useState(autoStart);
   const startRef = useRef(null);
 
+  const startTest = useCallback(() => {
+    startRef.current = performance.now();
+    setTesting(true);
+    setPerformanceConfig(null);
+  }, []);
+
   useEffect(() => {
-    if (!deviceProfile) return;
+    if (!deviceProfile || !testing) return;
 
     if (startRef.current === null) {
       startRef.current = performance.now();
     }
 
-    if (testing && performance.now() - startRef.current >= duration) {
+    if (performance.now() - startRef.current >= duration) {
       const fpsTier = avgFps >= 50 ? 'high' : avgFps >= 30 ? 'medium' : 'low';
       const order = { low: 0, medium: 1, high: 2 };
       const baseTier = deviceProfile.performanceTier || 'medium';
       const finalTier = order[fpsTier] < order[baseTier] ? fpsTier : baseTier;
       const finalConfig = getPerformanceProfile({
         ...deviceProfile,
-        performanceTier: finalTier
+        performanceTier: finalTier,
       });
       setPerformanceConfig(finalConfig);
       setTesting(false);
+      if (onComplete) onComplete(finalConfig);
     }
-  }, [avgFps, deviceProfile, duration, testing]);
+  }, [avgFps, deviceProfile, duration, testing, onComplete]);
 
-  return { performanceConfig, isTesting: testing };
+  useEffect(() => {
+    if (deviceProfile && autoStart && startRef.current === null) {
+      startTest();
+    }
+  }, [deviceProfile, autoStart, startTest]);
+
+  return { performanceConfig, isTesting: testing, startTest };
 };


### PR DESCRIPTION
## Summary
- create a new `<LoadingScreen>` component with styling props
- allow `useInitialPerformanceTest` to be started manually and expose callbacks
- update `App.jsx` to use the new loader and start the FPS test explicitly

## Testing
- `npm install`
- `npm run build`
- `npx eslint .` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6863662c3e488328b8b0ec047522b15a