### PR TITLE
Add profiler history + profile export tools

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -38,6 +38,7 @@ import { usePerformanceProfiler } from './performance/usePerformanceProfiler.jsx
 
 const APP_VERSION = '0.0.0';
 const PERFORMANCE_STORAGE_KEY = 'crystal-performance-config';
+const HISTORY_STORAGE_PREFIX = 'perf-history';
 
 // Convert UI config into animation config
 const buildAnimationConfig = (uiConfig) => {
@@ -294,6 +295,38 @@ function App() {
     }
   }, [hasInitialized, updateExternalPerformanceConfig]);
 
+  const saveProfileResult = useCallback((result) => {
+    if (!result?.config) return;
+    setProfileConfig(result.config);
+    try {
+      const key = fingerprint ? `${PERFORMANCE_STORAGE_KEY}:${fingerprint}` : PERFORMANCE_STORAGE_KEY;
+      localStorage.setItem(key, JSON.stringify({ version: APP_VERSION, config: result.config }));
+    } catch (err) {
+      if (import.meta.env.DEV) console.error('Failed to save performance config:', err);
+    }
+    try {
+      const histKey = fingerprint ? `${HISTORY_STORAGE_PREFIX}:${fingerprint}` : HISTORY_STORAGE_PREFIX;
+      const entry = { timestamp: Date.now(), fps: Math.round(result.avg || 0) };
+      const existing = JSON.parse(localStorage.getItem(histKey) || '[]');
+      existing.push(entry);
+      localStorage.setItem(histKey, JSON.stringify(existing));
+    } catch (err) {
+      if (import.meta.env.DEV) console.error('Failed to record performance history:', err);
+    }
+  }, [fingerprint]);
+
+  const handleForceRetest = useCallback(() => {
+    try {
+      const key = fingerprint ? `${PERFORMANCE_STORAGE_KEY}:${fingerprint}` : PERFORMANCE_STORAGE_KEY;
+      localStorage.removeItem(key);
+    } catch (err) {
+      if (import.meta.env.DEV) console.error('Failed to clear cached profile', err);
+    }
+    setProfileConfig(null);
+    setHasCachedProfile(false);
+    startProfiler(100).then(saveProfileResult);
+  }, [fingerprint, startProfiler, saveProfileResult]);
+
   const toggleUI = useCallback(() => {
     setShowUI(!showUI);
   }, [showUI]);
@@ -367,19 +400,9 @@ function App() {
         model: deviceProfile.deviceModel,
         gpu: deviceProfile.gpu?.tier
       });
-      startProfiler(progress).then(result => {
-        if (result?.config) {
-          setProfileConfig(result.config);
-          try {
-            const key = fingerprint ? `${PERFORMANCE_STORAGE_KEY}:${fingerprint}` : PERFORMANCE_STORAGE_KEY;
-            localStorage.setItem(key, JSON.stringify({ version: APP_VERSION, config: result.config }));
-          } catch (err) {
-            if (import.meta.env.DEV) console.error('Failed to save performance config:', err);
-          }
-        }
-      });
+      startProfiler(progress).then(saveProfileResult);
     }
-  }, [deviceProfile, isReady, modelsLoaded, profileConfig, hasCachedProfile, isProfiling, startProfiler, fingerprint]);
+  }, [deviceProfile, isReady, modelsLoaded, profileConfig, hasCachedProfile, isProfiling, startProfiler, fingerprint, saveProfileResult]);
 
   // Apply performance config when profiler completes or cache loaded
   useEffect(() => {
@@ -662,6 +685,8 @@ function App() {
           hasInitialized={hasInitialized}
           initialProfileApplied={!!performanceConfig}
           debugInfo={debugInfo}
+          fingerprint={fingerprint}
+          onForceRetest={handleForceRetest}
         />
       )}
     </>

--- a/src/components/ui/PerformanceDebugPanel.jsx
+++ b/src/components/ui/PerformanceDebugPanel.jsx
@@ -1,7 +1,9 @@
 // src/components/ui/PerformanceDebugPanel.jsx
 // UPDATED: Debug panel reflecting the fixed performance system
 
-import React from 'react';
+import React, { useRef } from 'react';
+
+const PERFORMANCE_STORAGE_KEY = 'crystal-performance-config';
 
 const PerformanceDebugPanel = ({
   deviceProfile,
@@ -9,9 +11,49 @@ const PerformanceDebugPanel = ({
   devicePerformanceProfile,
   initialPerformanceConfig,
   hasInitialized,
-  initialProfileApplied
+  initialProfileApplied,
+  fingerprint,
+  onForceRetest
 }) => {
   if (!import.meta.env.DEV && !window.__PERF_DEBUG__) return null;
+
+  const fileInputRef = useRef(null);
+
+  const exportProfile = () => {
+    try {
+      const key = fingerprint ? `${PERFORMANCE_STORAGE_KEY}:${fingerprint}` : PERFORMANCE_STORAGE_KEY;
+      const stored = localStorage.getItem(key);
+      if (stored) {
+        const blob = new Blob([stored], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = 'profile.json';
+        a.click();
+        URL.revokeObjectURL(url);
+      }
+    } catch (err) {
+      console.error('Export failed', err);
+    }
+  };
+
+  const importProfile = (e) => {
+    const file = e.target.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      try {
+        const text = ev.target.result;
+        JSON.parse(text);
+        const key = fingerprint ? `${PERFORMANCE_STORAGE_KEY}:${fingerprint}` : PERFORMANCE_STORAGE_KEY;
+        localStorage.setItem(key, text);
+        window.location.reload();
+      } catch (err) {
+        console.error('Import failed', err);
+      }
+    };
+    reader.readAsText(file);
+  };
 
   return (
     <div style={{
@@ -27,7 +69,7 @@ const PerformanceDebugPanel = ({
       fontFamily: 'monospace',
       zIndex: 20000,
       maxWidth: '900px',
-      pointerEvents: 'none'
+      pointerEvents: 'auto'
     }}>
       <div style={{ fontWeight: 'bold', marginBottom: '10px', color: '#ffff00' }}>
         🔧 FIXED PERFORMANCE SYSTEM (Press F12 for console)
@@ -88,6 +130,19 @@ const PerformanceDebugPanel = ({
         <div>Performance Test: {initialPerformanceConfig ? '✅ Completed' : '⏳ Running'}</div>
       </div>
       
+      <div style={{ marginTop: '10px', display: 'flex', gap: '8px' }}>
+        <button onClick={onForceRetest} style={{ pointerEvents: 'auto', padding: '6px 8px', fontSize: '11px' }}>
+          Force Re-test
+        </button>
+        <button onClick={exportProfile} style={{ pointerEvents: 'auto', padding: '6px 8px', fontSize: '11px' }}>
+          Export Profile
+        </button>
+        <button onClick={() => fileInputRef.current?.click()} style={{ pointerEvents: 'auto', padding: '6px 8px', fontSize: '11px' }}>
+          Import Profile
+        </button>
+        <input type="file" accept="application/json" ref={fileInputRef} onChange={importProfile} style={{ display: 'none' }} />
+      </div>
+
       <div style={{
         marginTop: '10px',
         padding: '10px',

--- a/src/performance/usePerformanceProfiler.jsx
+++ b/src/performance/usePerformanceProfiler.jsx
@@ -145,7 +145,7 @@ export const usePerformanceProfiler = () => {
       window.updateImmediateLoader(combined, 'Profiling Performance', 'Finalizing...', combined);
     }
     setIsProfiling(false);
-    return { config: currentConfig, metrics };
+    return { config: currentConfig, metrics, avg };
   }, [isProfiling, runWithConfig]);
 
   const cancelProfiler = useCallback(() => {


### PR DESCRIPTION
## Summary
- add `perf-history` logging for completed performance tests
- expose `handleForceRetest` to debug panel
- add JSON export/import actions in `PerformanceDebugPanel`
- expose final FPS avg from profiler

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688ae6f759988328a12ef8cd8c2dc659