### PR TITLE
feat: surface real performance test progress in loader

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -126,7 +126,10 @@ function App() {
     vignette: true
   });
   const [postProcessingConfig, setPostProcessingConfig] = useState(config.postProcessing);
-  const [testingProgress, setTestingProgress] = useState(0);
+  const testingStartRef = useRef(null);
+  const loadingStartRef = useRef(null);
+  const [testingDuration, setTestingDuration] = useState(null);
+  const [loadingDuration, setLoadingDuration] = useState(null);
 
   // FIXED: Enhanced performance hook with proper error handling
   const {
@@ -137,6 +140,7 @@ function App() {
     error: performanceError,
     testResults,
     testProgress: actualTestProgress,
+    testStatus,
     updateProfile,
     forceRetest,
     clearCache,
@@ -177,26 +181,39 @@ function App() {
     }
   }, [performanceProfile]);
 
-  // Simulated progress for device testing phase
-useEffect(() => {
-  let id;
-  if (performanceInitializing) {
-    setTestingProgress(0);
-    id = setInterval(() => {
-      setTestingProgress(prev => {
-        // FIXED: Don't go past 95% until test actually completes
-        if (prev < 85) return Math.min(prev + 5, 85);
-        if (prev < 95) return Math.min(prev + 2, 95); // Slower approach to 95%
-        return Math.min(prev + 0.5, 95); // Very slow approach, stop at 95%
-      });
-    }, 100);
-  } else if (performanceReady && !performanceError) {
-    // FIXED: When test completes, immediately jump to 100%
-    setTestingProgress(100);
-    clearInterval(id);
-  }
-  return () => clearInterval(id);
-}, [performanceInitializing, performanceReady, performanceError]);
+  // Track phase durations for dynamic overall progress
+  useEffect(() => {
+    if (performanceInitializing && !testingStartRef.current) {
+      testingStartRef.current = performance.now();
+    }
+    if (performanceReady && testingStartRef.current && testingDuration === null) {
+      setTestingDuration(performance.now() - testingStartRef.current);
+      testingStartRef.current = null;
+    }
+  }, [performanceInitializing, performanceReady, testingDuration]);
+
+  useEffect(() => {
+    if (isLoading && !loadingStartRef.current) {
+      loadingStartRef.current = performance.now();
+    }
+    if (assetsReady && loadingStartRef.current && loadingDuration === null) {
+      setLoadingDuration(performance.now() - loadingStartRef.current);
+      loadingStartRef.current = null;
+    }
+  }, [isLoading, assetsReady, loadingDuration]);
+
+  const computeOverallProgress = useCallback(() => {
+    const now = performance.now();
+    const testElapsed = testingDuration ?? (testingStartRef.current ? now - testingStartRef.current : 0);
+    const testTotal = testingDuration ?? (actualTestProgress > 0 ? testElapsed / (actualTestProgress / 100) : 0);
+    const loadElapsed = loadingDuration ?? (loadingStartRef.current ? now - loadingStartRef.current : 0);
+    const loadTotal = loadingDuration ?? (progress > 0 ? loadElapsed / (progress / 100) : 0);
+    const total = testTotal + loadTotal;
+    if (total === 0) return 0;
+    return (testElapsed + loadElapsed) / total;
+  }, [testingDuration, loadingDuration, actualTestProgress, progress]);
+
+  const overallProgress = computeOverallProgress();
 
   // Detect if mobile
   const isMobile = isMobileDevice();
@@ -397,22 +414,21 @@ useEffect(() => {
   // Show loader overlay during initialization and asset loading
   if (!isAppReady) {
     if (!performanceReady) {
-      const overallProgress = (testingProgress / 100) * 0.5;
       return (
         <LoaderV2
           phase="testing"
-          phaseProgress={testingProgress / 100}
+          phaseProgress={actualTestProgress / 100}
           overallProgress={overallProgress}
+          statusMessage={testStatus}
         />
       );
     }
-
-    const overallProgress = 0.5 + (progress / 100) * 0.5;
     return (
       <LoaderV2
         phase="loading"
         phaseProgress={progress / 100}
         overallProgress={overallProgress}
+        statusMessage={currentAsset}
       />
     );
   }

--- a/src/hooks/usePerformance.js
+++ b/src/hooks/usePerformance.js
@@ -15,6 +15,7 @@ export const usePerformance = () => {
   const [error, setError] = useState(null);
   const [testResults, setTestResults] = useState(manager.getTestResults());
   const [testProgress, setTestProgress] = useState(0); // NEW: Track test progress
+  const [testStatus, setTestStatus] = useState(''); // NEW: Track status message
 
   // Initialize performance manager
   useEffect(() => {
@@ -33,11 +34,13 @@ export const usePerformance = () => {
       setIsInitializing(true);
       setError(null);
       setTestProgress(0);
+      setTestStatus('');
 
       // FIXED: Set up progress callback
       manager.setProgressCallback((percentage, message) => {
         if (mounted) {
           setTestProgress(percentage);
+          setTestStatus(message || '');
           // Update global HTML loader too
           window.updateImmediateLoader?.({
             test: percentage,
@@ -74,9 +77,10 @@ export const usePerformance = () => {
         console.error('Failed to initialize performance manager:', err);
         
         if (mounted) {
-          setError(err.message);
-          setIsInitializing(false);
-          setTestProgress(100); // Complete even on error
+            setError(err.message);
+            setIsInitializing(false);
+            setTestProgress(100); // Complete even on error
+            setTestStatus(err.message);
           // Fall back to medium profile
           setProfile(manager.getProfile());
           setTier(manager.getTier());
@@ -124,6 +128,8 @@ export const usePerformance = () => {
     setIsInitializing(true);
     setError(null);
     setIsReady(false);
+    setTestProgress(0);
+    setTestStatus('');
 
     try {
       if (import.meta.env.DEV) {
@@ -169,20 +175,22 @@ export const usePerformance = () => {
     hasCache: !!testResults
   };
 
-  return { 
-    profile, 
-    tier, 
-    isReady, 
+  return {
+    profile,
+    tier,
+    isReady,
     isInitializing,
     error,
     testResults,
     testProgress,
+    testStatus,
     updateProfile,
     forceRetest,
     clearCache,
     debugInfo: {
       ...debugInfo,
-      testProgress
+      testProgress,
+      testStatus
     }
   };
 };

--- a/src/ui/LoaderV2.tsx
+++ b/src/ui/LoaderV2.tsx
@@ -5,6 +5,7 @@ export type LoaderV2Props = {
   phase: 'starting' | 'loading' | 'testing';
   phaseProgress: number; // 0..1
   overallProgress: number; // 0..1
+  statusMessage?: string;
 };
 
 const statusText = (phase: LoaderV2Props['phase']) => {
@@ -20,7 +21,7 @@ const statusText = (phase: LoaderV2Props['phase']) => {
   }
 };
 
-const LoaderV2: React.FC<LoaderV2Props> = ({ phase, phaseProgress, overallProgress }) => {
+const LoaderV2: React.FC<LoaderV2Props> = ({ phase, phaseProgress, overallProgress, statusMessage }) => {
   const isMobile = /Mobi|Android/i.test(navigator.userAgent);
   const stroke = isMobile ? 4 : 6;
   const R = 100;
@@ -95,14 +96,14 @@ const LoaderV2: React.FC<LoaderV2Props> = ({ phase, phaseProgress, overallProgre
           {percent}%
         </text>
       </svg>
-      <div className={styles.status} aria-live="polite">
-        {statusText(phase)}
-        <span className={styles.dots}>
-          <span className={styles.dot} />
-          <span className={styles.dot} />
-          <span className={styles.dot} />
-        </span>
-      </div>
+        <div className={styles.status} aria-live="polite">
+          {statusMessage || statusText(phase)}
+          <span className={styles.dots}>
+            <span className={styles.dot} />
+            <span className={styles.dot} />
+            <span className={styles.dot} />
+          </span>
+        </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- expose test progress and status message from `usePerformance`
- drive loader with real test/asset progress and dynamic weighting
- show detailed status messages in `LoaderV2`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689cba96b494832896ab6677651d6149