### PR TITLE
Preload assets before running performance test

### DIFF
--- a/src/performance/PerformanceTestScene.jsx
+++ b/src/performance/PerformanceTestScene.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, forwardRef, useImperativeHandle } from 'react';
+import React, { useState, useRef, forwardRef, useImperativeHandle, useEffect } from 'react';
 import { Canvas } from '@react-three/fiber';
 import { Environment } from '@react-three/drei';
 import { EffectComposer, Bloom, ChromaticAberration, Noise, Vignette } from '@react-three/postprocessing';
@@ -8,6 +8,7 @@ import * as THREE from 'three';
 import UnifiedCrystalScene from '../components/three/UnifiedCrystalScene';
 import * as defaultConfig from '../crystalConfig';
 import { getHDRIPath } from '../utils/deviceProfiles';
+import { preloadAssets } from '../utils/preloadAssets';
 
 const PerformanceTestScene = forwardRef(({
   config = defaultConfig,
@@ -33,6 +34,11 @@ const PerformanceTestScene = forwardRef(({
   const rafRef = useRef(null);
   const durationRef = useRef(0);
   const resolveRef = useRef(null);
+  const assetPromiseRef = useRef(Promise.resolve());
+
+  useEffect(() => {
+    assetPromiseRef.current = preloadAssets(hdriQuality);
+  }, []);
 
   const animationData = {
     state: 'hero',
@@ -80,7 +86,9 @@ const PerformanceTestScene = forwardRef(({
       startRef.current = 0;
       setActive(true);
       return new Promise((resolve) => {
-        resolveRef.current = resolve;
+        resolveRef.current = (result) => {
+          assetPromiseRef.current.then(() => resolve(result));
+        };
         rafRef.current = requestAnimationFrame(loop);
       });
     }

--- a/src/utils/preloadAssets.js
+++ b/src/utils/preloadAssets.js
@@ -5,10 +5,17 @@ import { assets } from '../crystalConfig';
 import { getHDRIPath } from './deviceProfiles';
 
 export function preloadAssets(hdriQuality = 'low') {
-  Object.values(assets.models).forEach((url) => useGLTF.preload(url));
+  const promises = [];
+  Object.values(assets.models).forEach((url) => {
+    const p = useGLTF.preload(url);
+    if (p) promises.push(p);
+  });
   if (assets.textures?.normalMap) {
-    useTexture.preload(assets.textures.normalMap);
+    const p = useTexture.preload(assets.textures.normalMap);
+    if (p) promises.push(p);
   }
   const hdriPath = getHDRIPath(hdriQuality);
-  useLoader.preload(RGBELoader, hdriPath);
+  const hdriPromise = useLoader.preload(RGBELoader, hdriPath);
+  if (hdriPromise) promises.push(hdriPromise);
+  return Promise.all(promises);
 }


### PR DESCRIPTION
## Summary
- preload all required 3D assets when `PerformanceTestScene` mounts
- return a promise from `preloadAssets`
- wait for assets to finish loading before resolving `runTest`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688af6df6a988328b773521446293acf