### PR TITLE
Optimize performance test duration and unify post-processing

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -161,8 +161,21 @@ function App() {
   // Initialize effects from the detected device profile
   useEffect(() => {
     if (performanceProfile?.postProcessing) {
-      setEffectsEnabled(performanceProfile.postProcessing);
-      setPostProcessingConfig(performanceProfile.postProcessing);
+      // Apply unified noise and vignette settings regardless of profile
+      const unifiedEffects = {
+        ...performanceProfile.postProcessing,
+        noise: true,        // Always enabled
+        vignette: true      // Always enabled
+      };
+
+      setEffectsEnabled(unifiedEffects);
+
+      // Apply unified configuration values
+      setPostProcessingConfig({
+        ...performanceProfile.postProcessing,
+        noise: { opacity: 1.5 },      // Unified value
+        vignette: { darkness: 0.7 }    // Unified value
+      });
     }
   }, [performanceProfile]);
 

--- a/src/crystalConfig.js
+++ b/src/crystalConfig.js
@@ -280,12 +280,12 @@ export const postProcessing = {
     modulationOffset: 0.5
   },
   noise: {
-    opacity: 0.1
+    opacity: 1.5  // UNIFIED: Set to 1.5 for all levels
   },
   vignette: {
     eskil: false,
     offset: 0.1,
-    darkness: 1.1
+    darkness: 0.7  // UNIFIED: Set to 0.7 for all levels
   }
 }
 

--- a/src/utils/PerformanceManager.js
+++ b/src/utils/PerformanceManager.js
@@ -141,7 +141,7 @@ export default class PerformanceManager {
     document.body.appendChild(canvas);
 
     try {
-      const iterations = 3;
+      const iterations = 2;
 
       // Test medium quality with progressive updates (0-60%)
       const mediumResults = await this._testWithActualSceneComplexity(
@@ -257,7 +257,7 @@ export default class PerformanceManager {
   }
 
 
-  async _testWithActualSceneComplexity(canvas, tier, iterations = 3, onProgress) {
+  async _testWithActualSceneComplexity(canvas, tier, iterations = 2, onProgress) {
     const profile = PERFORMANCE_PROFILES[tier];
     const THREE = await import('three');
 
@@ -343,8 +343,8 @@ export default class PerformanceManager {
       // FIXED: Don't simulate post-processing overhead - test real rendering load only
 
       const samples = [];
-      const warmup = 200; // Ignore first 200ms
-      const measureDuration = 1500; // 1.5 seconds of sampling
+      const warmup = 100; // Ignore first 100ms
+      const measureDuration = 600; // 0.6 seconds of sampling
       const totalDuration = warmup + measureDuration;
       let startTime = 0;
       let lastTime = 0;

--- a/src/utils/deviceProfiles.js
+++ b/src/utils/deviceProfiles.js
@@ -71,11 +71,11 @@ export const PERFORMANCE_PROFILES = {
     // Animations
     simplifiedAnimations: false,
     
-    // Post-processing (keep some effects for visual quality)
+    // Post-processing (noise and vignette enabled for consistency)
     postProcessing: {
       bloom: true,
-      chromaticAberration: false, 
-      noise: false,
+      chromaticAberration: false,
+      noise: true,
       vignette: true
     },
     
@@ -114,12 +114,12 @@ export const PERFORMANCE_PROFILES = {
     // Animations
     simplifiedAnimations: false,
     
-    // Post-processing (disabled for maximum performance)
+    // Post-processing (bloom/CA vary, noise and vignette always on)
     postProcessing: {
       bloom: false,
       chromaticAberration: false,
-      noise: false,
-      vignette: false
+      noise: true,
+      vignette: true
     },
     
     // All tiers now target a 60 FPS baseline


### PR DESCRIPTION
## Summary
- shorten performance test with 100ms warmup, 600ms measurement and two iterations
- enable subtle noise and vignette post-processing on all device profiles
- apply unified noise and vignette configuration values

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68995133e7d08328bf1ddd4b508ca398