### PR TITLE
Delay perf test until crystal models loaded

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -98,6 +98,10 @@ function App() {
   // ENHANCED: App ready state with better tracking
   // ========================================
   const [isAppReady, setIsAppReady] = useState(false);
+
+  // Track when GLTF models have loaded via Fixed3DCanvas
+  const fixedCanvasRef = useRef();
+  const [modelsLoaded, setModelsLoaded] = useState(false);
   
   // Basic state hooks
   const [hideAllUI, setHideAllUI] = useState(false);
@@ -295,9 +299,21 @@ function App() {
     }
   }, [isAppReady]);
 
-  // ENHANCED: Start performance test when device profile and assets are ready
+  // Poll the Fixed3DCanvas ref until models are loaded
   useEffect(() => {
-    if (deviceProfile && isReady && !testPerformanceConfig && !isPerfTesting) {
+    if (modelsLoaded) return;
+    const id = setInterval(() => {
+      if (fixedCanvasRef.current?.modelsLoaded) {
+        setModelsLoaded(true);
+        clearInterval(id);
+      }
+    }, 100);
+    return () => clearInterval(id);
+  }, [modelsLoaded]);
+
+  // ENHANCED: Start performance test when device profile, assets and models are ready
+  useEffect(() => {
+    if (deviceProfile && isReady && modelsLoaded && !testPerformanceConfig && !isPerfTesting) {
       if (import.meta.env.DEV) console.log('🔬 Starting enhanced performance test for device:', {
         category: deviceProfile.category,
         tier: deviceProfile.performanceTier,
@@ -306,7 +322,7 @@ function App() {
       });
       startPerfTest();
     }
-  }, [deviceProfile, isReady, testPerformanceConfig, isPerfTesting, startPerfTest]);
+  }, [deviceProfile, isReady, modelsLoaded, testPerformanceConfig, isPerfTesting, startPerfTest]);
 
   // Apply performance config when test completes
   useEffect(() => {
@@ -434,9 +450,10 @@ function App() {
         config={animationConfig}
       >
         {/* Fixed 3D Canvas */}
-        <Fixed3DCanvas
-          materialVariant={materialVariant}
-          effectsEnabled={effectsEnabled}
+          <Fixed3DCanvas
+            ref={fixedCanvasRef}
+            materialVariant={materialVariant}
+            effectsEnabled={effectsEnabled}
           postProcessingConfig={postProcessingConfig}
           performanceConfig={performanceConfig}
           config={config}

--- a/src/components/layout/Fixed3DCanvas.jsx
+++ b/src/components/layout/Fixed3DCanvas.jsx
@@ -1,7 +1,7 @@
 // UPDATED: src/components/layout/Fixed3DCanvas.jsx
 // ADDED: Bottom directional light to illuminate crystal undersides
 
-import React, { useRef, useState, useEffect } from 'react';
+import React, { useRef, useState, useEffect, forwardRef, useImperativeHandle } from 'react';
 import { Canvas, useFrame } from '@react-three/fiber';
 import { Environment, OrbitControls } from '@react-three/drei';
 import { EffectComposer, Bloom, ChromaticAberration, Noise, Vignette } from '@react-three/postprocessing';
@@ -44,7 +44,7 @@ const PulsingOmniLight = () => {
 /**
  * UPDATED: Fixed3DCanvas with bottom directional light for better crystal illumination
  */
-const Fixed3DCanvas = ({ 
+const Fixed3DCanvas = forwardRef(({
   // Animation data from MasterAnimationCoordinator
   animationData,
   
@@ -57,9 +57,14 @@ const Fixed3DCanvas = ({
   canvasProps = {},
   environmentProps = {},
   isMobile = false
-}) => {
+}, ref) => {
   // NEW: Ref to access crystal scene for debug panels
   const crystalSceneRef = useRef();
+
+  // Expose internal state to parent components
+  useImperativeHandle(ref, () => ({
+    modelsLoaded: crystalSceneRef.current?.modelsLoaded || false
+  }), [crystalSceneRef.current?.modelsLoaded]);
   
   // NEW: State for debug data
   const [debugData, setDebugData] = useState({
@@ -290,6 +295,6 @@ const Fixed3DCanvas = ({
       )}
     </>
   );
-};
+});
 
 export default Fixed3DCanvas;

--- a/src/components/three/UnifiedCrystalScene.jsx
+++ b/src/components/three/UnifiedCrystalScene.jsx
@@ -44,6 +44,9 @@ const UnifiedCrystalScene = forwardRef(({
   // Track material updates so we can reapply when ready
   const [materialVersion, setMaterialVersion] = useState(0);
 
+  // Track when GLTF models have loaded
+  const [modelsLoaded, setModelsLoaded] = useState(false);
+
   const handleMaterialReady = useCallback(() => {
     setMaterialVersion(v => v + 1);
   }, []);
@@ -59,6 +62,9 @@ const UnifiedCrystalScene = forwardRef(({
   useImperativeHandle(ref, () => ({
     // Expose the refs array directly (this is what Fixed3DCanvas expects)
     facetRefs: facetRefs.current,
+
+    // Loaded state for parent components
+    modelsLoaded,
     
     // Helper method for getting specific facet ref
     getFacetRef: (index) => facetRefs.current[index],
@@ -130,7 +136,7 @@ const UnifiedCrystalScene = forwardRef(({
         }
       }
     }
-  }), [facetKeys, showWholeCrystal, showFacets, sphereVisible, showCrystalDebug]);
+  }), [facetKeys, showWholeCrystal, showFacets, sphereVisible, showCrystalDebug, modelsLoaded]);
 
   // Load models
   const wholeCrystal = useGLTF(config.assets.models.crystalWhole);
@@ -142,6 +148,15 @@ const UnifiedCrystalScene = forwardRef(({
     useGLTF(config.assets.models.facetLeadership),
     useGLTF(config.assets.models.facetExploration)
   ];
+
+  // Mark models as loaded when all GLTF hooks resolve
+  useEffect(() => {
+    const allLoaded =
+      wholeCrystal && facetModels.every((m) => m && m.scene);
+    if (allLoaded) {
+      setModelsLoaded(true);
+    }
+  }, [wholeCrystal, ...facetModels]);
   
   // Keyboard listener for debug toggle
   useEffect(() => {


### PR DESCRIPTION
## Summary
- track when GLTF models finish loading in `UnifiedCrystalScene`
- expose `modelsLoaded` via `useImperativeHandle`
- forward ref from `Fixed3DCanvas` to pass up crystal scene state
- poll for models readiness in `App` and delay FPS test until models are loaded

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688030a9bb6c8328b89befb622fa87b8