### PR TITLE
Fix HDRI import error

### DIFF
--- a/src/performance/PerformanceTestScene.jsx
+++ b/src/performance/PerformanceTestScene.jsx
@@ -7,7 +7,7 @@ import * as THREE from 'three';
 
 import UnifiedCrystalScene from '../components/three/UnifiedCrystalScene';
 import * as defaultConfig from '../crystalConfig';
-import { getHDRIPath, getCanvasDPR } from '../utils/deviceProfiles';
+import { getHDRIPath, getCanvasDPR } from '../utils/renderUtils';
 import { preloadAssets } from '../utils/preloadAssets';
 
 const PerformanceTestScene = forwardRef(({
@@ -24,8 +24,7 @@ const PerformanceTestScene = forwardRef(({
   anisotropicFiltering = 4,
   simplifiedAnimations = false,
   reducedParticles = false,
-  particleCount = 16,
-  deviceProfile
+  particleCount = 16
 }, ref) => {
   const [active, setActive] = useState(false);
   const fpsSamples = useRef([]);
@@ -111,7 +110,7 @@ const PerformanceTestScene = forwardRef(({
     particleCount
   };
 
-  const [minDpr, maxDpr] = getCanvasDPR(deviceProfile, { renderScale });
+  const [minDpr, maxDpr] = getCanvasDPR({ renderScale, pbrQuality });
 
   return active ? (
     <div style={{ position: 'fixed', inset: 0, pointerEvents: 'none' }}>

--- a/src/utils/deviceProfiles.js
+++ b/src/utils/deviceProfiles.js
@@ -1,2 +1,33 @@
 // src/utils/deviceProfiles.js
-export const PERFORMANCE_PROFILES = { /* high, medium, low */ };
+export const PERFORMANCE_PROFILES = {
+  high: {
+    renderScale: 1.0,
+    pbrQuality: 'high',
+    useNormalMaps: true,
+    particleCount: 16,
+    postProcessing: {
+      bloom: true,
+      chromaticAberration: true
+    }
+  },
+  medium: {
+    renderScale: 0.75,
+    pbrQuality: 'medium',
+    useNormalMaps: false,
+    particleCount: 8,
+    postProcessing: {
+      bloom: true,
+      chromaticAberration: false
+    }
+  },
+  low: {
+    renderScale: 0.5,
+    pbrQuality: 'low',
+    useNormalMaps: false,
+    particleCount: 4,
+    postProcessing: {
+      bloom: false,
+      chromaticAberration: false
+    }
+  }
+};

--- a/src/utils/preloadAssets.js
+++ b/src/utils/preloadAssets.js
@@ -2,7 +2,7 @@ import { useGLTF, useTexture } from '@react-three/drei';
 import { useLoader } from '@react-three/fiber';
 import { RGBELoader } from 'three-stdlib';
 import { assets } from '../crystalConfig';
-import { getHDRIPath } from './deviceProfiles';
+import { getHDRIPath } from './renderUtils';
 
 export function preloadAssets(hdriQuality = 'low') {
   const promises = [];

--- a/src/utils/renderUtils.js
+++ b/src/utils/renderUtils.js
@@ -1,0 +1,15 @@
+export const getHDRIPath = (quality = 'low') => {
+  const q = ['high', 'medium', 'low'].includes(quality) ? quality : 'low';
+  return `/assets/environment/prismatic09-${q}.hdr`;
+};
+
+export const getCanvasDPR = (profile = {}) => {
+  const maxDpr = Math.min(window.devicePixelRatio || 1, 2);
+  if (profile.pbrQuality === 'low' || profile.renderScale <= 0.5) {
+    return [1, 1];
+  }
+  if (profile.pbrQuality === 'medium' || profile.renderScale < 1) {
+    return [1, Math.min(maxDpr, 1.25)];
+  }
+  return [1, maxDpr];
+};


### PR DESCRIPTION
## Summary
- add simplified performance profiles
- replace old HDRI utilities with `renderUtils`
- update preloader and performance test scene to use new helpers

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688b84973fb0832886032367d58e4518