### PR TITLE
Expose performance tier

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The hook returns:
 - `profile` – current performance settings
 - `isReady` – `true` once the benchmark has completed
 - `updateProfile(tier)` – manually switch tiers
+- `tier` – active tier name
 
 Profiles are defined in [`src/utils/deviceProfiles.js`](src/utils/deviceProfiles.js). Call `updateProfile` or use the performance controls in the debug panel to override the selected profile at runtime.
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -132,6 +132,7 @@ function App() {
   // ENHANCED: Device profile hook with better debugging
   const {
     profile: performanceProfile,
+    tier: performanceTier,
     isReady: hasInitialized,
     updateProfile
   } = usePerformance();
@@ -307,7 +308,7 @@ function App() {
       if (import.meta.env.DEV) console.log('🎯 App is ready - enhanced system initialized:', {
         assetsLoaded: isReady,
         performanceConfigured: !!performanceConfig,
-        deviceTier: performanceProfile?.tier,
+        deviceTier: performanceTier,
         finalSettings: {
           renderScale: performanceConfig.renderScale,
           pbrQuality: performanceConfig.pbrQuality,
@@ -557,6 +558,7 @@ function App() {
           performanceConfig={performanceConfig}
           hasInitialized={hasInitialized}
           initialProfileApplied={!!performanceConfig}
+          tier={performanceTier}
         />
       )}
     </>

--- a/src/components/ui/PerformanceDebugPanel.jsx
+++ b/src/components/ui/PerformanceDebugPanel.jsx
@@ -8,7 +8,8 @@ const PERFORMANCE_STORAGE_KEY = 'crystal-performance-config';
 const PerformanceDebugPanel = ({
   performanceConfig,
   hasInitialized,
-  initialProfileApplied
+  initialProfileApplied,
+  tier
 }) => {
   if (!import.meta.env.DEV && !window.__PERF_DEBUG__) return null;
 
@@ -75,6 +76,7 @@ const PerformanceDebugPanel = ({
         
         <div>
           <div style={{ color: '#ffd600', fontWeight: 'bold' }}>Active Config:</div>
+          <div>Tier: {tier}</div>
           <div style={{ color: performanceConfig?.usePBR ? '#4CAF50' : '#F44336' }}>
             PBR: {performanceConfig?.usePBR ? 'YES' : 'NO'}
           </div>

--- a/src/hooks/usePerformance.js
+++ b/src/hooks/usePerformance.js
@@ -5,11 +5,13 @@ const manager = new PerformanceManager();
 
 export const usePerformance = () => {
   const [profile, setProfile] = useState(manager.getProfile());
+  const [tier, setTier] = useState(manager.getTier());
   const [isReady, setIsReady] = useState(manager.isReady());
 
   useEffect(() => {
     manager.initialize().then(() => {
       setProfile(manager.getProfile());
+      setTier(manager.getTier());
       setIsReady(true);
     });
   }, []);
@@ -17,9 +19,10 @@ export const usePerformance = () => {
   const updateProfile = useCallback((tier) => {
     manager.setProfile(tier);
     setProfile(manager.getProfile());
+    setTier(manager.getTier());
   }, []);
 
-  return { profile, isReady, updateProfile };
+  return { profile, tier, isReady, updateProfile };
 };
 
 export default usePerformance;

--- a/src/utils/PerformanceManager.js
+++ b/src/utils/PerformanceManager.js
@@ -51,6 +51,10 @@ export default class PerformanceManager {
     return this.profile;
   }
 
+  getTier() {
+    return this.tier;
+  }
+
   setProfile(tier) {
     if (PERFORMANCE_PROFILES[tier]) {
       this.tier = tier;


### PR DESCRIPTION
## Summary
- expose the active tier in `PerformanceManager`
- surface the tier from `usePerformance`
- display tier in the debug panel
- log the tier and pass to `PerformanceDebugPanel`
- document tier in the README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688bba7e38008328a644cfc176aab80a