### PR TITLE
Fix useDeviceProfile order

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -97,23 +97,23 @@ function App() {
 
   const { progress } = useProgress();
 
+  // Device profile for performance optimization (unchanged)
+  const {
+    performanceProfile: devicePerformanceProfile,
+    deviceProfile,
+    getOptimalCanvasProps,
+    getOptimalEnvironmentProps,
+    updateExternalPerformanceConfig,
+    isDetecting
+  } = useDeviceProfile({
+    enableDebugLogging: false,
+    enableOrientationLock: false
+  });
+
   // Preload assets immediately based on detected performance profile
   useEffect(() => {
     preloadAssets(devicePerformanceProfile?.hdriQuality || 'low');
   }, [devicePerformanceProfile]);
-
-  // Device profile for performance optimization (unchanged)
-  const { 
-    performanceProfile: devicePerformanceProfile, 
-    deviceProfile, 
-    getOptimalCanvasProps,
-    getOptimalEnvironmentProps,
-    updateExternalPerformanceConfig,
-    isDetecting 
-  } = useDeviceProfile({ 
-    enableDebugLogging: false,
-    enableOrientationLock: false
-  });
 
   // UI Hide Toggle State
   const [hideAllUI, setHideAllUI] = useState(false);


### PR DESCRIPTION
## Summary
- move `useDeviceProfile` hook above the preload `useEffect`

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686600e9145c8328974ef7fe807a4b36