### PR TITLE
Update performance profiler to accept initial settings

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -182,7 +182,7 @@ function App() {
     cancelProfiler,
     progress: profilerProgress,
     isProfiling
-  } = usePerformanceProfiler();
+  } = usePerformanceProfiler(devicePerformanceProfile);
 
   const [profileConfig, setProfileConfig] = useState(null);
   const [hasCachedProfile, setHasCachedProfile] = useState(false);
@@ -198,6 +198,8 @@ function App() {
           if (!obj.version || obj.version === APP_VERSION) {
             setProfileConfig(obj.config || obj);
             setHasCachedProfile(true);
+          } else {
+            localStorage.removeItem(key);
           }
         }
       } catch (err) {

--- a/src/performance/usePerformanceProfiler.jsx
+++ b/src/performance/usePerformanceProfiler.jsx
@@ -80,9 +80,9 @@ const stepDescriptions = [
   'Simplify animations'
 ];
 
-export const usePerformanceProfiler = () => {
+export const usePerformanceProfiler = (initialConfig = HIGH_SETTINGS) => {
   const sceneRef = useRef(null);
-  const [sceneConfig, setSceneConfig] = useState(HIGH_SETTINGS);
+  const [sceneConfig, setSceneConfig] = useState(initialConfig);
   const [progress, setProgress] = useState(0);
   const [isProfiling, setIsProfiling] = useState(false);
   const cancelRef = useRef(false);
@@ -107,7 +107,7 @@ export const usePerformanceProfiler = () => {
     setProgress(0);
 
     const metrics = [];
-    let currentConfig = { ...HIGH_SETTINGS };
+    let currentConfig = { ...initialConfig };
     let result = await runWithConfig(currentConfig);
     metrics.push({ config: currentConfig, metrics: result });
     let avg = result.avg;


### PR DESCRIPTION
## Summary
- allow `usePerformanceProfiler` to take an initial configuration
- use the detected `devicePerformanceProfile` as the baseline
- discard outdated cached profiles when the app version changes

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688aeb646da88328a5418a4e4dbc4291