### PR TITLE
Improve material application and loader timing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -292,10 +292,7 @@ function App() {
     
     if (shouldBeReady && !isAppReady) {
       console.log('🎯 App is ready to show');
-      // Small delay to ensure everything is settled
-      setTimeout(() => {
-        setIsAppReady(true);
-      }, 200);
+      setIsAppReady(true);
     }
   }, [isDetecting, isReady, devicePerformanceProfile, initialPerformanceConfig, isAppReady]);
 

--- a/src/components/materials/CrystalMaterial.jsx
+++ b/src/components/materials/CrystalMaterial.jsx
@@ -6,11 +6,12 @@ import * as THREE from 'three';
  * Component to create and apply the base crystal material
  * Updated for Three.js compatibility with fixed normal map toggling
  */
-const CrystalMaterial = ({ 
-  config, 
-  materialRef, 
+const CrystalMaterial = ({
+  config,
+  materialRef,
   variant = 'default',
-  performanceConfig = {}
+  performanceConfig = {},
+  onMaterialReady = null
 }) => {
   // Set default performance settings if not provided
   const {
@@ -82,9 +83,10 @@ const CrystalMaterial = ({
       
       // Create the material
       const material = new THREE.MeshPhysicalMaterial(baseConfig);
-      
+
       // Store the material
       materialRef.current = material;
+      if (onMaterialReady) onMaterialReady(material);
       
       // We'll load the normal map in a separate effect
     };
@@ -207,11 +209,13 @@ const CrystalMaterial = ({
     // If material already exists, just update it
     if (materialRef.current) {
       updateMaterial();
+      if (onMaterialReady) onMaterialReady(materialRef.current);
       return;
     }
     
     // Otherwise create new material
     createMaterial();
+    if (onMaterialReady) onMaterialReady(materialRef.current);
     
   }, [config.materials.crystal, variant, materialRef, usePBR, useNormalMaps]);
   

--- a/src/components/three/MaterialManager.jsx
+++ b/src/components/three/MaterialManager.jsx
@@ -9,11 +9,12 @@ import * as THREE from 'three';
  * Component to manage and apply the correct material based on selected variant
  * UPDATED: Now respects performance profile settings and creates appropriate materials
  */
-const MaterialManager = ({ 
+const MaterialManager = ({
   materialVariant,
   config,
   materialRef,
-  performanceConfig = {}
+  performanceConfig = {},
+  onMaterialReady = null
 }) => {
   // Create separate refs for each material type to prevent sharing
   const crystalMaterialRef = useRef();
@@ -84,6 +85,7 @@ const MaterialManager = ({
       const basicMaterial = new THREE.MeshLambertMaterial(materialProps);
       basicMaterialRef.current = basicMaterial;
       console.log('✅ Basic material created for low-performance device:', materialVariant);
+      if (onMaterialReady) onMaterialReady(basicMaterial);
     }
   }, [usePBR, config.materials.crystal.color, config.materials.crystal.emissive, materialVariant]);
 
@@ -153,6 +155,8 @@ const MaterialManager = ({
       materialRef.current = crystalMaterialRef.current;
       console.log('✅ Using PBR crystal material:', materialVariant);
     }
+
+    if (onMaterialReady) onMaterialReady(materialRef.current);
   }, [materialVariant, materialRef, usePBR]);
   
   // Only render PBR material component if PBR is enabled
@@ -166,11 +170,12 @@ const MaterialManager = ({
     <CrystalMaterial 
       config={config} 
       materialRef={crystalMaterialRef} 
-      variant={materialVariant === 'default' || 
-               materialVariant === 'glass' || 
-               materialVariant === 'gem' || 
+      variant={materialVariant === 'default' ||
+               materialVariant === 'glass' ||
+               materialVariant === 'gem' ||
                materialVariant === 'holographic' ? materialVariant : 'default'}
       performanceConfig={performanceConfig}
+      onMaterialReady={onMaterialReady}
     />
   );
 };

--- a/src/components/three/UnifiedCrystalScene.jsx
+++ b/src/components/three/UnifiedCrystalScene.jsx
@@ -1,6 +1,6 @@
 // ONLY CHANGE: Fixed facet refs exposure for anchor targeting
 
-import React, { useRef, useState, useEffect, forwardRef, useImperativeHandle } from 'react'
+import React, { useRef, useState, useEffect, useCallback, forwardRef, useImperativeHandle } from 'react'
 import { useFrame, useThree } from '@react-three/fiber'
 import { useGLTF, Html } from '@react-three/drei'
 import * as THREE from 'three'
@@ -36,9 +36,16 @@ const UnifiedCrystalScene = forwardRef(({
   const [showCrystalDebug, setShowCrystalDebug] = useState(false);
   
   const { clock } = useThree();
-  
+
   // Facet configuration
   const facetKeys = ['empathy', 'narrative', 'craft', 'system', 'leadership', 'exploration'];
+
+  // Track material updates so we can reapply when ready
+  const [materialVersion, setMaterialVersion] = useState(0);
+
+  const handleMaterialReady = useCallback(() => {
+    setMaterialVersion(v => v + 1);
+  }, []);
 
   
   useEffect(() => {
@@ -180,7 +187,7 @@ const UnifiedCrystalScene = forwardRef(({
     applyMaterial(wholeCrystal.scene);
     facetModels.forEach(model => applyMaterial(model.scene));
     
-  }, [wholeCrystal, facetModels, crystalMaterialRef.current]);
+  }, [wholeCrystal, facetModels, materialVersion]);
 
   // Debug anchor positions when facets are loaded
   useEffect(() => {
@@ -355,6 +362,7 @@ const UnifiedCrystalScene = forwardRef(({
         config={config}
         materialRef={crystalMaterialRef}
         performanceConfig={performanceConfig}
+        onMaterialReady={handleMaterialReady}
       />
 
       {/* Enhanced Glowing Sphere */}


### PR DESCRIPTION
## Summary
- trigger app ready immediately when assets and profile are ready
- notify when materials are created and apply to models reliably
- reapply materials when performance settings change
- expose material loading events for UnifiedCrystalScene

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6866a0db7aa08328b8554e1149328e24