### PR TITLE
chore: remove unused device detection helpers

### DIFF
--- a/src/utils/deviceDetection.js
+++ b/src/utils/deviceDetection.js
@@ -1,9 +1,0 @@
-// src/utils/deviceDetection.js
-// Simplified helpers for basic device checks
-
-export const isMobile = () => /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
-
-export const isTablet = () => /(iPad|Android(?!.*Mobile))/i.test(navigator.userAgent);
-
-export const isDesktop = () => !isMobile() && !isTablet();
-


### PR DESCRIPTION
## Summary
- remove legacy device detection util
- confirm no `detectDeviceCapabilities` or related helpers are imported elsewhere

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6894d529ff0c83289e5b55a78deef717