### PR TITLE
Add radial progress indicators for loading phases

### DIFF
--- a/index.html
+++ b/index.html
@@ -203,7 +203,7 @@
     <!-- CRITICAL: Update loader from JavaScript -->
     <script type="module">
       // Global functions to update the immediate loader
-      window.updateImmediateLoader = function(progress, phase, currentAsset, testingProgress) {
+      window.updateImmediateLoader = function({ start = null, assets = null, test = null, phase, currentAsset }) {
         const ringStart = document.getElementById('ring-start');
         const ringAssets = document.getElementById('ring-assets');
         const ringTest = document.getElementById('ring-test');
@@ -214,20 +214,9 @@
 
         window.__phaseProgress = window.__phaseProgress || { start: 0, assets: 0, test: 0 };
 
-        if (phase === 'Starting Application') {
-          window.__phaseProgress.start = progress;
-        } else if (phase === 'Loading Assets') {
-          window.__phaseProgress.start = 100;
-          window.__phaseProgress.assets = progress;
-        } else if (phase === 'Testing Performance') {
-          window.__phaseProgress.start = 100;
-          window.__phaseProgress.assets = 100;
-          if (typeof testingProgress === 'number') window.__phaseProgress.test = testingProgress;
-        } else if (phase === 'Ready') {
-          window.__phaseProgress.start = 100;
-          window.__phaseProgress.assets = 100;
-          window.__phaseProgress.test = 100;
-        }
+        if (typeof start === 'number') window.__phaseProgress.start = start;
+        if (typeof assets === 'number') window.__phaseProgress.assets = assets;
+        if (typeof test === 'number') window.__phaseProgress.test = test;
 
         if (ringStart) ringStart.style.strokeDashoffset = 100 - window.__phaseProgress.start;
         if (ringAssets) ringAssets.style.strokeDashoffset = 100 - window.__phaseProgress.assets;
@@ -252,7 +241,7 @@
           if (testingInfo) testingInfo.textContent = '';
         }
 
-        if (import.meta.env.DEV) console.log('📊 Immediate loader updated:', { progress, phase, currentAsset, testingProgress });
+        if (import.meta.env.DEV) console.log('📊 Immediate loader updated:', { start, assets, test, phase, currentAsset });
       };
       
       // Hide immediate loader and show React app
@@ -278,7 +267,7 @@
       };
       
       // Initial update
-      window.updateImmediateLoader(0, 'Starting Application', 'Starting application...', null);
+      window.updateImmediateLoader({ start: 0, assets: 0, test: 0, phase: 'Starting Application', currentAsset: 'Starting application...' });
     </script>
     
     <script type="module" src="/src/main.jsx"></script>

--- a/index.html
+++ b/index.html
@@ -63,65 +63,59 @@
         max-width: 400px;
         margin-bottom: 1rem;
       }
-      
-      /* Progress bar background */
-      .progress-bar-bg {
-        width: 100%;
-        height: 8px;
-        background-color: rgba(255, 255, 255, 0.1);
-        border-radius: 4px;
-        overflow: hidden;
-        margin-bottom: 1rem;
-      }
-      
-      /* Progress bar fill */
-      .progress-bar-fill {
-        width: 0%;
-        height: 100%;
-        background-color: #64ffda;
-        border-radius: 4px;
-        transition: width 0.3s ease;
-        box-shadow: 0 0 10px rgba(100, 255, 218, 0.4);
+
+      .radial-progress {
+        width: 160px;
+        height: 160px;
+        margin: 0 auto 1rem;
+        position: relative;
       }
 
-      /* Testing progress bar */
-      .testing-progress-bg {
+      .radial-progress svg {
         width: 100%;
-        height: 4px;
-        background-color: rgba(255, 255, 255, 0.1);
-        border-radius: 4px;
-        overflow: hidden;
-        margin-top: 4px;
-        display: none;
+        height: 100%;
+        transform: rotate(-90deg);
       }
 
-      .testing-progress-fill {
-        width: 0%;
-        height: 100%;
-        background-color: #bb86fc;
-        border-radius: 4px;
-        transition: width 0.3s ease;
+      .ring-bg {
+        fill: none;
+        stroke: rgba(255, 255, 255, 0.1);
+        stroke-width: 8;
       }
-      
-      /* Progress info */
-      .progress-info {
+
+      .ring {
+        fill: none;
+        stroke-width: 8;
+        stroke-dasharray: 100;
+        stroke-dashoffset: 100;
+        transition: stroke-dashoffset 0.3s ease;
+      }
+
+      .start-ring { stroke: #64ffda; }
+      .assets-ring { stroke: #bb86fc; }
+      .test-ring { stroke: #ffa726; }
+
+      .radial-center {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        text-align: center;
         display: flex;
-        justify-content: space-between;
+        flex-direction: column;
         align-items: center;
-        color: white;
-        font-size: 0.9rem;
-        margin-bottom: 0.5rem;
       }
-      
+
       .progress-phase {
-        color: #64ffda;
+        color: #fff;
         font-weight: 600;
       }
-      
+
       .progress-percent {
         color: rgba(255, 255, 255, 0.7);
+        font-size: 0.8rem;
       }
-      
+
       /* Current asset display */
       .current-asset {
         text-align: center;
@@ -178,19 +172,20 @@
       <div class="loader-title">Multifaceted Designer</div>
       
       <div class="progress-container">
-        <div class="progress-info">
-          <span class="progress-phase" id="progress-phase">Initializing...</span>
-          <span class="progress-percent" id="progress-percent">0%</span>
+        <div class="radial-progress">
+          <svg viewBox="0 0 160 160">
+            <circle class="ring-bg" cx="80" cy="80" r="70" pathLength="100" />
+            <circle class="ring start-ring" id="ring-start" cx="80" cy="80" r="70" pathLength="100" />
+            <circle class="ring-bg" cx="80" cy="80" r="55" pathLength="100" />
+            <circle class="ring assets-ring" id="ring-assets" cx="80" cy="80" r="55" pathLength="100" />
+            <circle class="ring-bg" cx="80" cy="80" r="40" pathLength="100" />
+            <circle class="ring test-ring" id="ring-test" cx="80" cy="80" r="40" pathLength="100" />
+          </svg>
+          <div class="radial-center">
+            <div class="progress-phase" id="progress-phase">Starting Application</div>
+            <div class="progress-percent" id="progress-percent">0%</div>
+          </div>
         </div>
-        
-        <div class="progress-bar-bg">
-          <div class="progress-bar-fill" id="progress-bar-fill"></div>
-        </div>
-
-        <div class="testing-progress-bg" id="testing-progress-bg">
-          <div class="testing-progress-fill" id="testing-progress-fill"></div>
-        </div>
-
         <div class="current-asset" id="current-asset">Starting up...</div>
         <div class="current-asset" id="testing-info" style="margin-top:4px"></div>
       </div>
@@ -209,43 +204,54 @@
     <script type="module">
       // Global functions to update the immediate loader
       window.updateImmediateLoader = function(progress, phase, currentAsset, testingProgress) {
-        const progressFill = document.getElementById('progress-bar-fill');
-        const testingFill = document.getElementById('testing-progress-fill');
-        const testingBg = document.getElementById('testing-progress-bg');
+        const ringStart = document.getElementById('ring-start');
+        const ringAssets = document.getElementById('ring-assets');
+        const ringTest = document.getElementById('ring-test');
         const testingInfo = document.getElementById('testing-info');
         const progressPhase = document.getElementById('progress-phase');
         const progressPercent = document.getElementById('progress-percent');
         const currentAssetEl = document.getElementById('current-asset');
-        
-        if (progressFill) {
-          progressFill.style.width = progress + '%';
+
+        window.__phaseProgress = window.__phaseProgress || { start: 0, assets: 0, test: 0 };
+
+        if (phase === 'Starting Application') {
+          window.__phaseProgress.start = progress;
+        } else if (phase === 'Loading Assets') {
+          window.__phaseProgress.start = 100;
+          window.__phaseProgress.assets = progress;
+        } else if (phase === 'Testing Performance') {
+          window.__phaseProgress.start = 100;
+          window.__phaseProgress.assets = 100;
+          if (typeof testingProgress === 'number') window.__phaseProgress.test = testingProgress;
+        } else if (phase === 'Ready') {
+          window.__phaseProgress.start = 100;
+          window.__phaseProgress.assets = 100;
+          window.__phaseProgress.test = 100;
         }
 
-        if (testingFill && testingBg) {
-          if (typeof testingProgress === 'number') {
-            testingBg.style.display = 'block';
-            testingFill.style.width = testingProgress + '%';
-          } else {
-            testingBg.style.display = 'none';
-          }
-        }
-        
+        if (ringStart) ringStart.style.strokeDashoffset = 100 - window.__phaseProgress.start;
+        if (ringAssets) ringAssets.style.strokeDashoffset = 100 - window.__phaseProgress.assets;
+        if (ringTest) ringTest.style.strokeDashoffset = 100 - window.__phaseProgress.test;
+
         if (progressPhase) {
           progressPhase.textContent = phase || 'Loading...';
         }
-        
+
+        let displayProgress = window.__phaseProgress.start;
+        if (phase === 'Loading Assets') displayProgress = window.__phaseProgress.assets;
+        else if (phase === 'Testing Performance') displayProgress = window.__phaseProgress.test;
         if (progressPercent) {
-          progressPercent.textContent = Math.round(progress) + '%';
+          progressPercent.textContent = Math.round(displayProgress) + '%';
         }
-        
-        if (testingInfo && typeof testingProgress === 'number') {
+
+        if (testingInfo && phase === 'Testing Performance') {
           testingInfo.textContent = currentAsset || '';
           if (currentAssetEl) currentAssetEl.textContent = '';
         } else {
           if (currentAssetEl) currentAssetEl.textContent = currentAsset || '';
           if (testingInfo) testingInfo.textContent = '';
         }
-        
+
         if (import.meta.env.DEV) console.log('📊 Immediate loader updated:', { progress, phase, currentAsset, testingProgress });
       };
       
@@ -272,7 +278,7 @@
       };
       
       // Initial update
-      window.updateImmediateLoader(0, 'Initializing...', 'Starting application...', null);
+      window.updateImmediateLoader(0, 'Starting Application', 'Starting application...', null);
     </script>
     
     <script type="module" src="/src/main.jsx"></script>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -345,13 +345,13 @@ function App() {
         displayAsset = 'Starting experience...';
       }
 
-      const activeProgress = phase === 'initializing' ? startingProgress : progress;
-      window.updateImmediateLoader(
-        activeProgress,
-        displayPhase,
-        displayAsset,
-        performanceInitializing ? testingProgress : null
-      );
+      window.updateImmediateLoader({
+        start: startingProgress,
+        assets: progress,
+        test: testingProgress,
+        phase: displayPhase,
+        currentAsset: displayAsset
+      });
     }
   }, [progress, phase, currentAsset, isAppReady, performanceInitializing, performanceError, testingProgress, startingProgress]);
 
@@ -426,11 +426,12 @@ function App() {
   if (!isAppReady) {
     return (
       <EnhancedLoadingScreen
-        progress={Math.round(phase === 'initializing' ? startingProgress : progress)}
         phase={performanceInitializing ? 'profiling' : phase}
         currentAsset={performanceInitializing ? 'Testing device performance...' : currentAsset}
         loadedAssets={loadedAssets}
         totalAssets={totalAssets}
+        startingProgress={Math.round(startingProgress)}
+        assetProgress={Math.round(progress)}
         profilerProgress={performanceInitializing ? testingProgress : null}
         errors={performanceError ? [performanceError, ...errors] : errors}
         onRetry={retry}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -143,6 +143,20 @@ function App() {
     debugInfo
   } = usePerformance();
 
+  // FIXED: Asset loader hook with proper performance profile dependency
+  const {
+    progress,
+    phase,
+    currentAsset,
+    loadedAssets,
+    totalAssets,
+    errors,
+    isLoading,
+    isReady: assetsReady,
+    hasErrors,
+    retry
+  } = useAssetLoader(performanceProfile);
+
   // Initialize effects from the detected device profile
   useEffect(() => {
     if (performanceProfile?.postProcessing) {
@@ -168,7 +182,7 @@ function App() {
   // Simulated progress for starting phase
   useEffect(() => {
     let id;
-    if (phase === 'initializing' && !performanceInitializing) {
+    if (phase === 'initializing') {
       setStartingProgress(0);
       id = setInterval(() => {
         setStartingProgress(prev => Math.min(prev + 5, 100));
@@ -177,32 +191,10 @@ function App() {
       setStartingProgress(prev => (prev < 100 ? 100 : prev));
     }
     return () => clearInterval(id);
-  }, [phase, performanceInitializing]);
-
-  // FIXED: Asset loader hook with proper performance profile dependency
-  const {
-    progress,
-    phase,
-    currentAsset,
-    loadedAssets,
-    totalAssets,
-    errors,
-    isLoading,
-    isReady: assetsReady,
-    hasErrors,
-    retry
-  } = useAssetLoader(performanceProfile);
+  }, [phase]);
 
   // Detect if mobile
   const isMobile = isMobileDevice();
-
-  // Sync effects with the current performance configuration
-  useEffect(() => {
-    if (performanceProfile?.postProcessing) {
-      setEffectsEnabled(performanceProfile.postProcessing);
-      setPostProcessingConfig(performanceProfile.postProcessing);
-    }
-  }, [performanceProfile]);
 
   // ========================================
   // FIXED: App ready detection with proper dependencies

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -127,6 +127,7 @@ function App() {
   });
   const [postProcessingConfig, setPostProcessingConfig] = useState(config.postProcessing);
   const [testingProgress, setTestingProgress] = useState(0);
+  const [startingProgress, setStartingProgress] = useState(0);
 
   // FIXED: Enhanced performance hook with proper error handling
   const {
@@ -163,6 +164,20 @@ function App() {
     }
     return () => clearInterval(id);
   }, [performanceInitializing]);
+
+  // Simulated progress for starting phase
+  useEffect(() => {
+    let id;
+    if (phase === 'initializing' && !performanceInitializing) {
+      setStartingProgress(0);
+      id = setInterval(() => {
+        setStartingProgress(prev => Math.min(prev + 5, 100));
+      }, 100);
+    } else {
+      setStartingProgress(prev => (prev < 100 ? 100 : prev));
+    }
+    return () => clearInterval(id);
+  }, [phase, performanceInitializing]);
 
   // FIXED: Asset loader hook with proper performance profile dependency
   const {
@@ -338,14 +353,15 @@ function App() {
         displayAsset = 'Starting experience...';
       }
 
+      const activeProgress = phase === 'initializing' ? startingProgress : progress;
       window.updateImmediateLoader(
-        progress,
+        activeProgress,
         displayPhase,
         displayAsset,
         performanceInitializing ? testingProgress : null
       );
     }
-  }, [progress, phase, currentAsset, isAppReady, performanceInitializing, performanceError, testingProgress]);
+  }, [progress, phase, currentAsset, isAppReady, performanceInitializing, performanceError, testingProgress, startingProgress]);
 
   // Hide immediate loader and show React app when ready
   useEffect(() => {
@@ -418,7 +434,7 @@ function App() {
   if (!isAppReady) {
     return (
       <EnhancedLoadingScreen
-        progress={Math.round(progress)}
+        progress={Math.round(phase === 'initializing' ? startingProgress : progress)}
         phase={performanceInitializing ? 'profiling' : phase}
         currentAsset={performanceInitializing ? 'Testing device performance...' : currentAsset}
         loadedAssets={loadedAssets}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -126,6 +126,7 @@ function App() {
     vignette: true
   });
   const [postProcessingConfig, setPostProcessingConfig] = useState(config.postProcessing);
+  const [testingProgress, setTestingProgress] = useState(0);
 
   // FIXED: Enhanced performance hook with proper error handling
   const {
@@ -148,6 +149,20 @@ function App() {
       setPostProcessingConfig(performanceProfile.postProcessing);
     }
   }, [performanceProfile]);
+
+  // Simulated progress for device testing phase
+  useEffect(() => {
+    let id;
+    if (performanceInitializing) {
+      setTestingProgress(0);
+      id = setInterval(() => {
+        setTestingProgress(prev => Math.min(prev + 5, 100));
+      }, 100);
+    } else {
+      setTestingProgress(prev => (prev < 100 ? 100 : prev));
+    }
+    return () => clearInterval(id);
+  }, [performanceInitializing]);
 
   // FIXED: Asset loader hook with proper performance profile dependency
   const {
@@ -306,7 +321,7 @@ function App() {
   // Update the immediate HTML loader with performance info
   useEffect(() => {
     if (window.updateImmediateLoader) {
-      let displayPhase = 'Initializing...';
+      let displayPhase = 'Starting Application';
       let displayAsset = 'Setting up...';
 
       if (performanceInitializing) {
@@ -323,9 +338,14 @@ function App() {
         displayAsset = 'Starting experience...';
       }
 
-      window.updateImmediateLoader(progress, displayPhase, displayAsset, null);
+      window.updateImmediateLoader(
+        progress,
+        displayPhase,
+        displayAsset,
+        performanceInitializing ? testingProgress : null
+      );
     }
-  }, [progress, phase, currentAsset, isAppReady, performanceInitializing, performanceError]);
+  }, [progress, phase, currentAsset, isAppReady, performanceInitializing, performanceError, testingProgress]);
 
   // Hide immediate loader and show React app when ready
   useEffect(() => {
@@ -403,7 +423,7 @@ function App() {
         currentAsset={performanceInitializing ? 'Testing device performance...' : currentAsset}
         loadedAssets={loadedAssets}
         totalAssets={totalAssets}
-        profilerProgress={performanceInitializing ? 50 : null}
+        profilerProgress={performanceInitializing ? testingProgress : null}
         errors={performanceError ? [performanceError, ...errors] : errors}
         onRetry={retry}
       />

--- a/src/components/ui/EnhancedLoadingScreen.jsx
+++ b/src/components/ui/EnhancedLoadingScreen.jsx
@@ -5,11 +5,12 @@ import React from 'react';
 import RadialProgressRing from './RadialProgressRing.jsx';
 
 const EnhancedLoadingScreen = ({
-  progress = 0,
   phase = 'initializing',
   currentAsset = '',
   loadedAssets = 0,
   totalAssets = 0,
+  startingProgress = 0,
+  assetProgress = 0,
   profilerProgress = null,
   errors = [],
   onRetry = null
@@ -105,14 +106,17 @@ const EnhancedLoadingScreen = ({
 
         {/* Radial Progress Rings */}
         {(() => {
-          const startProgress = phase === 'initializing' ? progress : 100;
-          const loadProgress = phase === 'loading' ? progress : phase !== 'initializing' ? 100 : 0;
-          const testProgress = phase === 'profiling' ? (profilerProgress ?? 0) : phase === 'ready' ? 100 : 0;
-          const currentProgress = phase === 'profiling' ? testProgress : phase === 'loading' ? loadProgress : startProgress;
+          const testProgress = profilerProgress ?? 0;
+          const currentProgress =
+            phase === 'profiling'
+              ? testProgress
+              : phase === 'loading'
+                ? assetProgress
+                : startingProgress;
           return (
             <div style={{ position: 'relative', width: '200px', height: '200px', marginBottom: '1rem' }}>
-              <RadialProgressRing size={200} progress={startProgress} color="#64ffda" />
-              <RadialProgressRing size={160} progress={loadProgress} color="#bb86fc" />
+              <RadialProgressRing size={200} progress={startingProgress} color="#64ffda" />
+              <RadialProgressRing size={160} progress={assetProgress} color="#bb86fc" />
               <RadialProgressRing size={120} progress={testProgress} color="#ffa726" />
               <div style={{ position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%, -50%)', textAlign: 'center' }}>
                 <div style={{ color: getProgressColor(), fontWeight: '600', marginBottom: '0.25rem', fontSize: '0.9rem' }}>{getPhaseMessage()}</div>

--- a/src/components/ui/EnhancedLoadingScreen.jsx
+++ b/src/components/ui/EnhancedLoadingScreen.jsx
@@ -2,6 +2,7 @@
 // FIXED: Better messaging that explains the conservative approach
 
 import React from 'react';
+import RadialProgressRing from './RadialProgressRing.jsx';
 
 const EnhancedLoadingScreen = ({
   progress = 0,
@@ -16,11 +17,11 @@ const EnhancedLoadingScreen = ({
   const getPhaseMessage = () => {
     switch (phase) {
       case 'initializing':
-        return 'Initializing...';
-      case 'profiling':
-        return 'Optimizing Performance';
+        return 'Starting Application';
       case 'loading':
         return 'Loading Assets';
+      case 'profiling':
+        return 'Testing Performance';
       case 'ready':
         return errors.length > 0 ? 'Ready (with warnings)' : 'Ready to Experience';
       case 'error':
@@ -33,7 +34,8 @@ const EnhancedLoadingScreen = ({
   const getProgressColor = () => {
     if (phase === 'error') return '#ff6b6b';
     if (phase === 'ready' && errors.length > 0) return '#ffa726';
-    if (phase === 'profiling') return '#bb86fc';
+    if (phase === 'profiling') return '#ffa726';
+    if (phase === 'loading') return '#bb86fc';
     return '#64ffda';
   };
 
@@ -95,45 +97,30 @@ const EnhancedLoadingScreen = ({
       <div style={{
         width: '90%',
         maxWidth: '400px',
-        marginBottom: '2rem'
+        marginBottom: '2rem',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center'
       }}>
-        
-        {/* Progress Bar Background */}
-        <div style={{
-          width: '100%',
-          height: '8px',
-          backgroundColor: 'rgba(255, 255, 255, 0.1)',
-          borderRadius: '4px',
-          overflow: 'hidden',
-          marginBottom: '1rem'
-        }}>
-          {/* Progress Bar Fill */}
-          <div style={{
-            width: `${progress}%`,
-            height: '100%',
-            backgroundColor: getProgressColor(),
-            borderRadius: '4px',
-            transition: 'width 0.3s ease, background-color 0.3s ease',
-            boxShadow: `0 0 10px ${getProgressColor()}40`
-          }} />
-        </div>
 
-        {/* Progress Info */}
-        <div style={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-          color: 'white',
-          fontSize: '0.9rem',
-          marginBottom: '0.5rem'
-        }}>
-          <span style={{ color: getProgressColor(), fontWeight: '600' }}>
-            {getPhaseMessage()}
-          </span>
-          <span style={{ color: 'rgba(255, 255, 255, 0.7)' }}>
-            {progress}%
-          </span>
-        </div>
+        {/* Radial Progress Rings */}
+        {(() => {
+          const startProgress = phase === 'initializing' ? progress : 100;
+          const loadProgress = phase === 'loading' ? progress : phase !== 'initializing' ? 100 : 0;
+          const testProgress = phase === 'profiling' ? (profilerProgress ?? 0) : phase === 'ready' ? 100 : 0;
+          const currentProgress = phase === 'profiling' ? testProgress : phase === 'loading' ? loadProgress : startProgress;
+          return (
+            <div style={{ position: 'relative', width: '200px', height: '200px', marginBottom: '1rem' }}>
+              <RadialProgressRing size={200} progress={startProgress} color="#64ffda" />
+              <RadialProgressRing size={160} progress={loadProgress} color="#bb86fc" />
+              <RadialProgressRing size={120} progress={testProgress} color="#ffa726" />
+              <div style={{ position: 'absolute', top: '50%', left: '50%', transform: 'translate(-50%, -50%)', textAlign: 'center' }}>
+                <div style={{ color: getProgressColor(), fontWeight: '600', marginBottom: '0.25rem', fontSize: '0.9rem' }}>{getPhaseMessage()}</div>
+                <div style={{ color: 'rgba(255, 255, 255, 0.7)', fontSize: '0.8rem' }}>{Math.round(currentProgress)}%</div>
+              </div>
+            </div>
+          );
+        })()}
 
         {/* Asset Counter */}
         {totalAssets > 0 && phase === 'loading' && (
@@ -165,12 +152,12 @@ const EnhancedLoadingScreen = ({
           <div style={{
             marginTop: '1rem',
             padding: '1rem',
-            backgroundColor: 'rgba(187, 134, 252, 0.1)',
-            border: '1px solid rgba(187, 134, 252, 0.3)',
+            backgroundColor: 'rgba(255, 167, 38, 0.1)',
+            border: '1px solid rgba(255, 167, 38, 0.3)',
             borderRadius: '8px'
           }}>
             <div style={{
-              color: '#bb86fc',
+              color: '#ffa726',
               fontWeight: '600',
               marginBottom: '0.5rem',
               fontSize: '0.9rem',
@@ -181,7 +168,7 @@ const EnhancedLoadingScreen = ({
             <div style={{
               width: '100%',
               height: '4px',
-              backgroundColor: 'rgba(187, 134, 252, 0.2)',
+              backgroundColor: 'rgba(255, 167, 38, 0.2)',
               borderRadius: '2px',
               overflow: 'hidden',
               marginBottom: '0.5rem'
@@ -189,7 +176,7 @@ const EnhancedLoadingScreen = ({
               <div style={{
                 width: `${profilerProgress}%`,
                 height: '100%',
-                backgroundColor: '#bb86fc',
+                backgroundColor: '#ffa726',
                 borderRadius: '2px',
                 transition: 'width 0.3s ease'
               }} />

--- a/src/components/ui/RadialProgressRing.jsx
+++ b/src/components/ui/RadialProgressRing.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+
+const RadialProgressRing = ({
+  size = 160,
+  strokeWidth = 8,
+  progress = 0,
+  color = '#64ffda',
+  trackColor = 'rgba(255,255,255,0.1)'
+}) => {
+  const center = size / 2;
+  const radius = center - strokeWidth / 2;
+  const clamped = Math.min(Math.max(progress, 0), 100);
+  return (
+    <svg
+      width={size}
+      height={size}
+      style={{ position: 'absolute', top: 0, left: 0, transform: 'rotate(-90deg)' }}
+    >
+      <circle
+        cx={center}
+        cy={center}
+        r={radius}
+        fill="none"
+        stroke={trackColor}
+        strokeWidth={strokeWidth}
+      />
+      <circle
+        cx={center}
+        cy={center}
+        r={radius}
+        fill="none"
+        stroke={color}
+        strokeWidth={strokeWidth}
+        pathLength="100"
+        strokeDasharray="100"
+        strokeDashoffset={100 - clamped}
+        style={{ transition: 'stroke-dashoffset 0.3s ease' }}
+      />
+    </svg>
+  );
+};
+
+export default RadialProgressRing;

--- a/src/hooks/useAssetLoader.js
+++ b/src/hooks/useAssetLoader.js
@@ -40,11 +40,6 @@ export const useAssetLoader = (performanceProfile) => {
       phase: finalProgress === 100 ? 'ready' : 'loading'
     }));
 
-    // CRITICAL: Update HTML loader immediately
-    if (window.updateImmediateLoader) {
-      const displayPhase = finalProgress === 100 ? 'Ready' : 'Loading Assets';
-      window.updateImmediateLoader(finalProgress, displayPhase, name || assetKey, null);
-    }
 
     if (import.meta.env.DEV) console.log(`📊 Asset progress: ${assetKey} = ${Math.round(progress * 100)}%, Total: ${finalProgress}%`);
   }, []);
@@ -199,10 +194,6 @@ export const useAssetLoader = (performanceProfile) => {
       phase: 'loading'
     }));
 
-    // Update HTML loader
-    if (window.updateImmediateLoader) {
-      window.updateImmediateLoader(0, 'Loading Assets', 'Preparing to load assets...', null);
-    }
 
     // Initialize progress tracking
     progressRef.current.clear();
@@ -224,9 +215,6 @@ export const useAssetLoader = (performanceProfile) => {
         currentAsset: 'All assets loaded'
       }));
 
-      if (window.updateImmediateLoader) {
-        window.updateImmediateLoader(100, 'Ready', 'All assets loaded', null);
-      }
 
       if (import.meta.env.DEV) console.log('✅ All assets loaded successfully');
       


### PR DESCRIPTION
## Summary
- replace linear loader with concentric radial progress rings across startup, asset loading, and device testing stages
- track and display per-phase progress in the immediate loader and React loading screen
- add reusable `RadialProgressRing` component for performant SVG rendering

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68954b33a2e88328b5c5b6ebc2537eed