### PR TITLE
refactor: enforce 60 fps thresholds

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -454,9 +454,9 @@ function App() {
       
       {/* FIXED: Performance alerts with tier-appropriate thresholds */}
       {!hideAllUI && (
-        <PerformanceAlert 
+        <PerformanceAlert
           visible={true}
-          threshold={performanceProfile?.minAcceptableFPS || 25}
+          threshold={performanceProfile?.minAcceptableFPS || 55}
           onPerformanceIssue={(data) => {
             if (import.meta.env.DEV) console.warn('Performance issue detected:', data);
           }}

--- a/src/utils/PerformanceManager.js
+++ b/src/utils/PerformanceManager.js
@@ -336,23 +336,22 @@ export default class PerformanceManager {
   }
 
   _determineTierFromResults(testResults) {
-    // FIXED: Much more conservative thresholds that trust devices that were working before
+    // Strict thresholds for a true 60 FPS experience
     const { avgFps, minFps } = testResults;
 
     if (import.meta.env.DEV) {
       console.log('🔧 Performance test results:', { avgFps, minFps });
     }
 
-    // Determine tier with a small buffer so ~30 FPS devices aren't flagged as low
-    // High: 40+ avg, 30+ min
-    if (avgFps >= 40 && minFps >= 30) {
+    // High tier only if we comfortably hit 60 FPS
+    if (avgFps >= 58 && minFps >= 55) {
       return 'high';
     }
-    // Medium: 28+ avg, 22+ min (gives ~2 FPS margin around 30)
-    else if (avgFps >= 28 && minFps >= 22) {
+    // Medium tier accepts slightly lower but still near-60 FPS performance
+    else if (avgFps >= 55 && minFps >= 50) {
       return 'medium';
     }
-    // Low: anything below the medium thresholds
+    // Anything below goes to low tier
     else {
       return 'low';
     }

--- a/src/utils/deviceProfiles.js
+++ b/src/utils/deviceProfiles.js
@@ -36,12 +36,12 @@ export const PERFORMANCE_PROFILES = {
       vignette: true
     },
     
-    // FIXED: More realistic performance targets
-    targetFPS: 40,
-    minAcceptableFPS: 30,
-    
+    // Updated: strict 60 FPS targets for top-tier hardware
+    targetFPS: 60,
+    minAcceptableFPS: 55,
+
     // Debug info
-    description: 'High-end devices (avg ≥40 FPS) with dedicated GPUs',
+    description: 'High-end devices (avg ≥60 FPS) with dedicated GPUs',
     expectedDevices: ['RTX 30/40 series', 'M1/M2 MacBooks', 'High-end iPhones/iPads']
   },
 
@@ -79,12 +79,12 @@ export const PERFORMANCE_PROFILES = {
       vignette: true
     },
     
-    // FIXED: Conservative performance targets that most devices can hit
-    targetFPS: 30,
-    minAcceptableFPS: 25,
-    
+    // Updated: 60 FPS targets with slightly reduced visuals
+    targetFPS: 60,
+    minAcceptableFPS: 55,
+
     // Debug info
-    description: 'Mid-range devices (~30 FPS) and integrated graphics - safe default',
+    description: 'Mid-range devices (55-60 FPS) - safe default',
     expectedDevices: ['GTX 10/16 series', 'Intel/AMD integrated', 'Standard smartphones']
   },
 
@@ -122,12 +122,12 @@ export const PERFORMANCE_PROFILES = {
       vignette: false
     },
     
-    // FIXED: Lower targets for truly low-end devices
-    targetFPS: 25,
-    minAcceptableFPS: 20,
-    
+    // Updated: still targets 60 FPS but with aggressive reductions
+    targetFPS: 60,
+    minAcceptableFPS: 55,
+
     // Debug info
-    description: 'Older devices and low-end hardware (<28 FPS) only',
+    description: 'Older devices and low-end hardware aiming for 60 FPS',
     expectedDevices: ['Older smartphones', 'Budget laptops', 'Very old integrated graphics']
   },
 
@@ -159,9 +159,9 @@ export const PERFORMANCE_PROFILES = {
     },
     
     targetFPS: 60,
-    minAcceptableFPS: 45,
-    
-    description: 'Development/testing - maximum quality',
+    minAcceptableFPS: 55,
+
+    description: 'Development/testing - maximum quality (60 FPS target)',
     expectedDevices: ['Development machines only']
   }
 };


### PR DESCRIPTION
## Summary
- align all device profiles to target a consistent 60 FPS with a 55 FPS minimum
- tighten performance tier classification to require near‑60 FPS averages
- raise performance alert defaults to flag dips below 55 FPS

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `npm run lint` *(fails: Missing script: "lint")*


------
https://chatgpt.com/codex/tasks/task_e_6893b8f194c08328ae66e9e1ad6983a4