### PR TITLE
Fix toggle controls in settings panel

### DIFF
--- a/src/components/ui/PerformanceControls.jsx
+++ b/src/components/ui/PerformanceControls.jsx
@@ -174,7 +174,15 @@ const PerformanceControls = ({
   
   // Custom toggle switch component
   const ToggleSwitch = ({ checked, onChange, disabled = false }) => (
-    <div style={controlToggleStyle}>
+    <label
+      style={{
+        ...controlToggleStyle,
+        cursor: disabled ? "not-allowed" : "pointer",
+        opacity: disabled ? 0.5 : 1,
+        position: "relative",
+        display: "inline-block"
+      }}
+    >
       <input
         type="checkbox"
         checked={checked}
@@ -182,50 +190,40 @@ const PerformanceControls = ({
         disabled={disabled}
         style={{
           opacity: 0,
-          width: 0,
-          height: 0
+          width: "100%",
+          height: "100%",
+          position: "absolute",
+          top: 0,
+          left: 0,
+          margin: 0,
+          cursor: "inherit"
         }}
       />
       <span
         style={{
-          position: 'absolute',
-          cursor: disabled ? 'not-allowed' : 'pointer',
+          position: "absolute",
           top: 0,
           left: 0,
           right: 0,
           bottom: 0,
-          backgroundColor: disabled ? 'rgba(150, 150, 150, 0.2)' : (checked ? '#64ffda' : 'rgba(255, 255, 255, 0.2)'),
-          opacity: disabled ? 0.5 : 1,
-          transition: '0.3s',
-          borderRadius: '20px',
-          '&:before': {
-            position: 'absolute',
-            content: '""',
-            height: '16px',
-            width: '16px',
-            left: checked ? '20px' : '4px',
-            bottom: '2px',
-            backgroundColor: 'white',
-            transition: '0.3s',
-            borderRadius: '50%'
-          }
+          backgroundColor: disabled ? "rgba(150, 150, 150, 0.2)" : (checked ? "#64ffda" : "rgba(255, 255, 255, 0.2)"),
+          borderRadius: "20px",
+          transition: "background-color 0.3s"
         }}
-        onClick={disabled ? null : onChange}
-      >
-        <span 
-          style={{
-            position: 'absolute',
-            height: '16px',
-            width: '16px',
-            left: checked ? '20px' : '4px',
-            bottom: '2px',
-            backgroundColor: 'white',
-            transition: '0.3s',
-            borderRadius: '50%'
-          }}
-        />
-      </span>
-    </div>
+      />
+      <span
+        style={{
+          position: "absolute",
+          top: "2px",
+          left: checked ? "22px" : "2px",
+          width: "16px",
+          height: "16px",
+          backgroundColor: "white",
+          borderRadius: "50%",
+          transition: "left 0.3s"
+        }}
+      />
+    </label>
   );
 
   // Only render if visible

--- a/src/components/ui/PostProcessingControls.jsx
+++ b/src/components/ui/PostProcessingControls.jsx
@@ -174,56 +174,54 @@ const PostProcessingControls = ({
   
   // Custom toggle switch component
   const ToggleSwitch = ({ checked, onChange }) => (
-    <div style={controlToggleStyle}>
+    <label
+      style={{
+        ...controlToggleStyle,
+        cursor: "pointer",
+        position: "relative",
+        display: "inline-block"
+      }}
+    >
       <input
         type="checkbox"
         checked={checked}
         onChange={onChange}
         style={{
           opacity: 0,
-          width: 0,
-          height: 0
+          width: "100%",
+          height: "100%",
+          position: "absolute",
+          top: 0,
+          left: 0,
+          margin: 0,
+          cursor: "inherit"
         }}
       />
       <span
         style={{
-          position: 'absolute',
-          cursor: 'pointer',
+          position: "absolute",
           top: 0,
           left: 0,
           right: 0,
           bottom: 0,
-          backgroundColor: checked ? '#64ffda' : 'rgba(255, 255, 255, 0.2)',
-          transition: '0.3s',
-          borderRadius: '20px',
-          '&:before': {
-            position: 'absolute',
-            content: '""',
-            height: '16px',
-            width: '16px',
-            left: checked ? '20px' : '4px',
-            bottom: '2px',
-            backgroundColor: 'white',
-            transition: '0.3s',
-            borderRadius: '50%'
-          }
+          backgroundColor: checked ? "#64ffda" : "rgba(255, 255, 255, 0.2)",
+          transition: "background-color 0.3s",
+          borderRadius: "20px"
         }}
-        onClick={onChange}
-      >
-        <span 
-          style={{
-            position: 'absolute',
-            height: '16px',
-            width: '16px',
-            left: checked ? '20px' : '4px',
-            bottom: '2px',
-            backgroundColor: 'white',
-            transition: '0.3s',
-            borderRadius: '50%'
-          }}
-        />
-      </span>
-    </div>
+      />
+      <span
+        style={{
+          position: "absolute",
+          top: "2px",
+          left: checked ? "22px" : "2px",
+          width: "16px",
+          height: "16px",
+          backgroundColor: "white",
+          borderRadius: "50%",
+          transition: "left 0.3s"
+        }}
+      />
+    </label>
   );
   
   // Only render if visible


### PR DESCRIPTION
## Summary
- Rework settings panel toggle switch in PostProcessingControls for reliable effect toggling
- Rework PerformanceControls toggles to ensure performance options can be switched on and off

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (warning: BatchedMesh is not exported; build produced output)


------
https://chatgpt.com/codex/tasks/task_e_689a8873b3d88328972951116b6a93f1