### PR TITLE
Enable simplified 3D effects

### DIFF
--- a/src/components/layout/Fixed3DCanvas.jsx
+++ b/src/components/layout/Fixed3DCanvas.jsx
@@ -17,11 +17,15 @@ import { FPSCounter } from '../ui/FpsDisplay';
 // ADDED: Import the debug panels component
 import CrystalDebugPanels from '../ui/CrystalDebugPanels';
 
-const PulsingOmniLight = () => {
+const PulsingOmniLight = ({ simplified = false }) => {
   const lightRef = useRef();
-  
+
   useFrame((state) => {
     if (lightRef.current) {
+      if (simplified) {
+        lightRef.current.intensity = 100.5;
+        return;
+      }
       const time = state.clock.elapsedTime;
       const pulse = Math.sin(time * 2 + Math.sin(time * 0.7) * 0.5) * 0.3 + 1;
       lightRef.current.intensity = 100.5 * pulse;
@@ -77,6 +81,10 @@ const Fixed3DCanvas = forwardRef(({
     showCrystalDebug: false,
     lastCrystalForm: 'whole'
   });
+
+  const simplifiedAnimations = performanceConfig?.simplifiedAnimations;
+  const dustEnabled = !performanceConfig?.reducedParticles;
+  const particleCount = performanceConfig?.particleCount;
 
   // NEW: Update debug data when crystal scene changes
   useEffect(() => {
@@ -145,7 +153,9 @@ const Fixed3DCanvas = forwardRef(({
           <color attach="background" args={['#050505']} />
           
           {/* Persistent Dust System */}
-          <PersistentDustSystem />
+          {dustEnabled && (
+            <PersistentDustSystem count={particleCount} enabled={dustEnabled} />
+          )}
           
           {/* UPDATED: Enhanced lighting setup with bottom directional light */}
           <ambientLight intensity={config?.lighting?.ambient?.intensity || 0.4} />
@@ -182,7 +192,7 @@ const Fixed3DCanvas = forwardRef(({
               />
             ))}
 
-          <PulsingOmniLight />
+          <PulsingOmniLight simplified={simplifiedAnimations} />
           
           {/* Spot light */}
           <spotLight
@@ -195,10 +205,11 @@ const Fixed3DCanvas = forwardRef(({
           />
           
           {/* UPDATED: Enhanced Camera Controller with facet refs */}
-          <UnifiedCameraController 
+          <UnifiedCameraController
             animationData={animationData}
             config={config}
             isMobile={isMobile}
+            simplifiedAnimations={simplifiedAnimations}
             facetRefs={getFacetRefs()} // FIXED: Pass exposed facet refs for anchor targeting
           />
           
@@ -210,6 +221,7 @@ const Fixed3DCanvas = forwardRef(({
             materialVariant={materialVariant}
             performanceConfig={performanceConfig}
             isMobile={isMobile}
+            simplifiedAnimations={simplifiedAnimations}
           />
           
           {/* Environment (unchanged) */}

--- a/src/components/three/GlowingSphereImage.jsx
+++ b/src/components/three/GlowingSphereImage.jsx
@@ -57,9 +57,10 @@ const GlowingSphereImage = ({
   
   // Animation state
   animationData = null,
-  
+
   // Debug
-  debugMode = false
+  debugMode = false,
+  simplifiedAnimations = false
 }) => {
   const meshRef = useRef();
   const { camera } = useThree();
@@ -208,7 +209,7 @@ const GlowingSphereImage = ({
     }
   });
   
-  if (!visible) return null;
+  if (!visible || simplifiedAnimations) return null;
   
   return (
     <mesh

--- a/src/components/three/PersistentDustSystem.jsx
+++ b/src/components/three/PersistentDustSystem.jsx
@@ -11,6 +11,7 @@ import * as THREE from 'three';
  */
 const PersistentDustSystem = ({
   count = 16,
+  enabled = true,
   emissionRadius = 5.5,
   emissionInnerRadius = 1.0,  // NEW: Inner radius for ring/donut shape
   emissionHeight = -4.0,
@@ -44,6 +45,9 @@ const PersistentDustSystem = ({
   enableFrustumCulling = false, // Keep particles alive even when emitter is off-screen
   maxDistance = 100             // Maximum distance from origin before culling particles
 }) => {
+  if (!enabled) {
+    return null;
+  }
   const particlesRef = useRef();
   const timeRef = useRef(0);
   

--- a/src/components/three/UnifiedCameraController.jsx
+++ b/src/components/three/UnifiedCameraController.jsx
@@ -2,10 +2,11 @@ import { useRef, useEffect } from 'react';
 import { useThree, useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
 
-const UnifiedCameraController = ({ 
+const UnifiedCameraController = ({
   animationData,
   config,
   isMobile = false,
+  simplifiedAnimations = false,
   facetRefs = null // Facet refs passed from UnifiedCrystalScene
 }) => {
   const { camera } = useThree();
@@ -233,6 +234,14 @@ const UnifiedCameraController = ({
    */
   useFrame(() => {
     if (!currentTarget.current) return;
+
+    if (simplifiedAnimations) {
+      camera.position.copy(currentTarget.current.position);
+      camera.lookAt(currentTarget.current.lookAt);
+      camera.fov = currentTarget.current.fov;
+      camera.updateProjectionMatrix();
+      return;
+    }
 
     const currentSpeeds = animationSpeed.current;
 

--- a/src/components/three/UnifiedCrystalScene.jsx
+++ b/src/components/three/UnifiedCrystalScene.jsx
@@ -14,10 +14,11 @@ import GlowingSphereImage, { BLENDING_MODES } from './GlowingSphereImage'
 
 const UnifiedCrystalScene = forwardRef(({ 
   animationData,
-  config, 
+  config,
   materialVariant = 'default',
   performanceConfig = { useNormalMaps: true, textureQuality: 'high', pbrQuality: 'high', usePBR: true },
-  isMobile = false
+  isMobile = false,
+  simplifiedAnimations = false
 }, ref) => {
   // Component refs for crystal animation
   const crystalGroupRef = useRef();
@@ -283,7 +284,7 @@ const UnifiedCrystalScene = forwardRef(({
 
   // Main animation loop
   useFrame(() => {
-    if (!animationData || !facetRefs.current.length) return;
+    if (!animationData || !facetRefs.current.length || simplifiedAnimations) return;
 
     const time = clock.getElapsedTime();
 
@@ -388,7 +389,7 @@ const UnifiedCrystalScene = forwardRef(({
       />
 
       {/* Enhanced Glowing Sphere */}
-      {sphereVisible && (
+      {sphereVisible && !simplifiedAnimations && (
         <GlowingSphereImage
           imagePath="/assets/textures/glowing-sphere06-noise.jpg"
           blendingMode={BLENDING_MODES.ADDITIVE}
@@ -402,6 +403,7 @@ const UnifiedCrystalScene = forwardRef(({
           position={[0, 0, 0]}
           visible={sphereVisible}
           animationData={animationData}
+          simplifiedAnimations={simplifiedAnimations}
           debugMode={import.meta.env.DEV}
         />
       )}
@@ -413,7 +415,7 @@ const UnifiedCrystalScene = forwardRef(({
         </group>
       )}
       
-      {showFacets && facetModels.map((model, index) => {
+      {showFacets && !simplifiedAnimations && facetModels.map((model, index) => {
         const facetKey = facetKeys[index];
 
         return (
@@ -427,7 +429,7 @@ const UnifiedCrystalScene = forwardRef(({
       })}
       
       {/* Debug visualization when enabled */}
-      {showCrystalDebug && showFacets && (
+      {showCrystalDebug && showFacets && !simplifiedAnimations && (
         <group name="anchor-debug-system">
           {facetKeys.map((facetKey, index) => {
             const facetRef = facetRefs.current[index];


### PR DESCRIPTION
## Summary
- allow `PersistentDustSystem` to be toggled via props
- configure particle effects and animation simplifications in `Fixed3DCanvas`
- respect simplified animations in camera controller, crystal scene, and sphere image

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6887cfab49a883289428acc6973cb89d