### PR TITLE
Fix simplified mode and test visibility

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -356,9 +356,9 @@ function App() {
     }
   }, [deviceProfile, isReady, modelsLoaded, testPerformanceConfig, isPerfTesting, startPerfTest]);
 
-  // Apply performance config when test completes
+  // Apply performance config only when the initial test finishes
   useEffect(() => {
-    if (testPerformanceConfig) {
+    if (testPerformanceConfig && !isPerfTesting) {
       if (import.meta.env.DEV) console.log('🎯 Applying enhanced performance test results:', testPerformanceConfig);
       setPerformanceConfig(testPerformanceConfig);
 
@@ -371,7 +371,7 @@ function App() {
         markAsInitialized();
       }
     }
-  }, [testPerformanceConfig, markAsInitialized, updateExternalPerformanceConfig]);
+  }, [testPerformanceConfig, isPerfTesting, markAsInitialized, updateExternalPerformanceConfig]);
 
   // ENHANCED: App ready detection with better criteria
   useEffect(() => {

--- a/src/components/three/UnifiedCrystalScene.jsx
+++ b/src/components/three/UnifiedCrystalScene.jsx
@@ -267,15 +267,26 @@ const UnifiedCrystalScene = forwardRef(({
         if (import.meta.env.DEV) {
           console.log('💎 Crystal: Explosion - hiding whole, showing facets, showing sphere');
         }
-        setShowWholeCrystal(false);
-        setShowFacets(true);
-        setSphereVisible(true);
-        
+        if (!simplifiedAnimations) {
+          setShowWholeCrystal(false);
+          setShowFacets(true);
+          setSphereVisible(true);
+        } else {
+          // In simplified mode keep the whole crystal visible
+          setShowWholeCrystal(true);
+          setShowFacets(false);
+          setSphereVisible(false);
+        }
+
       } else if (currentForm === 'whole') {
         if (import.meta.env.DEV) {
           console.log('💎 Crystal: Reform detected - hiding sphere');
         }
         setSphereVisible(false);
+        if (simplifiedAnimations) {
+          setShowWholeCrystal(true);
+          setShowFacets(false);
+        }
       }
       
       lastCrystalForm.current = currentForm;


### PR DESCRIPTION
## Summary
- apply initial performance config only after test finishes
- avoid hiding the whole crystal in simplified mode

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6887fc9aab8c8328b6a43d375dcc8c32