### PR TITLE
Fix indefinite performance test delay

### DIFF
--- a/src/hooks/useInitialPerformanceTest.js
+++ b/src/hooks/useInitialPerformanceTest.js
@@ -17,43 +17,59 @@ export const useInitialPerformanceTest = (
   const [performanceConfig, setPerformanceConfig] = useState(null);
   const [testing, setTesting] = useState(autoStart);
   const startRef = useRef(null);
+  const timeoutRef = useRef(null);
+  const finalizeTest = useCallback(() => {
+    const elapsed = performance.now() - (startRef.current || 0);
+    const fpsTier = avgFps >= 50 ? 'high' : avgFps >= 30 ? 'medium' : 'low';
+    const order = { low: 0, medium: 1, high: 2 };
+    const baseTier = deviceProfile?.performanceTier || 'medium';
+    const finalTier = order[fpsTier] < order[baseTier] ? fpsTier : baseTier;
+    const finalConfig = getPerformanceProfile({
+      ...deviceProfile,
+      performanceTier: finalTier,
+    });
+    setPerformanceConfig(finalConfig);
+    setTesting(false);
+    if (onComplete) onComplete(finalConfig);
+    console.log(`\u2705 Performance test completed in ${Math.round(elapsed)}ms`);
+  }, [avgFps, deviceProfile, onComplete]);
 
   const startTest = useCallback(() => {
     startRef.current = performance.now();
     console.log(`\uD83D\uDD01 Starting performance test (target ${duration}ms)...`);
     setTesting(true);
     setPerformanceConfig(null);
-  }, [duration]);
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    timeoutRef.current = setTimeout(finalizeTest, duration);
+  }, [duration, finalizeTest]);
 
   useEffect(() => {
     if (!deviceProfile || !testing) return;
 
     if (startRef.current === null) {
       startRef.current = performance.now();
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      timeoutRef.current = setTimeout(finalizeTest, duration);
     }
 
     if (performance.now() - startRef.current >= duration) {
-      const elapsed = performance.now() - startRef.current;
-      const fpsTier = avgFps >= 50 ? 'high' : avgFps >= 30 ? 'medium' : 'low';
-      const order = { low: 0, medium: 1, high: 2 };
-      const baseTier = deviceProfile.performanceTier || 'medium';
-      const finalTier = order[fpsTier] < order[baseTier] ? fpsTier : baseTier;
-      const finalConfig = getPerformanceProfile({
-        ...deviceProfile,
-        performanceTier: finalTier,
-      });
-      setPerformanceConfig(finalConfig);
-      setTesting(false);
-      if (onComplete) onComplete(finalConfig);
-      console.log(`\u2705 Performance test completed in ${Math.round(elapsed)}ms`);
+      finalizeTest();
     }
-  }, [avgFps, deviceProfile, duration, testing, onComplete]);
+  }, [avgFps, deviceProfile, duration, testing, finalizeTest]);
 
   useEffect(() => {
     if (deviceProfile && autoStart && startRef.current === null) {
       startTest();
     }
   }, [deviceProfile, autoStart, startTest]);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
 
   return { performanceConfig, isTesting: testing, startTest };
 };


### PR DESCRIPTION
## Summary
- use a timer to finish the startup FPS test even if RAF throttles
- clear timeout on unmount for safety

## Testing
- `eslint src/hooks/useInitialPerformanceTest.js` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: missing script)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866e06a7c80832890f1b0205021461a