### PR TITLE
Ensure gradient shader updates on color change

### DIFF
--- a/src/components/three/GradientBackground.jsx
+++ b/src/components/three/GradientBackground.jsx
@@ -51,6 +51,8 @@ const GradientBackground = forwardRef(({ backgrounds, initialKey = 'default', ra
     currentB.current.lerp(targetB.current, 0.05);
     materialRef.current.uniforms.colorA.value.copy(currentA.current);
     materialRef.current.uniforms.colorB.value.copy(currentB.current);
+    materialRef.current.uniformsNeedUpdate = true;
+    materialRef.current.needsUpdate = true;
   });
 
   useImperativeHandle(ref, () => ({


### PR DESCRIPTION
## Summary
- guarantee GradientBackground shader re-renders by toggling uniformsNeedUpdate and needsUpdate each frame

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint .` *(fails: Global "AudioWorkletGlobalScope " has leading or trailing whitespace)*

------
https://chatgpt.com/codex/tasks/task_e_688f9014210c83289f0b07b5f2384739