### PR TITLE
Update profiler startup dependencies

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -383,7 +383,7 @@ function App() {
 
   // Start performance profiler when ready and no cached profile
   useEffect(() => {
-    if (deviceProfile && isReady && !profileConfig && !hasCachedProfile && !isProfiling) {
+    if (deviceProfile && fingerprint !== null && isReady && !profileConfig && !hasCachedProfile && !isProfiling) {
       if (import.meta.env.DEV) console.log('🔬 Starting performance profiler for device:', {
         category: deviceProfile.category,
         tier: deviceProfile.performanceTier,
@@ -392,7 +392,7 @@ function App() {
       });
       startProfiler(progress).then(saveProfileResult);
     }
-  }, [deviceProfile, isReady, profileConfig, hasCachedProfile, isProfiling, startProfiler, progress, saveProfileResult]);
+  }, [deviceProfile, fingerprint, isReady, profileConfig, hasCachedProfile, isProfiling, startProfiler, progress, saveProfileResult]);
 
   // Apply performance config when profiler completes or cache loaded
   useEffect(() => {


### PR DESCRIPTION
## Summary
- start the performance profiler only after the device fingerprint is available
- store/retrieve profiles under `crystal-performance-config:<fingerprint>`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688b71eba32c8328be5f8ea3da32ecdf