### PR TITLE
Refactor to new performance hooks

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -34,11 +34,6 @@ import PerformanceDebugPanel from './components/ui/PerformanceDebugPanel';
 // Configuration and utilities
 import * as defaultConfig from './crystalConfig';
 import usePerformance from './hooks/usePerformance';
-import { usePerformanceProfiler } from './performance/usePerformanceProfiler.jsx';
-
-const APP_VERSION = '0.0.0';
-const PERFORMANCE_STORAGE_KEY = 'crystal-performance-config';
-const HISTORY_STORAGE_PREFIX = 'perf-history';
 
 // Convert UI config into animation config
 const buildAnimationConfig = (uiConfig) => {
@@ -136,7 +131,7 @@ function App() {
 
   // ENHANCED: Device profile hook with better debugging
   const {
-    profile: devicePerformanceProfile,
+    profile: performanceProfile,
     isReady: hasInitialized,
     updateProfile
   } = usePerformance();
@@ -146,11 +141,11 @@ function App() {
 
   // Initialize effects from the detected device profile
   useEffect(() => {
-    if (devicePerformanceProfile?.postProcessing) {
-      setEffectsEnabled(devicePerformanceProfile.postProcessing);
-      setPostProcessingConfig(devicePerformanceProfile.postProcessing);
+    if (performanceProfile?.postProcessing) {
+      setEffectsEnabled(performanceProfile.postProcessing);
+      setPostProcessingConfig(performanceProfile.postProcessing);
     }
-  }, [devicePerformanceProfile]);
+  }, [performanceProfile]);
 
   // ENHANCED: Asset loader hook
   const {
@@ -164,40 +159,15 @@ function App() {
     isReady,
     hasErrors,
     retry
-  } = useAssetLoader(devicePerformanceProfile);
+  } = useAssetLoader(performanceProfile);
 
-  // Performance profiler hook
-  const {
-    TestScene,
-    startProfiler,
-    cancelProfiler,
-    progress: profilerProgress,
-    isProfiling
-  } = usePerformanceProfiler(devicePerformanceProfile);
-
-  const [profileConfig, setProfileConfig] = useState(null);
-  const [hasCachedProfile, setHasCachedProfile] = useState(false);
-
-  // Load cached performance config if available
+  // Apply profile from performance manager when ready
   useEffect(() => {
-    if (!profileConfig && !hasCachedProfile) {
-      try {
-        const key = PERFORMANCE_STORAGE_KEY;
-        const stored = localStorage.getItem(key);
-        if (stored) {
-          const obj = JSON.parse(stored);
-          if (!obj.version || obj.version === APP_VERSION) {
-            setProfileConfig(obj.config || obj);
-            setHasCachedProfile(true);
-          } else {
-            localStorage.removeItem(key);
-          }
-        }
-      } catch (err) {
-        if (import.meta.env.DEV) console.error('Failed to load cached profile', err);
-      }
+    if (performanceProfile && !performanceConfig) {
+      setPerformanceConfig(performanceProfile);
     }
-  }, [profileConfig, hasCachedProfile]);
+  }, [performanceProfile, performanceConfig]);
+
 
   // Detect if mobile
   const isMobile = isMobileDevice();
@@ -284,37 +254,6 @@ function App() {
 
   }, []);
 
-  const saveProfileResult = useCallback((result) => {
-    if (!result?.config) return;
-    setProfileConfig(result.config);
-    try {
-      const key = PERFORMANCE_STORAGE_KEY;
-      localStorage.setItem(key, JSON.stringify({ version: APP_VERSION, config: result.config }));
-    } catch (err) {
-      if (import.meta.env.DEV) console.error('Failed to save performance config:', err);
-    }
-    try {
-      const histKey = HISTORY_STORAGE_PREFIX;
-      const entry = { timestamp: Date.now(), fps: Math.round(result.avg || 0) };
-      const existing = JSON.parse(localStorage.getItem(histKey) || '[]');
-      existing.push(entry);
-      localStorage.setItem(histKey, JSON.stringify(existing));
-    } catch (err) {
-      if (import.meta.env.DEV) console.error('Failed to record performance history:', err);
-    }
-  }, []);
-
-  const handleForceRetest = useCallback(() => {
-    try {
-      const key = PERFORMANCE_STORAGE_KEY;
-      localStorage.removeItem(key);
-    } catch (err) {
-      if (import.meta.env.DEV) console.error('Failed to clear cached profile', err);
-    }
-    setProfileConfig(null);
-    setHasCachedProfile(false);
-    startProfiler(100).then(saveProfileResult);
-  }, [startProfiler, saveProfileResult]);
 
   const toggleUI = useCallback(() => {
     setShowUI(!showUI);
@@ -333,28 +272,23 @@ function App() {
   // ENHANCED: Immediate loader with test progress
   // ========================================
 
-  // Update the immediate HTML loader with enhanced progress info
+  // Update the immediate HTML loader with progress info
   useEffect(() => {
-    if (window.updateImmediateLoader && !isProfiling) {
+    if (window.updateImmediateLoader) {
       let displayPhase = 'Initializing...';
       let displayAsset = 'Setting up...';
-      
+
       if (phase === 'loading') {
         displayPhase = 'Loading Assets';
         displayAsset = currentAsset || 'Loading resources...';
-      } else if (isProfiling) {
-        displayPhase = 'Profiling Performance';
-        displayAsset = `Running tests... ${Math.round(profilerProgress)}%`;
       } else if (isReady && performanceConfig) {
         displayPhase = 'Ready';
         displayAsset = 'Starting experience...';
       }
 
-      const finalProgress = isProfiling ? profilerProgress : progress;
-
-      window.updateImmediateLoader(finalProgress, displayPhase, displayAsset, null);
+      window.updateImmediateLoader(progress, displayPhase, displayAsset, null);
     }
-  }, [progress, phase, currentAsset, isProfiling, profilerProgress, isReady, performanceConfig]);
+  }, [progress, phase, currentAsset, isReady, performanceConfig]);
 
   // Hide immediate loader and show React app when ready
   useEffect(() => {
@@ -366,30 +300,14 @@ function App() {
   }, [isAppReady]);
 
 
-  // Start performance profiler when ready and no cached profile
-  useEffect(() => {
-    if (isReady && !profileConfig && !hasCachedProfile && !isProfiling) {
-      if (import.meta.env.DEV) console.log('🔬 Starting performance profiler');
-      startProfiler(progress).then(saveProfileResult);
-    }
-  }, [isReady, profileConfig, hasCachedProfile, isProfiling, startProfiler, progress, saveProfileResult]);
-
-  // Apply performance config when profiler completes or cache loaded
-  useEffect(() => {
-    if (profileConfig) {
-      if (import.meta.env.DEV) console.log('🎯 Applying profiler results:', profileConfig);
-      setPerformanceConfig(profileConfig);
-
-    }
-  }, [profileConfig]);
 
   // ENHANCED: App ready detection with better criteria
   useEffect(() => {
-    if (isReady && performanceConfig && !isProfiling && !isAppReady) {
+    if (isReady && performanceConfig && !isAppReady) {
       if (import.meta.env.DEV) console.log('🎯 App is ready - enhanced system initialized:', {
         assetsLoaded: isReady,
         performanceConfigured: !!performanceConfig,
-        deviceTier: devicePerformanceProfile?.tier,
+        deviceTier: performanceProfile?.tier,
         finalSettings: {
           renderScale: performanceConfig.renderScale,
           pbrQuality: performanceConfig.pbrQuality,
@@ -398,7 +316,7 @@ function App() {
       });
       setIsAppReady(true);
     }
-  }, [isReady, performanceConfig, isProfiling, isAppReady, devicePerformanceProfile]);
+  }, [isReady, performanceConfig, isAppReady, performanceProfile]);
 
   // UI Hide Toggle Keyboard Listener
   useEffect(() => {
@@ -443,19 +361,15 @@ function App() {
 
   if (!isAppReady) {
     return (
-      <>
-        {isProfiling && TestScene}
-        <EnhancedLoadingScreen
-          progress={isProfiling ? Math.round(profilerProgress) : Math.round(progress)}
-          phase={isProfiling ? 'profiling' : phase}
-          currentAsset={currentAsset}
-          loadedAssets={loadedAssets}
-          totalAssets={totalAssets}
-          profilerProgress={isProfiling ? profilerProgress : null}
-          errors={errors}
-          onRetry={retry}
-        />
-      </>
+      <EnhancedLoadingScreen
+        progress={Math.round(progress)}
+        phase={phase}
+        currentAsset={currentAsset}
+        loadedAssets={loadedAssets}
+        totalAssets={totalAssets}
+        errors={errors}
+        onRetry={retry}
+      />
     );
   }
 
@@ -524,7 +438,7 @@ function App() {
             materialVariant={materialVariant}
             effectsEnabled={effectsEnabled}
           postProcessingConfig={postProcessingConfig}
-          performanceConfig={performanceConfig}
+          performanceProfile={performanceConfig}
           config={config}
           canvasProps={canvasProps}
           environmentProps={environmentProps}
@@ -641,10 +555,8 @@ function App() {
       {(import.meta.env.DEV || perfDebug) && (
         <PerformanceDebugPanel
           performanceConfig={performanceConfig}
-          initialPerformanceConfig={profileConfig}
           hasInitialized={hasInitialized}
           initialProfileApplied={!!performanceConfig}
-          onForceRetest={handleForceRetest}
         />
       )}
     </>

--- a/src/components/layout/Fixed3DCanvas.jsx
+++ b/src/components/layout/Fixed3DCanvas.jsx
@@ -56,7 +56,7 @@ const Fixed3DCanvas = forwardRef(({
   materialVariant = 'default',
   effectsEnabled,
   postProcessingConfig,
-  performanceConfig,
+  performanceProfile,
   config,
   canvasProps = {},
   environmentProps = {},
@@ -82,9 +82,9 @@ const Fixed3DCanvas = forwardRef(({
     lastCrystalForm: 'whole'
   });
 
-  const simplifiedAnimations = performanceConfig?.simplifiedAnimations;
-  const dustEnabled = !performanceConfig?.reducedParticles;
-  const particleCount = performanceConfig?.particleCount;
+  const simplifiedAnimations = performanceProfile?.simplifiedAnimations;
+  const dustEnabled = !performanceProfile?.reducedParticles;
+  const particleCount = performanceProfile?.particleCount;
 
   // NEW: Update debug data when crystal scene changes
   useEffect(() => {
@@ -181,7 +181,7 @@ const Fixed3DCanvas = forwardRef(({
           
           {/* Point lights */}
           {config?.lighting?.pointLights
-            ?.slice(0, performanceConfig?.maxLights || config?.lighting?.pointLights.length)
+            ?.slice(0, performanceProfile?.maxLights || config?.lighting?.pointLights.length)
             .map((light, index) => (
               <pointLight
                 key={index}
@@ -219,7 +219,7 @@ const Fixed3DCanvas = forwardRef(({
             animationData={animationData}
             config={config}
             materialVariant={materialVariant}
-            performanceConfig={performanceConfig}
+            performanceProfile={performanceProfile}
             isMobile={isMobile}
             simplifiedAnimations={simplifiedAnimations}
           />

--- a/src/components/three/MaterialManager.jsx
+++ b/src/components/three/MaterialManager.jsx
@@ -10,7 +10,7 @@ const MaterialManager = ({
   materialVariant,
   config,
   materialRef,
-  performanceConfig = {},
+  performanceProfile = {},
   onMaterialReady = null
 }) => {
   const crystalMaterialRef = useRef();
@@ -25,7 +25,7 @@ const MaterialManager = ({
     useNormalMaps: true,
     textureQuality: 'high',
     renderScale: 1.0,
-    ...performanceConfig
+    ...performanceProfile
   };
 
   const pbrQuality = safePerformanceConfig.pbrQuality || (safePerformanceConfig.usePBR === false ? 'low' : 'high');

--- a/src/components/three/UnifiedCrystalScene.jsx
+++ b/src/components/three/UnifiedCrystalScene.jsx
@@ -16,7 +16,7 @@ const UnifiedCrystalScene = forwardRef(({
   animationData,
   config,
   materialVariant = 'default',
-  performanceConfig = { useNormalMaps: true, textureQuality: 'high', pbrQuality: 'high', usePBR: true },
+  performanceProfile = { useNormalMaps: true, textureQuality: 'high', pbrQuality: 'high', usePBR: true },
   isMobile = false,
   simplifiedAnimations = false
 }, ref) => {
@@ -395,7 +395,7 @@ const UnifiedCrystalScene = forwardRef(({
         materialVariant={materialVariant}
         config={config}
         materialRef={crystalMaterialRef}
-        performanceConfig={performanceConfig}
+        performanceProfile={performanceProfile}
         onMaterialReady={handleMaterialReady}
       />
 

--- a/src/components/ui/PerformanceDebugPanel.jsx
+++ b/src/components/ui/PerformanceDebugPanel.jsx
@@ -7,10 +7,8 @@ const PERFORMANCE_STORAGE_KEY = 'crystal-performance-config';
 
 const PerformanceDebugPanel = ({
   performanceConfig,
-  initialPerformanceConfig,
   hasInitialized,
-  initialProfileApplied,
-  onForceRetest
+  initialProfileApplied
 }) => {
   if (!import.meta.env.DEV && !window.__PERF_DEBUG__) return null;
 
@@ -73,21 +71,7 @@ const PerformanceDebugPanel = ({
       </div>
       
       <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '15px' }}>
-        <div>
-          <div style={{ color: '#03dac6', fontWeight: 'bold' }}>Performance Test:</div>
-          <div style={{ color: initialPerformanceConfig ? '#4CAF50' : '#FF9800' }}>
-            Completed: {initialPerformanceConfig ? 'YES' : 'RUNNING'}
-          </div>
-          {initialPerformanceConfig && (
-            <>
-              <div>Material: {initialPerformanceConfig.pbrQuality}</div>
-              <div>PBR: {initialPerformanceConfig.usePBR ? 'YES' : 'NO'}</div>
-              <div>Normal Maps: {initialPerformanceConfig.useNormalMaps ? 'YES' : 'NO'}</div>
-              <div>Texture: {initialPerformanceConfig.textureQuality}</div>
-              <div>Render Scale: {initialPerformanceConfig.renderScale}</div>
-            </>
-          )}
-        </div>
+
         
         <div>
           <div style={{ color: '#ffd600', fontWeight: 'bold' }}>Active Config:</div>
@@ -107,13 +91,9 @@ const PerformanceDebugPanel = ({
         <div style={{ color: '#64ffda', fontWeight: 'bold' }}>System Status:</div>
         <div>Has Initialized: {hasInitialized ? '✅' : '❌'}</div>
         <div>Profile Applied: {initialProfileApplied ? '✅' : '❌'}</div>
-        <div>Performance Test: {initialPerformanceConfig ? '✅ Completed' : '⏳ Running'}</div>
       </div>
-      
+
       <div style={{ marginTop: '10px', display: 'flex', gap: '8px' }}>
-        <button onClick={onForceRetest} style={{ pointerEvents: 'auto', padding: '6px 8px', fontSize: '11px' }}>
-          Force Re-test
-        </button>
         <button onClick={exportProfile} style={{ pointerEvents: 'auto', padding: '6px 8px', fontSize: '11px' }}>
           Export Profile
         </button>


### PR DESCRIPTION
## Summary
- integrate updated `usePerformance` hook
- remove old profiler and cached fingerprint logic
- rename props to use `performanceProfile`

## Testing
- `npm install`
- `npm run build` *(fails: getHDRIPath not exported)*

------
https://chatgpt.com/codex/tasks/task_e_688b9a323a0c83288f65d73600704f51