### PR TITLE
Add hdri quality to performance profiles

### DIFF
--- a/src/hooks/useAssetLoader.js
+++ b/src/hooks/useAssetLoader.js
@@ -89,7 +89,7 @@ export const useAssetLoader = (performanceProfile) => {
     }
 
     // Load HDRI environment
-    const hdriQuality = performanceProfile?.hdriQuality || 'low';
+    const hdriQuality = performanceProfile?.hdriQuality;
     const hdriPath = `/assets/environment/prismatic09-${hdriQuality}.hdr`;
     // Preload models, textures and HDRI for quicker subsequent access
     preloadAssets(hdriQuality);

--- a/src/performance/PerformanceTestScene.jsx
+++ b/src/performance/PerformanceTestScene.jsx
@@ -18,7 +18,7 @@ const PerformanceTestScene = forwardRef(({
   usePBR = true,
   textureQuality = 'high',
   postProcessing = { bloom: true, chromaticAberration: true, noise: true, vignette: true },
-  hdriQuality = 'high',
+  hdriQuality,
   maxLights = 5,
   antialiasing = true,
   anisotropicFiltering = 4,
@@ -38,7 +38,7 @@ const PerformanceTestScene = forwardRef(({
 
   useEffect(() => {
     assetPromiseRef.current = preloadAssets(hdriQuality);
-  }, []);
+  }, [hdriQuality]);
 
   const animationData = {
     state: 'hero',

--- a/src/utils/deviceProfiles.js
+++ b/src/utils/deviceProfiles.js
@@ -3,6 +3,7 @@ export const PERFORMANCE_PROFILES = {
   high: {
     renderScale: 1.0,
     pbrQuality: 'high',
+    hdriQuality: 'high',
     useNormalMaps: true,
     particleCount: 16,
     postProcessing: {
@@ -13,6 +14,7 @@ export const PERFORMANCE_PROFILES = {
   medium: {
     renderScale: 0.75,
     pbrQuality: 'medium',
+    hdriQuality: 'medium',
     useNormalMaps: false,
     particleCount: 8,
     postProcessing: {
@@ -23,6 +25,7 @@ export const PERFORMANCE_PROFILES = {
   low: {
     renderScale: 0.5,
     pbrQuality: 'low',
+    hdriQuality: 'low',
     useNormalMaps: false,
     particleCount: 4,
     postProcessing: {


### PR DESCRIPTION
## Summary
- extend device performance profiles with `hdriQuality`
- use that field in `useAssetLoader`
- update `PerformanceTestScene` to preload HDRIs with the configured quality

## Testing
- `npm install` *(to install ESLint)*
- `npx eslint .` *(fails: Key "globals" config error)*

------
https://chatgpt.com/codex/tasks/task_e_688bb7110de883288008948e925c2c5f