### PR TITLE
Add loading progress

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -78,6 +78,7 @@ import PerformanceControls from './components/ui/PerformanceControls';
 import AccessibilityInstructions from './components/ui/AccessibilityInstructions';
 import FpsDisplay, { PerformanceAlert } from './components/ui/FpsDisplay';
 import LoadingScreen from './components/ui/LoadingScreen';
+import { useProgress } from '@react-three/drei';
 
 // Configuration and utilities (unchanged)
 import * as defaultConfig from './crystalConfig';
@@ -92,6 +93,8 @@ const isMobileDevice = () => {
 
 function App() {
   const isMobile = isMobileDevice();
+
+  const { progress } = useProgress();
 
   // Device profile for performance optimization (unchanged)
   const { 
@@ -317,9 +320,11 @@ function App() {
   const canvasProps = getOptimalCanvasProps();
   const environmentProps = getOptimalEnvironmentProps();
 
+  const showLoading = !isReady || progress < 100;
+
   return (
     <>
-      {!isReady && <LoadingScreen />}
+      {showLoading && <LoadingScreen progress={progress} />}
       {/* UI Hide Toggle Button - Always Visible */}
       <button
         onClick={() => setHideAllUI(!hideAllUI)}

--- a/src/components/ui/LoadingScreen.jsx
+++ b/src/components/ui/LoadingScreen.jsx
@@ -4,7 +4,13 @@ const LoadingScreen = ({
   style = {},
   className = '',
   text = 'Loading...',
+  progress = null,
 }) => {
+  const displayText =
+    progress !== null && progress !== undefined
+      ? `${text} ${Math.floor(progress)}%`
+      : text;
+
   return (
     <div
       className={className}
@@ -24,7 +30,7 @@ const LoadingScreen = ({
         ...style,
       }}
     >
-      {text}
+      {displayText}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- enhance `LoadingScreen` to show percent progress
- report asset loading progress in `App.jsx` using `useProgress`

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6865caf3fabc8328b2f8fa0a40550680