### PR TITLE
feat: enhance loader status messaging

### DIFF
--- a/src/ui/LoaderV2.module.css
+++ b/src/ui/LoaderV2.module.css
@@ -37,7 +37,15 @@
   color: var(--offwhite, #F4F2E6);
   display: flex;
   align-items: center;
-  gap: 0.25rem;
+  gap: 0.5rem;
+}
+
+.phase {
+  font-weight: 600;
+}
+
+.message {
+  opacity: 0.8;
 }
 
 .dots {

--- a/src/ui/LoaderV2.tsx
+++ b/src/ui/LoaderV2.tsx
@@ -5,17 +5,18 @@ export type LoaderV2Props = {
   phase: 'starting' | 'loading' | 'testing';
   phaseProgress: number; // 0..1
   overallProgress: number; // 0..1
+  /** optional detailed message for the current phase */
   statusMessage?: string;
 };
 
 const statusText = (phase: LoaderV2Props['phase']) => {
   switch (phase) {
     case 'starting':
-      return 'Starting';
+      return 'Initializing system';
     case 'loading':
-      return 'Loading';
+      return 'Loading assets';
     case 'testing':
-      return 'Testing';
+      return 'Testing performance';
     default:
       return '';
   }
@@ -96,9 +97,17 @@ const LoaderV2: React.FC<LoaderV2Props> = ({ phase, phaseProgress, overallProgre
           {percent}%
         </text>
       </svg>
-        <div className={styles.status} aria-live="polite">
-          {statusMessage || statusText(phase)}
-          <span className={styles.dots}>
+        <div
+          className={styles.status}
+          aria-live="polite"
+          aria-atomic="true"
+          role="status"
+        >
+          <span className={styles.phase}>{statusText(phase)}</span>
+          {statusMessage && (
+            <span className={styles.message}>{statusMessage}</span>
+          )}
+          <span className={styles.dots} aria-hidden="true">
             <span className={styles.dot} />
             <span className={styles.dot} />
             <span className={styles.dot} />


### PR DESCRIPTION
## Summary
- use descriptive status labels like "Initializing system" and "Loading assets"
- surface optional detailed status messages with clear styling
- improve loader accessibility via aria live region

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689cbcffda38832894911d6d9f9931b0