### PR TITLE
Add very low perf tier and debug toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The returned `updateExternalPerformanceConfig` function allows you to override t
 
 ### Debugging in production
 
-To inspect the device and performance profiles in a live build set `window.__PERF_DEBUG__ = true` in the browser console. Set it back to `false` to hide debug output.
+To inspect the device and performance profiles in a live build you can toggle the debug panel at any time by pressing **P**. This sets `window.__PERF_DEBUG__` to `true` and re‑pressing **P** hides it again.
 
 ## One‑time performance test
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ Options such as `enableDebugLogging`, `enableOrientationLock` and `enableProfile
 
 The returned `updateExternalPerformanceConfig` function allows you to override the automatic profile at runtime (for example from the "Performance" tab in the UI).
 
+### Debugging in production
+
+To inspect the device and performance profiles in a live build set `window.__PERF_DEBUG__ = true` in the browser console. Set it back to `false` to hide debug output.
+
 ## One‑time performance test
 
 After the device profile is resolved the app runs `useInitialPerformanceTest`. This hook measures the FPS for about four seconds and adjusts the performance profile if necessary. The test runs only once on first load. When complete, the resulting profile is stored via `updateExternalPerformanceConfig`.
@@ -24,6 +28,7 @@ While detection and the FPS test are running the `LoadingScreen` component keeps
 ## Customising performance settings
 
 Performance presets for each device tier live in [`src/utils/deviceProfiles.js`](src/utils/deviceProfiles.js). To tweak defaults edit those profiles. To override the active settings at runtime call `updateExternalPerformanceConfig` with a custom configuration object. You may also enable the manual `overrideProfile` helper exposed by `useDeviceProfile` when developing.
+The predefined tiers are `high`, `medium`, `low` and the new `very-low` profile for extremely slow hardware.
 
 ## Development
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -105,6 +105,7 @@ function App() {
   
   // Basic state hooks
   const [hideAllUI, setHideAllUI] = useState(false);
+  const [perfDebug, setPerfDebug] = useState(window.__PERF_DEBUG__ || false);
   const [snapSpeed, setSnapSpeed] = useState('medium');
   const [config, setConfig] = useState({
     ...defaultConfig,
@@ -399,6 +400,16 @@ function App() {
           });
         }
       }
+
+      if (e.key === 'p' || e.key === 'P') {
+        if (!e.ctrlKey && !e.altKey && !e.metaKey && !e.shiftKey) {
+          e.preventDefault();
+          const next = !window.__PERF_DEBUG__;
+          window.__PERF_DEBUG__ = next;
+          setPerfDebug(next);
+          if (import.meta.env.DEV || next) console.log(`🛠️ Performance debug ${next ? 'enabled' : 'disabled'}`);
+        }
+      }
     };
     
     window.addEventListener('keydown', handleKeyDown);
@@ -589,7 +600,7 @@ function App() {
       )}
 
       {/* ENHANCED: Debug Panel with detailed performance info */}
-      {import.meta.env.DEV && (
+      {(import.meta.env.DEV || perfDebug) && (
         <PerformanceDebugPanel
           deviceProfile={deviceProfile}
           performanceConfig={performanceConfig}

--- a/src/components/ui/PerformanceDebugPanel.jsx
+++ b/src/components/ui/PerformanceDebugPanel.jsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 
-const PerformanceDebugPanel = ({ 
+const PerformanceDebugPanel = ({
   deviceProfile,
   performanceConfig,
   devicePerformanceProfile,
@@ -11,7 +11,7 @@ const PerformanceDebugPanel = ({
   hasInitialized,
   initialProfileApplied
 }) => {
-  if (!import.meta.env.DEV) return null;
+  if (!import.meta.env.DEV && !window.__PERF_DEBUG__) return null;
 
   return (
     <div style={{

--- a/src/hooks/useDeviceProfile.js
+++ b/src/hooks/useDeviceProfile.js
@@ -55,7 +55,7 @@ export const useDeviceProfile = (options = {}) => {
       setUIProfile(ui);
       
       // Debug logging
-      if (enableDebugLogging) {
+      if (enableDebugLogging || window.__PERF_DEBUG__) {
         const profileKey = `${device.category}-${device.performanceTier}`;
         if (detectDeviceProfile.lastProfileKey !== profileKey) {
           logProfileInfo(device, performance, ui);
@@ -196,8 +196,8 @@ export const useDeviceProfile = (options = {}) => {
     
     setManualOverride({ tier, performance: overridePerformance });
     
-    if (enableDebugLogging) {
-      if (import.meta.env.DEV) console.log('🔧 Manual override applied:', tier, overridePerformance);
+    if (enableDebugLogging || window.__PERF_DEBUG__) {
+      if (import.meta.env.DEV || window.__PERF_DEBUG__) console.log('🔧 Manual override applied:', tier, overridePerformance);
     }
   }, [deviceProfile, enableProfileOverride, enableDebugLogging]);
   
@@ -276,7 +276,7 @@ export const useDeviceProfile = (options = {}) => {
   // Performance monitoring utilities
   const isHighPerformance = currentDeviceProfile?.performanceTier === 'high';
   const isMobileDevice = currentDeviceProfile?.isMobile || false;
-  const isLowEndDevice = currentDeviceProfile?.performanceTier === 'low';
+  const isLowEndDevice = ['low', 'very-low'].includes(currentDeviceProfile?.performanceTier);
   
   return {
     // Profile information

--- a/src/utils/deviceDetection.js
+++ b/src/utils/deviceDetection.js
@@ -235,6 +235,9 @@ const classifyEnhancedPerformance = (capabilities, gpuInfo) => {
     }
     
     // Low-end desktop
+    if (gpuInfo?.tier === 'integrated-old' || capabilities.cpuCores <= 2 || capabilities.estimatedRAM <= 4) {
+      return 'very-low';
+    }
     return 'low';
   }
   
@@ -254,6 +257,9 @@ const classifyEnhancedPerformance = (capabilities, gpuInfo) => {
     }
     
     // Low-end mobile
+    if (capabilities.estimatedRAM <= 2 || gpuInfo?.tier === 'mobile-unknown') {
+      return 'very-low';
+    }
     return 'low';
   }
   

--- a/src/utils/deviceProfiles.js
+++ b/src/utils/deviceProfiles.js
@@ -95,7 +95,7 @@ export const mediumMobileProfile = {
  */
 export const lowEndMobileProfile = {
   ...basePerformanceSettings,
-  
+
   renderScale: 0.5,         // Keep low render scale
   
   // Disable all expensive features
@@ -120,6 +120,15 @@ export const lowEndMobileProfile = {
   
   reducedParticles: true,
   simplifiedAnimations: true  // CHANGED: Enable simplified animations
+};
+
+/**
+ * NEW: Extremely low-end profile for old hardware
+ * Mostly identical to lowEndMobileProfile but with an even lower render scale
+ */
+export const veryLowProfile = {
+  ...lowEndMobileProfile,
+  renderScale: 0.35
 };
 
 /**
@@ -235,12 +244,20 @@ export const getPerformanceProfile = (deviceProfile) => {
         pbrQuality: 'high',
         usePBR: true  // Keep PBR on desktop even if medium performance
       };
-    } else {
+    } else if (deviceProfile.performanceTier === 'low') {
       return {
         ...desktopProfile,
         renderScale: 0.6,
         pbrQuality: 'low',
-        usePBR: false,    // Only disable PBR on very low-end desktop
+        usePBR: false,
+        textureQuality: 'low'
+      };
+    } else {
+      return {
+        ...desktopProfile,
+        renderScale: 0.4,
+        pbrQuality: 'low',
+        usePBR: false,
         textureQuality: 'low'
       };
     }
@@ -251,8 +268,12 @@ export const getPerformanceProfile = (deviceProfile) => {
     if (deviceProfile.performanceTier === 'high') {
       if (import.meta.env.DEV) console.log('✅ High-end tablet - using optimized non-PBR profile');
       return highEndTabletProfile;
-    } else {
+    } else if (deviceProfile.performanceTier === 'medium') {
       return mediumTabletProfile;
+    } else if (deviceProfile.performanceTier === 'low') {
+      return { ...mediumTabletProfile, renderScale: 0.6, textureQuality: 'low' };
+    } else {
+      return veryLowProfile;
     }
   }
   
@@ -263,8 +284,10 @@ export const getPerformanceProfile = (deviceProfile) => {
       return highEndMobileProfile;
     } else if (deviceProfile.performanceTier === 'medium') {
       return mediumMobileProfile;
-    } else {
+    } else if (deviceProfile.performanceTier === 'low') {
       return lowEndMobileProfile;
+    } else {
+      return veryLowProfile;
     }
   }
   
@@ -370,14 +393,17 @@ export const getCanvasDPR = (deviceProfile, performanceProfile) => {
 };
 
 export const logProfileInfo = (deviceProfile, performanceProfile, uiProfile) => {
-  if (import.meta.env.DEV) console.group('🎮 OPTIMIZED Device Profile Configuration');
-  if (import.meta.env.DEV) console.log('Device:', deviceProfile);
-  if (import.meta.env.DEV) console.log('Performance Profile:', performanceProfile);
-  if (import.meta.env.DEV) console.log('UI Profile:', uiProfile);
-  if (import.meta.env.DEV) console.log('HDRI Path:', getHDRIPath(performanceProfile.hdriQuality));
-  if (import.meta.env.DEV) console.log('Recommended DPR:', getCanvasDPR(deviceProfile, performanceProfile));
-  
-  if (import.meta.env.DEV) console.log('📊 OPTIMIZED Performance Summary:', {
+  const debugEnabled = import.meta.env.DEV || window.__PERF_DEBUG__;
+  if (!debugEnabled) return;
+
+  console.group('🎮 OPTIMIZED Device Profile Configuration');
+  console.log('Device:', deviceProfile);
+  console.log('Performance Profile:', performanceProfile);
+  console.log('UI Profile:', uiProfile);
+  console.log('HDRI Path:', getHDRIPath(performanceProfile.hdriQuality));
+  console.log('Recommended DPR:', getCanvasDPR(deviceProfile, performanceProfile));
+
+  console.log('📊 OPTIMIZED Performance Summary:', {
     renderScale: performanceProfile.renderScale,
     pbrQuality: performanceProfile.pbrQuality,
     usePBR: performanceProfile.usePBR,
@@ -388,6 +414,6 @@ export const logProfileInfo = (deviceProfile, performanceProfile, uiProfile) => 
       .map(([effect, _]) => effect),
     optimization: performanceProfile.pbrQuality
   });
-  
-  if (import.meta.env.DEV) console.groupEnd();
+
+  console.groupEnd();
 };


### PR DESCRIPTION
## Summary
- add a new `veryLowProfile` performance preset with render scale 0.35
- extend `getPerformanceProfile` and device detection logic for a `very-low` tier
- allow toggling performance debug in production with `window.__PERF_DEBUG__`
- treat the new tier as low end and document new debug feature

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68868f96310c83288fb9c9437c8cb041