### PR TITLE
Fix gradient background color updates

### DIFF
--- a/src/components/layout/Fixed3DCanvas.jsx
+++ b/src/components/layout/Fixed3DCanvas.jsx
@@ -107,8 +107,8 @@ const Fixed3DCanvas = forwardRef(({
   }, [crystalSceneRef]);
 
   // FIXED: Update gradient background based on scroll zone or project focus
-  const bg = backgroundRef.current;
   useEffect(() => {
+    const bg = backgroundRef.current;
     if (!bg || !animationData) return;
     
     let key = 'default';
@@ -168,8 +168,7 @@ const Fixed3DCanvas = forwardRef(({
     animationData?.focusedFacet,
     animationData?.currentZone, 
     animationData?.state,
-    animationData?.projectInfo,
-    bg
+    animationData?.projectInfo
   ]);
 
   // FIXED: Function to get facet refs from crystal scene with proper access

--- a/src/components/three/GradientBackground.jsx
+++ b/src/components/three/GradientBackground.jsx
@@ -51,6 +51,8 @@ const GradientBackground = forwardRef(({ backgrounds, initialKey = 'default', ra
     currentB.current.lerp(targetB.current, 0.05);
     materialRef.current.uniforms.colorA.value.copy(currentA.current);
     materialRef.current.uniforms.colorB.value.copy(currentB.current);
+    // Ensure updated colors are sent to the GPU
+    materialRef.current.uniformsNeedUpdate = true;
   });
 
   useImperativeHandle(ref, () => ({


### PR DESCRIPTION
## Summary
- ensure Fixed3DCanvas grabs latest GradientBackground ref before updating colors
- force shader uniforms to refresh so color transitions reach the GPU

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_688ec76a8c1c8328bf02624417d7e21f