### PR TITLE
Adjust performance tier thresholds

### DIFF
--- a/src/utils/PerformanceManager.js
+++ b/src/utils/PerformanceManager.js
@@ -338,21 +338,21 @@ export default class PerformanceManager {
   _determineTierFromResults(testResults) {
     // FIXED: Much more conservative thresholds that trust devices that were working before
     const { avgFps, minFps } = testResults;
-    
+
     if (import.meta.env.DEV) {
-      console.log('🔧 Conservative performance test results:', { avgFps, minFps });
+      console.log('🔧 Performance test results:', { avgFps, minFps });
     }
 
-    // FIXED: Lower thresholds that match the "Fix Strategy" from the document
-    // High: 35+ avg, 25+ min (instead of 45+/35+)
-    if (avgFps >= 35 && minFps >= 25) {
+    // Determine tier with a small buffer so ~30 FPS devices aren't flagged as low
+    // High: 40+ avg, 30+ min
+    if (avgFps >= 40 && minFps >= 30) {
       return 'high';
     }
-    // Medium: 22+ avg, 18+ min (instead of 30+/25+)  
-    else if (avgFps >= 22 && minFps >= 18) {
+    // Medium: 28+ avg, 22+ min (gives ~2 FPS margin around 30)
+    else if (avgFps >= 28 && minFps >= 22) {
       return 'medium';
     }
-    // Low: <22 avg FPS
+    // Low: anything below the medium thresholds
     else {
       return 'low';
     }

--- a/src/utils/deviceProfiles.js
+++ b/src/utils/deviceProfiles.js
@@ -41,7 +41,7 @@ export const PERFORMANCE_PROFILES = {
     minAcceptableFPS: 30,
     
     // Debug info
-    description: 'High-end devices with dedicated GPUs',
+    description: 'High-end devices (avg ≥40 FPS) with dedicated GPUs',
     expectedDevices: ['RTX 30/40 series', 'M1/M2 MacBooks', 'High-end iPhones/iPads']
   },
 
@@ -84,7 +84,7 @@ export const PERFORMANCE_PROFILES = {
     minAcceptableFPS: 25,
     
     // Debug info
-    description: 'Mid-range devices and integrated graphics - safe default',
+    description: 'Mid-range devices (~30 FPS) and integrated graphics - safe default',
     expectedDevices: ['GTX 10/16 series', 'Intel/AMD integrated', 'Standard smartphones']
   },
 
@@ -127,7 +127,7 @@ export const PERFORMANCE_PROFILES = {
     minAcceptableFPS: 20,
     
     // Debug info
-    description: 'Older devices and low-end hardware only',
+    description: 'Older devices and low-end hardware (<28 FPS) only',
     expectedDevices: ['Older smartphones', 'Budget laptops', 'Very old integrated graphics']
   },
 


### PR DESCRIPTION
## Summary
- Reevaluate FPS thresholds and add buffer so ~30 FPS devices don't fall into the low tier
- Document FPS expectations in performance profile descriptions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: "BatchedMesh" is not exported by "three.module.js")*

------
https://chatgpt.com/codex/tasks/task_e_688e367bc4e0832888d430643a68c625