### PR TITLE
Notify HTML loader with incremental asset progress

### DIFF
--- a/src/hooks/useAssetLoader.js
+++ b/src/hooks/useAssetLoader.js
@@ -40,6 +40,12 @@ export const useAssetLoader = (performanceProfile) => {
       phase: finalProgress === 100 ? 'ready' : 'loading'
     }));
 
+    // Notify HTML loader for immediate progress updates
+    window.updateImmediateLoader?.({
+      assets: finalProgress,
+      phase: 'Loading Assets',
+      currentAsset: name || assetKey,
+    });
 
     if (import.meta.env.DEV) console.log(`📊 Asset progress: ${assetKey} = ${Math.round(progress * 100)}%, Total: ${finalProgress}%`);
   }, []);


### PR DESCRIPTION
## Summary
- call `window.updateImmediateLoader` after each asset progress update so the external loader reflects incremental progress

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68957bcf54e48328af592c2d6d5747fe