### PR TITLE
Ensure loader ring progress is isolated per phase

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -400,18 +400,18 @@ function App() {
     // Normalize dedicated progress values
     const testingProgress = Math.min(testProgress / 40, 1); // 0-1 across full testing phase
     const assetsProgress = assetProgress / 100;
-    const itemProgressNorm = itemProgress / 100;
 
-    const phaseProgress = currentPhase === 'testing'
-      ? testingProgress
-      : assetsProgress;
-
-    // During testing, show per-step progress (each test spans 10%)
+    // Phase-specific progress values
     const testingSubProgress = (testProgress % 10) / 10; // 0-1 within current test
 
-    const subProgress = currentPhase === 'testing'
-      ? testingSubProgress
-      : itemProgressNorm;
+    let phaseProgress = 0;
+    let subProgress = 0;
+
+    if (currentPhase === 'loading') {
+      phaseProgress = assetsProgress; // Only move purple ring during asset loading
+    } else if (currentPhase === 'testing') {
+      subProgress = testingSubProgress; // Only move yellow ring during performance tests
+    }
 
     // Get current status message
     let statusMessage = '';

--- a/src/ui/LoaderV2.jsx
+++ b/src/ui/LoaderV2.jsx
@@ -25,11 +25,13 @@ const LoaderV2 = ({
       });
 
       setSmoothPhase(prev => {
+        if (phase !== 'loading') return prev; // Freeze once loading completes
         const diff = phaseProgress - prev;
         return prev + diff * 0.15;
       });
 
       setSmoothSub(prev => {
+        if (phase !== 'testing') return prev; // Freeze once testing completes
         const diff = subProgress - prev;
         return prev + diff * 0.12;
       });
@@ -44,7 +46,7 @@ const LoaderV2 = ({
         cancelAnimationFrame(animationFrameRef.current);
       }
     };
-  }, [overallProgress, phaseProgress, subProgress]);
+  }, [overallProgress, phaseProgress, subProgress, phase]);
 
   // FIXED: Correct ring mapping
   const ringProgress = {


### PR DESCRIPTION
## Summary
- Reset phase and sub progress when their phases are inactive
- Freeze loader rings at 100% so completed phases stay filled

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689d3f06e6588328851e9ffe0d20ae45