### PR TITLE
Add shader-driven gradient scene background

### DIFF
--- a/src/components/layout/Fixed3DCanvas.jsx
+++ b/src/components/layout/Fixed3DCanvas.jsx
@@ -16,6 +16,8 @@ import { FPSCounter } from '../ui/FpsDisplay';
 
 // ADDED: Import the debug panels component
 import CrystalDebugPanels from '../ui/CrystalDebugPanels';
+import GradientBackground from '../three/GradientBackground';
+import { projectBackgrounds } from '../../data/projectBackgrounds';
 
 const PulsingOmniLight = ({ simplified = false }) => {
   const lightRef = useRef();
@@ -64,10 +66,12 @@ const Fixed3DCanvas = forwardRef(({
 }, ref) => {
   // NEW: Ref to access crystal scene for debug panels
   const crystalSceneRef = useRef();
+  const backgroundRef = useRef();
 
   // Expose internal state to parent components
   useImperativeHandle(ref, () => ({
-    modelsLoaded: crystalSceneRef.current?.modelsLoaded || false
+    modelsLoaded: crystalSceneRef.current?.modelsLoaded || false,
+    updateBackground: (key) => backgroundRef.current?.updateBackground(key)
   }), [crystalSceneRef.current?.modelsLoaded]);
   
   // NEW: State for debug data
@@ -149,9 +153,9 @@ const Fixed3DCanvas = forwardRef(({
         >
           
           <FPSCounter />
-          
-          <color attach="background" args={['#050505']} />
-          
+
+          <GradientBackground ref={backgroundRef} backgrounds={projectBackgrounds} />
+
           {/* Persistent Dust System */}
           {dustEnabled && (
             <PersistentDustSystem count={particleCount} enabled={dustEnabled} />
@@ -224,10 +228,10 @@ const Fixed3DCanvas = forwardRef(({
             simplifiedAnimations={simplifiedAnimations}
           />
           
-          {/* Environment (unchanged) */}
-          <Environment 
-            files={environmentProps.files || config?.environment?.hdri || "/assets/environment/prismatic09-low.hdr"} 
-            background={config?.environment?.showBackground !== false} 
+          {/* Environment used for reflections only */}
+          <Environment
+            files={environmentProps.files || config?.environment?.hdri || "/assets/environment/prismatic09-low.hdr"}
+            background={false}
             rotation={config?.environment?.rotation || [0, Math.PI * 0.5, 0]}
           />
           

--- a/src/components/three/GradientBackground.jsx
+++ b/src/components/three/GradientBackground.jsx
@@ -1,0 +1,76 @@
+// src/components/three/GradientBackground.jsx
+// Large inverted sphere gradient background with smooth color transitions
+
+import React, { useRef, forwardRef, useImperativeHandle } from 'react';
+import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
+
+const vertexShader = /* glsl */`
+  varying vec3 vWorldPosition;
+  void main() {
+    vec4 worldPosition = modelMatrix * vec4(position, 1.0);
+    vWorldPosition = worldPosition.xyz;
+    gl_Position = projectionMatrix * viewMatrix * worldPosition;
+  }
+`;
+
+const fragmentShader = /* glsl */`
+  uniform vec3 colorA;
+  uniform vec3 colorB;
+  varying vec3 vWorldPosition;
+  void main() {
+    vec3 dir = normalize(vWorldPosition);
+    float height = dir.y * 0.5 + 0.5;
+    float angle = (atan(dir.z, dir.x) / (2.0 * 3.1415926)) + 0.5;
+    float noise = sin(vWorldPosition.x * 0.02) * sin(vWorldPosition.y * 0.02) * sin(vWorldPosition.z * 0.02);
+    float t = clamp(height + angle * 0.1 + noise * 0.1, 0.0, 1.0);
+    vec3 color = mix(colorA, colorB, t);
+    gl_FragColor = vec4(color, 1.0);
+  }
+`;
+
+const GradientBackground = forwardRef(({ backgrounds, initialKey = 'default', radius = 100 }, ref) => {
+  const materialRef = useRef();
+  const currentA = useRef(new THREE.Color(backgrounds[initialKey].colorA));
+  const currentB = useRef(new THREE.Color(backgrounds[initialKey].colorB));
+  const targetA = useRef(currentA.current.clone());
+  const targetB = useRef(currentB.current.clone());
+
+  useFrame(() => {
+    if (!materialRef.current) return;
+    currentA.current.lerp(targetA.current, 0.05);
+    currentB.current.lerp(targetB.current, 0.05);
+    materialRef.current.uniforms.colorA.value.copy(currentA.current);
+    materialRef.current.uniforms.colorB.value.copy(currentB.current);
+  });
+
+  useImperativeHandle(ref, () => ({
+    updateBackground: (key) => {
+      const scheme = backgrounds[key] || backgrounds.default;
+      targetA.current = new THREE.Color(scheme.colorA);
+      targetB.current = new THREE.Color(scheme.colorB);
+    }
+  }));
+
+  return (
+    <mesh position={[0, 0, 0]}>
+      <sphereGeometry args={[radius, 64, 64]} />
+      <shaderMaterial
+        ref={materialRef}
+        uniforms={{
+          colorA: { value: currentA.current.clone() },
+          colorB: { value: currentB.current.clone() }
+        }}
+        vertexShader={vertexShader}
+        fragmentShader={fragmentShader}
+        side={THREE.BackSide}
+        depthWrite={false}
+        depthTest={false}
+      />
+    </mesh>
+  );
+});
+
+GradientBackground.displayName = 'GradientBackground';
+
+export default GradientBackground;

--- a/src/data/projectBackgrounds.js
+++ b/src/data/projectBackgrounds.js
@@ -1,0 +1,14 @@
+// src/data/projectBackgrounds.js
+// Define color schemes for background gradients per project
+
+export const projectBackgrounds = {
+  default: {
+    colorA: '#1a1a1a',
+    colorB: '#4a4a4a'
+  },
+  projectAlpha: {
+    colorA: '#112233',
+    colorB: '#334455'
+  }
+  // Additional projects can be added here
+};

--- a/src/performance/PerformanceTestScene.jsx
+++ b/src/performance/PerformanceTestScene.jsx
@@ -165,7 +165,7 @@ const PerformanceTestScene = forwardRef(({
 
         <Environment
           files={getHDRIPath(hdriQuality)}
-          background={config.environment?.showBackground !== false}
+          background={false}
           rotation={config.environment?.rotation || [0, Math.PI * 0.5, 0]}
         />
 


### PR DESCRIPTION
## Summary
- add `GradientBackground` shader for dynamic sky colors
- expose `updateBackground` to switch gradients per project
- use HDRI only for reflections and keep background hidden

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688e4a7d0924832893d1774d347632b7