### PR TITLE
feat: add simplified animations toggle

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -261,7 +261,7 @@ function App() {
   // FIXED: Performance config handler with proper profile management
   const handlePerformanceConfigUpdate = useCallback((newConfig) => {
     if (import.meta.env.DEV) console.log("🔧 Performance config update:", newConfig);
-    
+
     // Update performance profile through the manager
     if (newConfig.pbrQuality && newConfig.pbrQuality !== performanceProfile.pbrQuality) {
       // This is a tier change, use the proper method
@@ -271,6 +271,11 @@ function App() {
 
       const overrides = newTier === 'low' ? { simplifiedAnimations: false } : {};
       updateProfile(newTier, overrides);
+    } else if (
+      typeof newConfig.simplifiedAnimations === 'boolean' &&
+      newConfig.simplifiedAnimations !== performanceProfile.simplifiedAnimations
+    ) {
+      updateProfile(performanceTier, { simplifiedAnimations: newConfig.simplifiedAnimations });
     } else {
       // For other config changes, we would need to extend the system
       // For now, just update the local effects
@@ -279,7 +284,7 @@ function App() {
         setPostProcessingConfig(newConfig.postProcessing);
       }
     }
-  }, [performanceProfile, updateProfile]);
+  }, [performanceProfile, performanceTier, updateProfile]);
 
   const toggleUI = useCallback(() => {
     setShowUI(!showUI);

--- a/src/components/ui/PerformanceControls.jsx
+++ b/src/components/ui/PerformanceControls.jsx
@@ -16,6 +16,7 @@ const PerformanceControls = ({
   const [textureQuality, setTextureQuality] = useState(performanceConfig?.textureQuality ?? 'high');
   const [pbrQuality, setPbrQuality] = useState(performanceConfig?.pbrQuality ?? 'high');
   const [renderScale, setRenderScale] = useState(performanceConfig?.renderScale ?? 1.0);
+  const [simplifiedAnimations, setSimplifiedAnimations] = useState(performanceConfig?.simplifiedAnimations ?? false);
   
   // Update local state when config changes externally
   useEffect(() => {
@@ -24,6 +25,7 @@ const PerformanceControls = ({
       if (performanceConfig.textureQuality !== undefined) setTextureQuality(performanceConfig.textureQuality);
       if (performanceConfig.pbrQuality !== undefined) setPbrQuality(performanceConfig.pbrQuality);
       if (performanceConfig.renderScale !== undefined) setRenderScale(performanceConfig.renderScale);
+      if (performanceConfig.simplifiedAnimations !== undefined) setSimplifiedAnimations(performanceConfig.simplifiedAnimations);
     }
   }, [performanceConfig]);
 
@@ -36,6 +38,18 @@ const PerformanceControls = ({
       onConfigUpdate({
         ...performanceConfig,
         useNormalMaps: newValue
+      });
+    }
+  };
+
+  const handleSimplifiedToggle = () => {
+    const newValue = !simplifiedAnimations;
+    setSimplifiedAnimations(newValue);
+
+    if (onConfigUpdate) {
+      onConfigUpdate({
+        ...performanceConfig,
+        simplifiedAnimations: newValue
       });
     }
   };
@@ -231,10 +245,24 @@ const PerformanceControls = ({
           backgroundColor: useNormalMaps ? 'rgba(100, 255, 218, 0.1)' : 'rgba(0, 0, 0, 0.2)'
         }}
       >
-        <div style={toggleLabelStyle}>Use Normal Maps</div>
-        <ToggleSwitch 
-          checked={useNormalMaps}
-          onChange={handleNormalMapToggle}
+      <div style={toggleLabelStyle}>Use Normal Maps</div>
+      <ToggleSwitch
+        checked={useNormalMaps}
+        onChange={handleNormalMapToggle}
+      />
+      </div>
+
+      {/* Simplified Animations Toggle */}
+      <div
+        style={{
+          ...toggleContainerStyle,
+          backgroundColor: simplifiedAnimations ? 'rgba(100, 255, 218, 0.1)' : 'rgba(0, 0, 0, 0.2)'
+        }}
+      >
+        <div style={toggleLabelStyle}>Simplified Animations</div>
+        <ToggleSwitch
+          checked={simplifiedAnimations}
+          onChange={handleSimplifiedToggle}
         />
       </div>
       


### PR DESCRIPTION
## Summary
- add simplified animations state and control to performance panel
- sync simplified animations updates with performance profile

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688d66f95d0083289d866fa1a70a90c6