### PR TITLE
Add dynamic color transitions for focused crystal facets

### DIFF
--- a/src/components/three/MaterialManager.jsx
+++ b/src/components/three/MaterialManager.jsx
@@ -461,6 +461,14 @@ const MaterialManager = ({
       if (import.meta.env.DEV) console.log('✅ Using full PBR crystal material:', materialVariant);
     }
 
+    // Store the base color so clones can reference the original
+    if (materialRef.current) {
+      materialRef.current.userData = {
+        ...(materialRef.current.userData || {}),
+        baseColor: materialRef.current.color.clone()
+      };
+    }
+
     if (onMaterialReady) onMaterialReady(materialRef.current);
   }, [materialVariant, materialRef, isLow, isMedium, onMaterialReady]);
   

--- a/src/components/three/UnifiedCrystalScene.jsx
+++ b/src/components/three/UnifiedCrystalScene.jsx
@@ -225,19 +225,25 @@ const UnifiedCrystalScene = forwardRef(({
     applyMaterial(wholeCrystal.scene, crystalMaterialRef.current);
 
     // Create or update facet materials
-    facetMaterialsRef.current = facetKeys.map((_, idx) => {
+    facetMaterialsRef.current = facetKeys.map((key, idx) => {
       const mat = crystalMaterialRef.current.clone();
-      mat.color.copy(defaultColorRef.current);
+
+      // If a facet is already active, initialize its material with the project color
+      const isActive = activeFacetRef.current === key;
+      const initialColor = isActive ? projectColors[idx] : defaultColorRef.current;
+
+      mat.color.copy(initialColor);
       mat.userData = {
         ...(mat.userData || {}),
-        targetColor: defaultColorRef.current.clone()
+        targetColor: initialColor.clone()
       };
+
       const model = facetModels[idx];
       applyMaterial(model.scene, mat);
       return mat;
     });
 
-  }, [wholeCrystal, facetModels, materialVersion, facetKeys]);
+  }, [wholeCrystal, facetModels, materialVersion, facetKeys, projectColors]);
 
   // Debug anchor positions when facets are loaded
   useEffect(() => {
@@ -279,6 +285,9 @@ const UnifiedCrystalScene = forwardRef(({
   useEffect(() => {
     const nextFacet = animationData?.focusedFacet;
 
+    // Wait until materials have been created
+    if (!facetMaterialsRef.current.length) return;
+
     // No facet focused – reset all to default
     if (!nextFacet) {
       facetMaterialsRef.current.forEach((mat) => {
@@ -297,7 +306,7 @@ const UnifiedCrystalScene = forwardRef(({
       });
       activeFacetRef.current = nextFacet;
     }
-  }, [animationData?.focusedFacet, facetKeys, projectColors]);
+  }, [animationData?.focusedFacet, materialVersion, facetKeys, projectColors]);
   
   // Crystal form change detection
   useEffect(() => {

--- a/src/components/three/UnifiedCrystalScene.jsx
+++ b/src/components/three/UnifiedCrystalScene.jsx
@@ -276,20 +276,21 @@ const UnifiedCrystalScene = forwardRef(({
 
   // Update target colors when facet focus actually changes
   useEffect(() => {
-    const inProjects = animationData?.state === 'project_focused';
-    const nextFacet = inProjects ? animationData?.focusedFacet : null;
+    const nextFacet = animationData?.focusedFacet;
 
-    // Leaving project zone - reset all to default
-    if (!inProjects && activeFacetRef.current !== null) {
-      facetKeys.forEach((_, idx) => {
-        targetColorsRef.current[idx] = defaultColorRef.current;
-      });
-      activeFacetRef.current = null;
+    // No facet focused – reset all to default
+    if (!nextFacet) {
+      if (activeFacetRef.current !== null) {
+        facetKeys.forEach((_, idx) => {
+          targetColorsRef.current[idx] = defaultColorRef.current;
+        });
+        activeFacetRef.current = null;
+      }
       return;
     }
 
     // Change to a new focused facet
-    if (nextFacet && nextFacet !== activeFacetRef.current) {
+    if (nextFacet !== activeFacetRef.current) {
       facetKeys.forEach((key, idx) => {
         targetColorsRef.current[idx] = nextFacet === key
           ? projectColors[idx]
@@ -297,7 +298,7 @@ const UnifiedCrystalScene = forwardRef(({
       });
       activeFacetRef.current = nextFacet;
     }
-  }, [animationData?.focusedFacet, animationData?.state, facetKeys, projectColors]);
+  }, [animationData?.focusedFacet, facetKeys, projectColors]);
   
   // Crystal form change detection
   useEffect(() => {

--- a/src/components/three/UnifiedCrystalScene.jsx
+++ b/src/components/three/UnifiedCrystalScene.jsx
@@ -45,12 +45,12 @@ const UnifiedCrystalScene = forwardRef(({
 
   // Individual facet materials and colors
   const facetMaterialsRef = useRef([]);
-  const targetColorsRef = useRef([]);
   const activeFacetRef = useRef(null);
   const defaultColorRef = useRef(new THREE.Color('#ffffff'));
-  const projectColors = useMemo(() => (
-    facetKeys.map(key => new THREE.Color(getProjectColorByFacetKey(key)))
-  ), [facetKeys]);
+  const projectColors = useMemo(
+    () => facetKeys.map(key => new THREE.Color(getProjectColorByFacetKey(key))),
+    [facetKeys]
+  );
 
   // Track material updates so we can reapply when ready
   const [materialVersion, setMaterialVersion] = useState(0);
@@ -228,13 +228,14 @@ const UnifiedCrystalScene = forwardRef(({
     facetMaterialsRef.current = facetKeys.map((_, idx) => {
       const mat = crystalMaterialRef.current.clone();
       mat.color.copy(defaultColorRef.current);
+      mat.userData = {
+        ...(mat.userData || {}),
+        targetColor: defaultColorRef.current.clone()
+      };
       const model = facetModels[idx];
       applyMaterial(model.scene, mat);
       return mat;
     });
-
-    // Initialize target colors for each facet
-    targetColorsRef.current = facetKeys.map(() => defaultColorRef.current.clone());
 
   }, [wholeCrystal, facetModels, materialVersion, facetKeys]);
 
@@ -280,21 +281,19 @@ const UnifiedCrystalScene = forwardRef(({
 
     // No facet focused – reset all to default
     if (!nextFacet) {
-      if (activeFacetRef.current !== null) {
-        facetKeys.forEach((_, idx) => {
-          targetColorsRef.current[idx] = defaultColorRef.current;
-        });
-        activeFacetRef.current = null;
-      }
+      facetMaterialsRef.current.forEach((mat) => {
+        mat.userData.targetColor.copy(defaultColorRef.current);
+      });
+      activeFacetRef.current = null;
       return;
     }
 
     // Change to a new focused facet
     if (nextFacet !== activeFacetRef.current) {
-      facetKeys.forEach((key, idx) => {
-        targetColorsRef.current[idx] = nextFacet === key
-          ? projectColors[idx]
-          : defaultColorRef.current;
+      facetMaterialsRef.current.forEach((mat, idx) => {
+        const key = facetKeys[idx];
+        const color = nextFacet === key ? projectColors[idx] : defaultColorRef.current;
+        mat.userData.targetColor.copy(color);
       });
       activeFacetRef.current = nextFacet;
     }
@@ -440,8 +439,8 @@ const UnifiedCrystalScene = forwardRef(({
     }
 
     // Smooth color transitions for facet materials
-    facetMaterialsRef.current.forEach((mat, idx) => {
-      const target = targetColorsRef.current[idx];
+    facetMaterialsRef.current.forEach((mat) => {
+      const target = mat.userData?.targetColor;
       if (mat && target) {
         mat.color.lerp(target, 0.08);
       }

--- a/src/components/three/UnifiedCrystalScene.jsx
+++ b/src/components/three/UnifiedCrystalScene.jsx
@@ -46,6 +46,7 @@ const UnifiedCrystalScene = forwardRef(({
   // Individual facet materials and colors
   const facetMaterialsRef = useRef([]);
   const targetColorsRef = useRef([]);
+  const activeFacetRef = useRef(null);
   const defaultColorRef = useRef(new THREE.Color('#ffffff'));
   const projectColors = useMemo(() => (
     facetKeys.map(key => new THREE.Color(getProjectColorByFacetKey(key)))
@@ -273,17 +274,29 @@ const UnifiedCrystalScene = forwardRef(({
     }
   }, [showCrystalDebug, showFacets, facetKeys]);
 
-  // Update target colors based on focused facet
+  // Update target colors when facet focus actually changes
   useEffect(() => {
-    const focused = animationData?.state === 'project_focused'
-      ? animationData?.focusedFacet
-      : null;
+    const inProjects = animationData?.state === 'project_focused';
+    const nextFacet = inProjects ? animationData?.focusedFacet : null;
 
-    facetKeys.forEach((key, idx) => {
-      targetColorsRef.current[idx] = focused === key
-        ? projectColors[idx]
-        : defaultColorRef.current;
-    });
+    // Leaving project zone - reset all to default
+    if (!inProjects && activeFacetRef.current !== null) {
+      facetKeys.forEach((_, idx) => {
+        targetColorsRef.current[idx] = defaultColorRef.current;
+      });
+      activeFacetRef.current = null;
+      return;
+    }
+
+    // Change to a new focused facet
+    if (nextFacet && nextFacet !== activeFacetRef.current) {
+      facetKeys.forEach((key, idx) => {
+        targetColorsRef.current[idx] = nextFacet === key
+          ? projectColors[idx]
+          : defaultColorRef.current;
+      });
+      activeFacetRef.current = nextFacet;
+    }
   }, [animationData?.focusedFacet, animationData?.state, facetKeys, projectColors]);
   
   // Crystal form change detection

--- a/src/components/three/UnifiedCrystalScene.jsx
+++ b/src/components/three/UnifiedCrystalScene.jsx
@@ -235,7 +235,9 @@ const UnifiedCrystalScene = forwardRef(({
       mat.color.copy(initialColor);
       mat.userData = {
         ...(mat.userData || {}),
-        targetColor: initialColor.clone()
+        targetColor: initialColor.clone(),
+        startColor: initialColor.clone(),
+        progress: 1
       };
 
       const model = facetModels[idx];
@@ -291,7 +293,9 @@ const UnifiedCrystalScene = forwardRef(({
     // No facet focused – reset all to default
     if (!nextFacet) {
       facetMaterialsRef.current.forEach((mat) => {
+        mat.userData.startColor.copy(mat.color);
         mat.userData.targetColor.copy(defaultColorRef.current);
+        mat.userData.progress = 0;
       });
       activeFacetRef.current = null;
       return;
@@ -302,7 +306,9 @@ const UnifiedCrystalScene = forwardRef(({
       facetMaterialsRef.current.forEach((mat, idx) => {
         const key = facetKeys[idx];
         const color = nextFacet === key ? projectColors[idx] : defaultColorRef.current;
+        mat.userData.startColor.copy(mat.color);
         mat.userData.targetColor.copy(color);
+        mat.userData.progress = 0;
       });
       activeFacetRef.current = nextFacet;
     }
@@ -354,7 +360,7 @@ const UnifiedCrystalScene = forwardRef(({
   }, [animationData?.crystalForm]);
 
   // Main animation loop
-  useFrame(() => {
+  useFrame((_, delta) => {
     if (!animationData || !facetRefs.current.length || simplifiedAnimations) return;
 
     const time = clock.getElapsedTime();
@@ -449,9 +455,11 @@ const UnifiedCrystalScene = forwardRef(({
 
     // Smooth color transitions for facet materials
     facetMaterialsRef.current.forEach((mat) => {
-      const target = mat.userData?.targetColor;
-      if (mat && target) {
-        mat.color.lerp(target, 0.08);
+      const { targetColor, startColor, progress = 1 } = mat.userData || {};
+      if (targetColor && startColor && progress < 1) {
+        const speed = 1.5; // seconds to fully transition
+        mat.userData.progress = Math.min(progress + delta * speed, 1);
+        mat.color.lerpColors(startColor, targetColor, mat.userData.progress);
       }
     });
   });

--- a/src/components/three/UnifiedCrystalScene.jsx
+++ b/src/components/three/UnifiedCrystalScene.jsx
@@ -1,7 +1,7 @@
 // UPDATED: src/components/three/UnifiedCrystalScene.jsx
 // FIXED: Disabled shadows for crystal materials to improve lighting through transparent faces
 
-import React, { useRef, useState, useEffect, useCallback, forwardRef, useImperativeHandle } from 'react'
+import React, { useRef, useState, useEffect, useCallback, forwardRef, useImperativeHandle, useMemo } from 'react'
 import { useFrame, useThree } from '@react-three/fiber'
 import { useGLTF, Html } from '@react-three/drei'
 import * as THREE from 'three'
@@ -11,6 +11,7 @@ import MaterialManager from './MaterialManager'
 
 // Import enhanced sphere component
 import GlowingSphereImage, { BLENDING_MODES } from './GlowingSphereImage'
+import { getProjectColorByFacetKey } from '../../data/projects'
 
 const UnifiedCrystalScene = forwardRef(({ 
   animationData,
@@ -25,7 +26,7 @@ const UnifiedCrystalScene = forwardRef(({
   const wholeCrystalRef = useRef();
   const facetRefs = useRef([]); 
   const crystalMaterialRef = useRef();
-  
+
   // Sphere state
   const [sphereVisible, setSphereVisible] = useState(false);
   
@@ -41,6 +42,14 @@ const UnifiedCrystalScene = forwardRef(({
 
   // Facet configuration
   const facetKeys = ['empathy', 'narrative', 'craft', 'system', 'leadership', 'exploration'];
+
+  // Individual facet materials and colors
+  const facetMaterialsRef = useRef([]);
+  const targetColorsRef = useRef([]);
+  const defaultColorRef = useRef(new THREE.Color('#ffffff'));
+  const projectColors = useMemo(() => (
+    facetKeys.map(key => new THREE.Color(getProjectColorByFacetKey(key)))
+  ), [facetKeys]);
 
   // Track material updates so we can reapply when ready
   const [materialVersion, setMaterialVersion] = useState(0);
@@ -186,31 +195,47 @@ const UnifiedCrystalScene = forwardRef(({
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, []);
   
-  // UPDATED: Apply shared material to all models with disabled shadows
+  // Apply materials to the crystal and create facet-specific clones
   useEffect(() => {
     if (!crystalMaterialRef.current) return;
-    
-    const applyMaterial = (modelScene) => {
+
+    // Default color for resetting facet materials
+    defaultColorRef.current.copy(
+      crystalMaterialRef.current.userData?.baseColor ||
+      crystalMaterialRef.current.color
+    );
+
+    // Apply material to whole crystal
+    const applyMaterial = (modelScene, material) => {
       if (!modelScene) return;
       modelScene.traverse((child) => {
         if (child.isMesh) {
-          child.material = crystalMaterialRef.current;
-          
-          // CHANGED: Disable shadows for crystal materials to improve transparent lighting
-          child.castShadow = false;    // Don't cast shadows
-          child.receiveShadow = false; // Don't receive shadows
-          
+          child.material = material;
+          child.castShadow = false;
+          child.receiveShadow = false;
+
           if (import.meta.env.DEV) {
             console.log(`💡 Disabled shadows for crystal mesh: ${child.name}`);
           }
         }
       });
     };
-    
-    applyMaterial(wholeCrystal.scene);
-    facetModels.forEach(model => applyMaterial(model.scene));
-    
-  }, [wholeCrystal, facetModels, materialVersion]);
+
+    applyMaterial(wholeCrystal.scene, crystalMaterialRef.current);
+
+    // Create or update facet materials
+    facetMaterialsRef.current = facetKeys.map((_, idx) => {
+      const mat = crystalMaterialRef.current.clone();
+      mat.color.copy(defaultColorRef.current);
+      const model = facetModels[idx];
+      applyMaterial(model.scene, mat);
+      return mat;
+    });
+
+    // Initialize target colors for each facet
+    targetColorsRef.current = facetKeys.map(() => defaultColorRef.current.clone());
+
+  }, [wholeCrystal, facetModels, materialVersion, facetKeys]);
 
   // Debug anchor positions when facets are loaded
   useEffect(() => {
@@ -247,6 +272,19 @@ const UnifiedCrystalScene = forwardRef(({
       if (import.meta.env.DEV) console.groupEnd();
     }
   }, [showCrystalDebug, showFacets, facetKeys]);
+
+  // Update target colors based on focused facet
+  useEffect(() => {
+    const focused = animationData?.state === 'project_focused'
+      ? animationData?.focusedFacet
+      : null;
+
+    facetKeys.forEach((key, idx) => {
+      targetColorsRef.current[idx] = focused === key
+        ? projectColors[idx]
+        : defaultColorRef.current;
+    });
+  }, [animationData?.focusedFacet, animationData?.state, facetKeys, projectColors]);
   
   // Crystal form change detection
   useEffect(() => {
@@ -386,6 +424,14 @@ const UnifiedCrystalScene = forwardRef(({
         setShowWholeCrystal(true);
       }
     }
+
+    // Smooth color transitions for facet materials
+    facetMaterialsRef.current.forEach((mat, idx) => {
+      const target = targetColorsRef.current[idx];
+      if (mat && target) {
+        mat.color.lerp(target, 0.08);
+      }
+    });
   });
 
   return (


### PR DESCRIPTION
## Summary
- clone the base crystal material for each facet and track project colors
- lerp facet material colors toward project hues when focused
- store base material color in userData for reliable resets

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6899264e067c83289f260addc9faf755