### PR TITLE
Add cached performance profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To inspect the device and performance profiles in a live build you can toggle th
 
 ## One‑time performance test
 
-After the device profile is resolved the app runs `useInitialPerformanceTest`. This hook measures the FPS for about four seconds and adjusts the performance profile if necessary. The test runs only once on first load. When complete, the resulting profile is stored via `updateExternalPerformanceConfig`.
+After the device profile is resolved the app runs `useInitialPerformanceTest`. This hook measures the FPS for about four seconds and adjusts the performance profile if necessary. When complete, the resulting configuration is saved to `localStorage` and passed back through `updateExternalPerformanceConfig` so subsequent visits start with the same settings.
 
 While detection and the FPS test are running the `LoadingScreen` component keeps the UI hidden. You can edit the loader styles or text in [`src/components/ui/LoadingScreen.jsx`](src/components/ui/LoadingScreen.jsx).
 

--- a/src/hooks/useDeviceProfile.js
+++ b/src/hooks/useDeviceProfile.js
@@ -14,11 +14,14 @@ import {
 /**
  * FIXED: Custom hook for device detection and performance optimization
  */
+const LOCAL_STORAGE_KEY = 'crystal-performance-config';
+
 export const useDeviceProfile = (options = {}) => {
   const {
     enableDebugLogging = false,
     enableOrientationLock = true,
-    enableProfileOverride = true
+    enableProfileOverride = true,
+    resetCachedSettings = false
   } = options;
   
   // State for device and profile information
@@ -41,8 +44,27 @@ export const useDeviceProfile = (options = {}) => {
       const device = detectDevice();
       
       // Get appropriate profiles
-      const performance = getPerformanceProfile(device);
+      let performance = getPerformanceProfile(device);
       const ui = getUIProfile(device);
+
+      if (resetCachedSettings) {
+        localStorage.removeItem(LOCAL_STORAGE_KEY);
+      } else {
+        const stored = localStorage.getItem(LOCAL_STORAGE_KEY);
+        if (stored) {
+          try {
+            const cached = JSON.parse(stored);
+            performance = { ...performance, ...cached };
+            if (import.meta.env.DEV) {
+              console.log('🔄 Applying cached performance config:', cached);
+            }
+          } catch (err) {
+            if (import.meta.env.DEV) {
+              console.error('Failed to parse cached performance config', err);
+            }
+          }
+        }
+      }
       
       // Apply orientation lock if needed
       if (enableOrientationLock && device.category === 'mobile') {
@@ -90,7 +112,7 @@ export const useDeviceProfile = (options = {}) => {
     } finally {
       setIsDetecting(false);
     }
-  }, [enableDebugLogging, enableOrientationLock]);
+  }, [enableDebugLogging, enableOrientationLock, resetCachedSettings]);
   
   // Initial detection on mount
   useEffect(() => {

--- a/src/hooks/useInitialPerformanceTest.js
+++ b/src/hooks/useInitialPerformanceTest.js
@@ -5,6 +5,8 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { useFPSMonitorDOM } from '../components/ui/FpsDisplay';
 import { getPerformanceProfile } from '../utils/deviceProfiles';
 
+const LOCAL_STORAGE_KEY = 'crystal-performance-config';
+
 // Exported priority map for adjustments
 export const TUNING_PRIORITY = {
   renderScale: 1,
@@ -78,6 +80,16 @@ export const useInitialPerformanceTest = (
 
   const finish = useCallback(() => {
     setTesting(false);
+    try {
+      localStorage.setItem(
+        LOCAL_STORAGE_KEY,
+        JSON.stringify(currentConfig.current)
+      );
+    } catch (err) {
+      if (import.meta.env.DEV) {
+        console.error('Failed to save performance config:', err);
+      }
+    }
     if (onComplete) onComplete(currentConfig.current);
   }, [onComplete]);
 


### PR DESCRIPTION
## Summary
- persist performance config after the FPS test
- load cached config in `useDeviceProfile`
- reset cached settings with a new hook option
- document that caching is used

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6887dfffaf6083289cc7d468da6f7ac9