### PR TITLE
Align profiler DPR with main scene

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -181,7 +181,7 @@ function App() {
     cancelProfiler,
     progress: profilerProgress,
     isProfiling
-  } = usePerformanceProfiler(devicePerformanceProfile);
+  } = usePerformanceProfiler(devicePerformanceProfile, deviceProfile);
 
   const [profileConfig, setProfileConfig] = useState(null);
   const [hasCachedProfile, setHasCachedProfile] = useState(false);

--- a/src/performance/PerformanceTestScene.jsx
+++ b/src/performance/PerformanceTestScene.jsx
@@ -7,7 +7,7 @@ import * as THREE from 'three';
 
 import UnifiedCrystalScene from '../components/three/UnifiedCrystalScene';
 import * as defaultConfig from '../crystalConfig';
-import { getHDRIPath } from '../utils/deviceProfiles';
+import { getHDRIPath, getCanvasDPR } from '../utils/deviceProfiles';
 import { preloadAssets } from '../utils/preloadAssets';
 
 const PerformanceTestScene = forwardRef(({
@@ -24,7 +24,8 @@ const PerformanceTestScene = forwardRef(({
   anisotropicFiltering = 4,
   simplifiedAnimations = false,
   reducedParticles = false,
-  particleCount = 16
+  particleCount = 16,
+  deviceProfile
 }, ref) => {
   const [active, setActive] = useState(false);
   const fpsSamples = useRef([]);
@@ -110,10 +111,12 @@ const PerformanceTestScene = forwardRef(({
     particleCount
   };
 
+  const [minDpr, maxDpr] = getCanvasDPR(deviceProfile, { renderScale });
+
   return active ? (
     <div style={{ position: 'fixed', inset: 0, pointerEvents: 'none' }}>
       <Canvas
-        dpr={renderScale}
+        dpr={[minDpr * renderScale, maxDpr * renderScale]}
         gl={{
           toneMapping: THREE.ACESFilmicToneMapping,
           toneMappingExposure: 0.2,

--- a/src/performance/usePerformanceProfiler.jsx
+++ b/src/performance/usePerformanceProfiler.jsx
@@ -80,7 +80,7 @@ const stepDescriptions = [
   'Simplify animations'
 ];
 
-export const usePerformanceProfiler = (initialConfig = HIGH_SETTINGS) => {
+export const usePerformanceProfiler = (initialConfig = HIGH_SETTINGS, deviceProfile = null) => {
   const sceneRef = useRef(null);
   const [sceneConfig, setSceneConfig] = useState(initialConfig);
   const [progress, setProgress] = useState(0);
@@ -88,7 +88,12 @@ export const usePerformanceProfiler = (initialConfig = HIGH_SETTINGS) => {
   const cancelRef = useRef(false);
 
   const TestScene = (
-    <PerformanceTestScene ref={sceneRef} {...sceneConfig} config={defaultConfig} />
+    <PerformanceTestScene
+      ref={sceneRef}
+      {...sceneConfig}
+      config={defaultConfig}
+      deviceProfile={deviceProfile}
+    />
   );
 
   const waitNextFrame = () =>


### PR DESCRIPTION
## Summary
- support a `deviceProfile` prop in `PerformanceTestScene`
- feed current device profile to `PerformanceTestScene` through `usePerformanceProfiler`
- use same DPR calculation for the profiler canvas
- pass `deviceProfile` when initializing the performance profiler in `App`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688afd172d20832893fe59dfaa072c20