### PR TITLE
Fix desktop-xl ui profile definition

### DIFF
--- a/src/utils/deviceProfiles.js
+++ b/src/utils/deviceProfiles.js
@@ -288,19 +288,14 @@ export const uiProfiles = {
     // 3D Viewport  
     viewportPadding: 20,
     showFpsCounter: true
-  },
-  
-  'desktop-xl': {
-    // Inherit desktop settings
-    ...this?.desktop || {},
-    
-    // Extra space utilization
-    maxVisiblePanels: 6,
-    viewportPadding: 40,
-    
-    // Enhanced layout
-    useWideLayout: true
   }
+};
+
+uiProfiles['desktop-xl'] = {
+  ...uiProfiles.desktop,
+  maxVisiblePanels: 6,
+  viewportPadding: 40,
+  useWideLayout: true
 };
 
 /**


### PR DESCRIPTION
## Summary
- remove problematic `this?.desktop` usage
- add `desktop-xl` UI profile after declaring base profiles

## Testing
- `npm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_6866d17ff0688328a6f2afd75b9c2400