### PR TITLE
Add pbrQuality to performance profiles

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -329,7 +329,7 @@ function App() {
         deviceTier: deviceProfile?.performanceTier,
         finalSettings: {
           renderScale: performanceConfig.renderScale,
-          usePBR: performanceConfig.usePBR,
+          pbrQuality: performanceConfig.pbrQuality,
           textureQuality: performanceConfig.textureQuality
         }
       });

--- a/src/components/materials/CrystalMaterial.jsx
+++ b/src/components/materials/CrystalMaterial.jsx
@@ -20,8 +20,11 @@ const CrystalMaterial = ({
   const {
     useNormalMaps = true,
     textureQuality = 'high',
-    usePBR = true
+    pbrQuality = 'high'
   } = performanceConfig;
+
+  const usePBR = pbrQuality !== 'low';
+  const isMedium = pbrQuality === 'medium';
   
   // ENHANCED: Create material with better shadow handling for transparent objects
   useEffect(() => {
@@ -86,7 +89,7 @@ const CrystalMaterial = ({
           baseConfig.envMapIntensity = usePBR ? 2.0 : 1.5;
           baseConfig.opacity = usePBR ? 0.6 : 0.7;
           break;
-          
+
         default:
           // Default variant - adaptive settings based on PBR availability
           if (!usePBR) {
@@ -104,6 +107,13 @@ const CrystalMaterial = ({
             baseConfig.reflectivity = Math.min(baseConfig.reflectivity + 0.1, 1.0);
           }
           break;
+      }
+
+      // Apply medium quality tweaks
+      if (isMedium && usePBR) {
+        baseConfig.transmission *= 0.7;
+        if (baseConfig.clearcoat !== undefined) baseConfig.clearcoat *= 0.7;
+        if (baseConfig.iridescence !== undefined) baseConfig.iridescence *= 0.5;
       }
       
       // UPDATED: Create material with improved shadow handling for transparent objects
@@ -275,7 +285,7 @@ const CrystalMaterial = ({
           material.emissiveIntensity = Math.max(0.15, currentEmissiveIntensity);
           material.envMapIntensity = usePBR ? 2.0 : 1.5;
           break;
-          
+
         default:
           // Apply performance adjustments to default settings
           if (!usePBR) {
@@ -292,6 +302,12 @@ const CrystalMaterial = ({
           }
           break;
       }
+
+      if (isMedium && usePBR) {
+        material.transmission *= 0.7;
+        if (material.clearcoat !== undefined) material.clearcoat *= 0.7;
+        if (material.iridescence !== undefined) material.iridescence *= 0.5;
+      }
       
       material.needsUpdate = true;
     };
@@ -305,7 +321,7 @@ const CrystalMaterial = ({
     
     if (onMaterialReady) onMaterialReady(materialRef.current);
     
-  }, [config.materials.crystal, variant, materialRef, usePBR, useNormalMaps]);
+  }, [config.materials.crystal, variant, materialRef, usePBR, isMedium, useNormalMaps]);
   
   // ENHANCED: Separate effect for handling normal maps with better error handling
   useEffect(() => {

--- a/src/components/three/MaterialManager.jsx
+++ b/src/components/three/MaterialManager.jsx
@@ -18,16 +18,19 @@ const MaterialManager = ({
   const { scene } = useThree(); // Get Three.js scene to access environment
   
   // FIXED: Null safety with proper defaults
-  const safePerformanceConfig = performanceConfig || {
+  const safePerformanceConfig = {
+    pbrQuality: 'high',
     usePBR: true,
     useNormalMaps: true,
     textureQuality: 'high',
-    renderScale: 1.0
+    renderScale: 1.0,
+    ...performanceConfig
   };
+
+  const pbrQuality = safePerformanceConfig.pbrQuality || (safePerformanceConfig.usePBR === false ? 'low' : 'high');
+  const usePBR = pbrQuality !== 'low';
   
-  const usePBR = safePerformanceConfig.usePBR !== false;
-  
-  if (import.meta.env.DEV) console.log('🎨 MaterialManager: PBR enabled?', usePBR, 'Performance config:', safePerformanceConfig);
+  if (import.meta.env.DEV) console.log('🎨 MaterialManager: PBR enabled?', usePBR, 'PBR quality:', pbrQuality, 'Performance config:', safePerformanceConfig);
 
   // OPTIMIZED: Create high-performance mobile material using MeshStandardMaterial
   useEffect(() => {

--- a/src/components/three/UnifiedCrystalScene.jsx
+++ b/src/components/three/UnifiedCrystalScene.jsx
@@ -16,7 +16,7 @@ const UnifiedCrystalScene = forwardRef(({
   animationData,
   config, 
   materialVariant = 'default',
-  performanceConfig = { useNormalMaps: true, textureQuality: 'high', usePBR: true },
+  performanceConfig = { useNormalMaps: true, textureQuality: 'high', pbrQuality: 'high', usePBR: true },
   isMobile = false
 }, ref) => {
   // Component refs for crystal animation

--- a/src/hooks/useDeviceProfile.js
+++ b/src/hooks/useDeviceProfile.js
@@ -66,7 +66,7 @@ export const useDeviceProfile = (options = {}) => {
       if (import.meta.env.DEV) console.log('🎯 Device Profile Applied:', {
         category: device.category,
         performanceTier: device.performanceTier,
-        usePBR: performance.usePBR,
+        pbrQuality: performance.pbrQuality,
         useNormalMaps: performance.useNormalMaps,
         textureQuality: performance.textureQuality,
         renderScale: performance.renderScale
@@ -110,8 +110,8 @@ export const useDeviceProfile = (options = {}) => {
       const currentProfile = manualOverride?.performance || performanceProfile;
       
       if (currentProfile) {
-        const hasChanges = 
-          config.usePBR !== currentProfile.usePBR ||
+        const hasChanges =
+          config.pbrQuality !== currentProfile.pbrQuality ||
           config.useNormalMaps !== currentProfile.useNormalMaps ||
           config.textureQuality !== currentProfile.textureQuality ||
           config.renderScale !== currentProfile.renderScale;
@@ -119,13 +119,13 @@ export const useDeviceProfile = (options = {}) => {
         if (hasChanges) {
           if (import.meta.env.DEV) console.log('✅ Applying external performance config changes:', {
             from: {
-              usePBR: currentProfile.usePBR,
+              pbrQuality: currentProfile.pbrQuality,
               useNormalMaps: currentProfile.useNormalMaps,
               textureQuality: currentProfile.textureQuality,
               renderScale: currentProfile.renderScale
             },
             to: {
-              usePBR: config.usePBR,
+              pbrQuality: config.pbrQuality,
               useNormalMaps: config.useNormalMaps,
               textureQuality: config.textureQuality,
               renderScale: config.renderScale
@@ -221,14 +221,14 @@ export const useDeviceProfile = (options = {}) => {
         source: externalPerformanceConfig ? 'External Config' : 
                 manualOverride ? 'Manual Override' : 
                 'Device Profile',
-        usePBR: effectivePerformanceConfig.usePBR,
+        pbrQuality: effectivePerformanceConfig.pbrQuality,
         useNormalMaps: effectivePerformanceConfig.useNormalMaps,
         textureQuality: effectivePerformanceConfig.textureQuality,
         renderScale: effectivePerformanceConfig.renderScale
       });
     }
-  }, [effectivePerformanceConfig?.usePBR, effectivePerformanceConfig?.useNormalMaps, 
-      effectivePerformanceConfig?.textureQuality, effectivePerformanceConfig?.renderScale, 
+  }, [effectivePerformanceConfig?.pbrQuality, effectivePerformanceConfig?.useNormalMaps,
+      effectivePerformanceConfig?.textureQuality, effectivePerformanceConfig?.renderScale,
       hasInitialized, externalPerformanceConfig, manualOverride]);
   
   // Utility functions

--- a/src/hooks/useInitialPerformanceTest.js
+++ b/src/hooks/useInitialPerformanceTest.js
@@ -115,6 +115,7 @@ export const useInitialPerformanceTest = (
         return {
           ...optimizedConfig,
           renderScale: 0.5,              // Low render scale
+          pbrQuality: 'low',
           usePBR: false,                 // Disable PBR
           useNormalMaps: false,
           textureQuality: 'low',
@@ -162,6 +163,7 @@ export const useInitialPerformanceTest = (
     else if (issues.severe) {
       if (import.meta.env.DEV) console.log('📉 Level 3 optimization: Aggressive performance mode');
       optimizedConfig.renderScale = Math.max(optimizedConfig.renderScale * 0.5, 0.3);
+      optimizedConfig.pbrQuality = 'low';
       optimizedConfig.usePBR = false;                 // Disable PBR entirely
       optimizedConfig.useNormalMaps = false;
       optimizedConfig.textureQuality = 'low';
@@ -205,7 +207,19 @@ export const useInitialPerformanceTest = (
     const issues = shouldAdjustPerformance(metrics, deviceProfile);
     
     // Create final configuration
-    const finalConfig = createOptimizedConfig(deviceProfile, metrics, issues);
+    let finalConfig = createOptimizedConfig(deviceProfile, metrics, issues);
+
+    // Adjust PBR quality based on measured FPS
+    if (metrics.avgFps > 50 && metrics.lowPercentile > 40) {
+      finalConfig.pbrQuality = 'high';
+    } else if (metrics.avgFps > 30 && metrics.lowPercentile > 20) {
+      if (finalConfig.pbrQuality === 'low') finalConfig.pbrQuality = 'medium';
+    } else if (metrics.avgFps < 25 || metrics.lowPercentile < 15) {
+      finalConfig.pbrQuality = 'low';
+    } else {
+      finalConfig.pbrQuality = finalConfig.pbrQuality || 'medium';
+    }
+    finalConfig.usePBR = finalConfig.pbrQuality !== 'low';
     
     // Log the decision
     if (import.meta.env.DEV) console.log(`🎯 Final Performance Decision:`, {
@@ -213,7 +227,7 @@ export const useInitialPerformanceTest = (
       hadIssues: issues ? Object.values(issues).some(Boolean) : false,
       finalSettings: {
         renderScale: finalConfig.renderScale,
-        usePBR: finalConfig.usePBR,
+        pbrQuality: finalConfig.pbrQuality,
         useNormalMaps: finalConfig.useNormalMaps,
         textureQuality: finalConfig.textureQuality,
         enabledEffects: Object.entries(finalConfig.postProcessing || {})

--- a/src/utils/deviceProfiles.js
+++ b/src/utils/deviceProfiles.js
@@ -5,6 +5,7 @@
 const basePerformanceSettings = {
   renderScale: 1.0,
   useNormalMaps: true,
+  pbrQuality: 'high',
   usePBR: true,
   textureQuality: 'high',
   postProcessing: {
@@ -32,6 +33,7 @@ export const highEndMobileProfile = {
   // OPTIMIZED: Disable PBR even on high-end mobile for better performance
   // The new MeshStandardMaterial looks great and performs much better
   useNormalMaps: true,      // Keep normal maps on high-end
+  pbrQuality: 'low',
   usePBR: false,            // CHANGED: Disable PBR for better performance
   textureQuality: 'high',   // Keep high textures
   
@@ -66,6 +68,7 @@ export const mediumMobileProfile = {
   
   // Disable expensive features
   useNormalMaps: false,     // CHANGED: Disable normal maps
+  pbrQuality: 'low',
   usePBR: false,            // Keep disabled
   textureQuality: 'medium',
   
@@ -97,6 +100,7 @@ export const lowEndMobileProfile = {
   
   // Disable all expensive features
   useNormalMaps: false,
+  pbrQuality: 'low',
   usePBR: false,
   textureQuality: 'low',
   
@@ -128,6 +132,7 @@ export const highEndTabletProfile = {
   
   // CHANGED: Even high-end tablets get non-PBR for better performance
   useNormalMaps: true,
+  pbrQuality: 'low',
   usePBR: false,            // CHANGED: Use optimized material instead
   textureQuality: 'high',
   
@@ -155,6 +160,7 @@ export const mediumTabletProfile = {
   renderScale: 0.7,
   
   useNormalMaps: false,
+  pbrQuality: 'low',
   usePBR: false,
   textureQuality: 'medium',
   
@@ -182,6 +188,7 @@ export const desktopProfile = {
   ...basePerformanceSettings,
   renderScale: 1.0,
   useNormalMaps: true,
+  pbrQuality: 'high',
   usePBR: true,             // Desktop keeps PBR
   textureQuality: 'high',
   postProcessing: {
@@ -221,18 +228,20 @@ export const getPerformanceProfile = (deviceProfile) => {
     if (deviceProfile.performanceTier === 'high') {
       return deviceProfile.category === 'desktop-xl' ? desktopXLProfile : desktopProfile;
     } else if (deviceProfile.performanceTier === 'medium') {
-      return { 
-        ...desktopProfile, 
-        renderScale: 0.8, 
+      return {
+        ...desktopProfile,
+        renderScale: 0.8,
         textureQuality: 'medium',
+        pbrQuality: 'high',
         usePBR: true  // Keep PBR on desktop even if medium performance
       };
     } else {
-      return { 
-        ...desktopProfile, 
-        renderScale: 0.6, 
+      return {
+        ...desktopProfile,
+        renderScale: 0.6,
+        pbrQuality: 'low',
         usePBR: false,    // Only disable PBR on very low-end desktop
-        textureQuality: 'low' 
+        textureQuality: 'low'
       };
     }
   }
@@ -370,13 +379,14 @@ export const logProfileInfo = (deviceProfile, performanceProfile, uiProfile) => 
   
   if (import.meta.env.DEV) console.log('📊 OPTIMIZED Performance Summary:', {
     renderScale: performanceProfile.renderScale,
+    pbrQuality: performanceProfile.pbrQuality,
     usePBR: performanceProfile.usePBR,
     useNormalMaps: performanceProfile.useNormalMaps,
     textureQuality: performanceProfile.textureQuality,
     postProcessing: Object.entries(performanceProfile.postProcessing)
       .filter(([_, enabled]) => enabled)
       .map(([effect, _]) => effect),
-    optimization: performanceProfile.usePBR ? 'Full PBR' : 'Optimized Standard Material'
+    optimization: performanceProfile.pbrQuality
   });
   
   if (import.meta.env.DEV) console.groupEnd();


### PR DESCRIPTION
## Summary
- introduce `pbrQuality` on all device performance profiles
- refactor device detection and initial performance test to use the new quality flag
- tweak material manager and crystal material to respect `pbrQuality`
- pass quality flag through the crystal scene and app logging

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687f15eeded8832893232573d971ad8a