### PR TITLE
Allow overriding performance profile settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ The hook returns:
 
 - `profile` – current performance settings
 - `isReady` – `true` once the benchmark has completed
-- `updateProfile(tier)` – manually switch tiers
+- `updateProfile(tier, overrides?)` – manually switch tiers and optionally
+  override specific settings (e.g. `updateProfile('low', { simplifiedAnimations: false })`)
 - `tier` – active tier name
 
 Profiles are defined in [`src/utils/deviceProfiles.js`](src/utils/deviceProfiles.js). Call `updateProfile` or use the performance controls in the debug panel to override the selected profile at runtime.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -268,8 +268,9 @@ function App() {
       let newTier = 'medium';
       if (newConfig.pbrQuality === 'high') newTier = 'high';
       else if (newConfig.pbrQuality === 'low') newTier = 'low';
-      
-      updateProfile(newTier);
+
+      const overrides = newTier === 'low' ? { simplifiedAnimations: false } : {};
+      updateProfile(newTier, overrides);
     } else {
       // For other config changes, we would need to extend the system
       // For now, just update the local effects

--- a/src/hooks/usePerformance.js
+++ b/src/hooks/usePerformance.js
@@ -76,9 +76,9 @@ export const usePerformance = () => {
   }, []);
 
   // Update profile manually
-  const updateProfile = useCallback((newTier) => {
+  const updateProfile = useCallback((newTier, overrides = {}) => {
     try {
-      manager.setProfile(newTier);
+      manager.setProfile(newTier, overrides);
       setProfile(manager.getProfile());
       setTier(manager.getTier());
       

--- a/src/utils/PerformanceManager.js
+++ b/src/utils/PerformanceManager.js
@@ -351,10 +351,10 @@ export default class PerformanceManager {
     return this._testResults;
   }
 
-  setProfile(tier) {
+  setProfile(tier, overrides = {}) {
     if (PERFORMANCE_PROFILES[tier]) {
       this.tier = tier;
-      this.profile = { ...PERFORMANCE_PROFILES[tier] };
+      this.profile = { ...PERFORMANCE_PROFILES[tier], ...overrides };
       
       // Update cache
       if (this._testResults) {


### PR DESCRIPTION
## Summary
- enable setting profile overrides in `PerformanceManager`
- support overrides in `usePerformance`
- prevent simplified animations when choosing low material quality
- document `updateProfile` API change

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688bd9eeca34832885674be90af8b22c