### PR TITLE
Sync tested performance config with device profile

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -313,12 +313,17 @@ function App() {
     if (testPerformanceConfig) {
       if (import.meta.env.DEV) console.log('🎯 Applying enhanced performance test results:', testPerformanceConfig);
       setPerformanceConfig(testPerformanceConfig);
-      
+
+      // Inform the device profile hook so helpers use the new config
+      if (updateExternalPerformanceConfig) {
+        updateExternalPerformanceConfig(testPerformanceConfig);
+      }
+
       if (markAsInitialized) {
         markAsInitialized();
       }
     }
-  }, [testPerformanceConfig, markAsInitialized]);
+  }, [testPerformanceConfig, markAsInitialized, updateExternalPerformanceConfig]);
 
   // ENHANCED: App ready detection with better criteria
   useEffect(() => {


### PR DESCRIPTION
## Summary
- push optimized test results into `useDeviceProfile` when initial test completes
- helpers already consume the effective performance config built from the external config

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687fe3b3e00c83289ef6d60170a36aa4