### PR TITLE
Gate asset loading on performance profile

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -127,7 +127,6 @@ function App() {
   });
   const [postProcessingConfig, setPostProcessingConfig] = useState(config.postProcessing);
   const [testingProgress, setTestingProgress] = useState(0);
-  const startingProgress = 100;
 
   // FIXED: Enhanced performance hook with proper error handling
   const {
@@ -147,7 +146,6 @@ function App() {
   // FIXED: Asset loader hook with proper performance profile dependency
   const {
     progress,
-    phase,
     currentAsset,
     loadedAssets,
     totalAssets,
@@ -156,7 +154,7 @@ function App() {
     isReady: assetsReady,
     hasErrors,
     retry
-  } = useAssetLoader(performanceProfile);
+  } = useAssetLoader(performanceReady ? performanceProfile : null);
 
   // Initialize effects from the detected device profile
   useEffect(() => {
@@ -396,30 +394,24 @@ useEffect(() => {
     };
   }, [performanceProfile]);
 
-  // Show new loader overlay
+  // Show loader overlay during initialization and asset loading
   if (!isAppReady) {
-    const loaderPhase = phase === 'initializing'
-      ? 'starting'
-      : phase === 'loading'
-        ? 'loading'
-        : 'testing';
+    if (!performanceReady) {
+      const overallProgress = (testingProgress / 100) * 0.5;
+      return (
+        <LoaderV2
+          phase="testing"
+          phaseProgress={testingProgress / 100}
+          overallProgress={overallProgress}
+        />
+      );
+    }
 
-    const phaseProgressValue = loaderPhase === 'starting'
-      ? startingProgress / 100
-      : loaderPhase === 'loading'
-        ? progress / 100
-        : testingProgress / 100;
-
-    const overallProgress = loaderPhase === 'starting'
-      ? phaseProgressValue * 0.33
-      : loaderPhase === 'loading'
-        ? 0.33 + phaseProgressValue * 0.33
-        : 0.66 + phaseProgressValue * 0.34;
-
+    const overallProgress = 0.5 + (progress / 100) * 0.5;
     return (
       <LoaderV2
-        phase={loaderPhase}
-        phaseProgress={phaseProgressValue}
+        phase="loading"
+        phaseProgress={progress / 100}
         overallProgress={overallProgress}
       />
     );

--- a/src/hooks/useAssetLoader.js
+++ b/src/hooks/useAssetLoader.js
@@ -19,6 +19,7 @@ export const useAssetLoader = (performanceProfile) => {
 
   const progressRef = useRef(new Map());
   const hasStartedLoading = useRef(false);
+  const previousProfile = useRef(null);
 
   /**
    * Update progress immediately and call global HTML loader
@@ -237,13 +238,29 @@ export const useAssetLoader = (performanceProfile) => {
   }, [getRequiredAssets, loadSingleAsset]);
 
   /**
-   * Start loading when performance profile is available
+   * Reset and start loading when a new performance profile arrives
    */
   useEffect(() => {
-    if (performanceProfile && !hasStartedLoading.current) {
+    if (!performanceProfile) return;
+
+    if (previousProfile.current !== performanceProfile) {
+      previousProfile.current = performanceProfile;
+      hasStartedLoading.current = false;
+      progressRef.current.clear();
+      setLoadingState({
+        progress: 0,
+        phase: 'initializing',
+        loadedAssets: 0,
+        totalAssets: 0,
+        currentAsset: 'Starting up...',
+        errors: []
+      });
+    }
+
+    if (!hasStartedLoading.current) {
       hasStartedLoading.current = true;
       if (import.meta.env.DEV) console.log('🚀 Starting asset loading with performance profile');
-      
+
       // Small delay to ensure HTML loader is ready
       setTimeout(() => {
         loadAllAssets();


### PR DESCRIPTION
## Summary
- Defer asset loading until performance system reports ready, then kick off loading with confirmed profile
- Reset asset loader when profile changes and add minimal loading overlay while performance tier is determined

## Testing
- `npx eslint src/App.jsx src/hooks/useAssetLoader.js` *(fails: Global "AudioWorkletGlobalScope " has leading or trailing whitespace)*
- `npm run build`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689cb8964e4c83288358d71bbbff3af6