### PR TITLE
Disable shadows and cleanup configs

### DIFF
--- a/src/components/layout/Fixed3DCanvas.jsx
+++ b/src/components/layout/Fixed3DCanvas.jsx
@@ -115,12 +115,11 @@ const Fixed3DCanvas = ({
         zIndex: 1, // Behind scrollable content (which is z-index 10)
         pointerEvents: 'none', // Don't block scrolling
       }}>
-        <Canvas 
-          shadows 
-          camera={{ 
-            position: config?.camera?.startingPosition || [0, 0, 4.5], 
-            fov: config?.camera?.fov || 45 
-          }} 
+        <Canvas
+          camera={{
+            position: config?.camera?.startingPosition || [0, 0, 4.5],
+            fov: config?.camera?.fov || 45
+          }}
           {...canvasProps}
           gl={{ 
             toneMapping: THREE.ACESFilmicToneMapping,
@@ -147,43 +146,47 @@ const Fixed3DCanvas = ({
           <ambientLight intensity={config?.lighting?.ambient?.intensity || 0.4} />
           
           {/* Main directional light (from above/side) */}
-          <directionalLight 
-            position={config?.lighting?.directional?.position || [10, 8, 5]} 
-            intensity={config?.lighting?.directional?.intensity || 1.8} 
-            color={config?.lighting?.directional?.color || "#FFFFFF"} 
-            castShadow={config?.lighting?.directional?.castShadow !== false} 
+          <directionalLight
+            position={config?.lighting?.directional?.position || [10, 8, 5]}
+            intensity={config?.lighting?.directional?.intensity || 1.8}
+            color={config?.lighting?.directional?.color || "#FFFFFF"}
+            castShadow={false}
           />
           
           {/* ADDED: Bottom directional light pointing upward */}
           {config?.lighting?.directionalBottom && (
-            <directionalLight 
-              position={config.lighting.directionalBottom.position || [0, -5, 0]} 
+            <directionalLight
+              position={config.lighting.directionalBottom.position || [0, -5, 0]}
               target-position={config.lighting.directionalBottom.target || [0, 0, 0]}
-              intensity={config.lighting.directionalBottom.intensity || 0.2} 
-              color={config.lighting.directionalBottom.color || "#e75c25ff"} 
-              castShadow={config.lighting.directionalBottom.castShadow !== true}
+              intensity={config.lighting.directionalBottom.intensity || 0.2}
+              color={config.lighting.directionalBottom.color || "#e75c25ff"}
+              castShadow={false}
             />
           )}
           
           {/* Point lights */}
-          {config?.lighting?.pointLights?.map((light, index) => (
-            <pointLight 
-              key={index}
-              position={light.position} 
-              intensity={light.intensity} 
-              color={light.color} 
-            />
-          ))}
+          {config?.lighting?.pointLights
+            ?.slice(0, performanceConfig?.maxLights || config?.lighting?.pointLights.length)
+            .map((light, index) => (
+              <pointLight
+                key={index}
+                position={light.position}
+                intensity={light.intensity}
+                color={light.color}
+                castShadow={false}
+              />
+            ))}
 
           <PulsingOmniLight />
           
           {/* Spot light */}
-          <spotLight 
-            position={config?.lighting?.spotLight?.position || [0, 0, 10]} 
-            intensity={config?.lighting?.spotLight?.intensity || 1000.2} 
-            angle={config?.lighting?.spotLight?.angle || Math.PI / 4} 
-            penumbra={config?.lighting?.spotLight?.penumbra || 0.2} 
-            color={config?.lighting?.spotLight?.color || "#ffffffff"} 
+          <spotLight
+            position={config?.lighting?.spotLight?.position || [0, 0, 10]}
+            intensity={config?.lighting?.spotLight?.intensity || 1000.2}
+            angle={config?.lighting?.spotLight?.angle || Math.PI / 4}
+            penumbra={config?.lighting?.spotLight?.penumbra || 0.2}
+            color={config?.lighting?.spotLight?.color || "#ffffffff"}
+            castShadow={false}
           />
           
           {/* UPDATED: Enhanced Camera Controller with facet refs */}

--- a/src/hooks/useInitialPerformanceTest.js
+++ b/src/hooks/useInitialPerformanceTest.js
@@ -125,7 +125,6 @@ export const useInitialPerformanceTest = (
             vignette: true
           },
           maxLights: 2,
-          shadowQuality: 'off',
           hdriQuality: 'low',
           antialiasing: false,
           anisotropicFiltering: 1
@@ -173,7 +172,6 @@ export const useInitialPerformanceTest = (
         vignette: true
       };
       optimizedConfig.maxLights = Math.min(optimizedConfig.maxLights, 2);
-      optimizedConfig.shadowQuality = 'off';
       optimizedConfig.hdriQuality = 'low';
       optimizedConfig.antialiasing = false;
       optimizedConfig.anisotropicFiltering = 1;

--- a/src/utils/deviceProfiles.js
+++ b/src/utils/deviceProfiles.js
@@ -14,7 +14,6 @@ const basePerformanceSettings = {
     vignette: true
   },
   maxLights: 5,
-  shadowQuality: 'high',
   hdriQuality: 'high',
   antialiasing: true,
   anisotropicFiltering: 4
@@ -46,7 +45,6 @@ export const highEndMobileProfile = {
   
   // Conservative lighting
   maxLights: 3,
-  shadowQuality: 'medium',
   hdriQuality: 'high',      // Keep high HDRI for environment reflections
   
   // Minimal AA
@@ -80,7 +78,6 @@ export const mediumMobileProfile = {
   },
   
   maxLights: 2,
-  shadowQuality: 'low',
   hdriQuality: 'medium',    // Medium HDRI still gives reflections
   
   antialiasing: false,
@@ -112,7 +109,6 @@ export const lowEndMobileProfile = {
   },
   
   maxLights: 2,
-  shadowQuality: 'off',
   hdriQuality: 'low',       // Still get some environment reflections
   
   antialiasing: false,
@@ -144,7 +140,6 @@ export const highEndTabletProfile = {
   },
   
   maxLights: 4,
-  shadowQuality: 'high',
   hdriQuality: 'high',
   
   antialiasing: false,      // CHANGED: Disable for better performance
@@ -171,7 +166,6 @@ export const mediumTabletProfile = {
   },
   
   maxLights: 2,
-  shadowQuality: 'medium',
   hdriQuality: 'medium',
   
   antialiasing: false,
@@ -197,7 +191,6 @@ export const desktopProfile = {
     vignette: true
   },
   maxLights: 5,
-  shadowQuality: 'high',
   hdriQuality: 'high',
   antialiasing: true,
   anisotropicFiltering: 4
@@ -207,7 +200,6 @@ export const desktopXLProfile = {
   ...desktopProfile,
   renderScale: 1.0,
   maxLights: 6,
-  shadowQuality: 'ultra',
   anisotropicFiltering: 8,
   enhancedReflections: true
 };


### PR DESCRIPTION
## Summary
- slice point lights by maxLights and disable shadows in Fixed3DCanvas
- drop `shadowQuality` from all performance profiles
- remove shadow quality handling in initial performance test hook

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687f12bb4ca08328a504686a4f0a77af