### PR TITLE
Refine loader progress and performance panel

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -315,10 +315,12 @@ function App() {
 
   const getOverallProgress = () => {
     if (!performanceReady) {
-      return testProgress / 100;
+      // Performance testing accounts for 40% of total progress
+      return (testProgress / 100) * 0.4;
     }
     if (!assetsReady) {
-      return 0.4 + (assetProgress / 100) * 0.6; // Testing = 40%, Loading = 60%
+      // Asset loading covers the remaining 60%
+      return 0.4 + (assetProgress / 100) * 0.6;
     }
     return 1.0;
   };
@@ -402,9 +404,9 @@ function App() {
     // Get current status message
     let statusMessage = '';
     if (currentPhase === 'testing') {
-      statusMessage = testStatus;
+      statusMessage = testStatus || 'Testing performance...';
     } else if (currentPhase === 'loading') {
-      statusMessage = currentAsset;
+      statusMessage = currentAsset || 'Loading assets...';
     }
 
     return (

--- a/src/components/ui/PerformanceDebugPanel.jsx
+++ b/src/components/ui/PerformanceDebugPanel.jsx
@@ -137,6 +137,10 @@ const PerformanceDebugPanel = ({
           <div>Initialized: {hasInitialized ? '✅' : '❌'}</div>
           <div>Profile Applied: {initialProfileApplied ? '✅' : '❌'}</div>
           <div>Is Initializing: {debugInfo?.isInitializing ? '⏳' : '✅'}</div>
+          <div>Test Progress: {Math.round(debugInfo?.testProgress || 0)}%</div>
+          {debugInfo?.testStatus && (
+            <div>Test Status: {debugInfo.testStatus}</div>
+          )}
           <div>Has Cache: {debugInfo?.hasCache ? '✅' : '❌'}</div>
           <div>Manager Ready: {debugInfo?.managerReady ? '✅' : '❌'}</div>
           {debugInfo?.error && (

--- a/src/ui/LoaderV2.module.css
+++ b/src/ui/LoaderV2.module.css
@@ -1,10 +1,11 @@
 :root{
   --bg: #0B0B0C;
-  --ring1: #CFECDD;  /* outer = overall (mint) */
-  --ring2: #CDBCF6;  /* middle = assets (lavender) */
-  --ring3: #F7DBB1;  /* inner = performance (peach) */
+  --ring1: #64ffda;  /* outer = initialization (teal) */
+  --ring2: #bb86fc;  /* middle = assets (purple) */
+  --ring3: #ff64b0;  /* inner = performance (pink) */
   --ringTrack: rgba(255,255,255,0.12);
   --text: #F0ECE0;
+  --offwhite: #F4F2E6;
   --ringStroke: 6;
 }
 
@@ -20,11 +21,13 @@
 
 .headline{
   margin: 0 0 14px 0;
-  color: var(--text);
   font-family: "Times New Roman", ui-serif, Georgia, serif;
   font-size: clamp(26px, 4vw, 48px);
   font-weight: 700;
   text-align: center; letter-spacing: 0.02em;
+  background: linear-gradient(90deg, var(--ring1), var(--ring2));
+  -webkit-background-clip: text;
+  color: transparent;
 }
 .subhead{
   display: block; margin-top: 4px;
@@ -39,6 +42,18 @@
 .progress{ transition: stroke-dashoffset 0.35s ease-out, stroke 0.2s ease-out; }
 
 .diamond{ filter: drop-shadow(0 0 10px rgba(255,255,230,0.18)); }
+
+.percent{
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 28px;
+  font-weight: 600;
+  color: var(--offwhite);
+  pointer-events: none;
+}
 
 .status{
   margin-top: 10px; color: var(--text); font-size: 12px; letter-spacing: 0.06em; text-align: center;

--- a/src/ui/LoaderV2.tsx
+++ b/src/ui/LoaderV2.tsx
@@ -1,313 +1,135 @@
-// src/ui/LoaderV2.jsx
-// FIXED: Correct progress ring mapping and smooth progress tracking
+// src/ui/LoaderV2.tsx
+// Radial loader with phase specific rings and diamond center
 
-import React, { useState, useEffect, useRef } from 'react';
+import React from 'react';
+import styles from './LoaderV2.module.css';
 
-const LoaderV2 = ({
-  phase = 'initializing',
+const clamp = (v: number) => Math.min(1, Math.max(0, v));
+
+interface LoaderProps {
+  phase?: 'starting' | 'loading' | 'testing';
+  phaseProgress?: number; // 0..1 for active phase
+  overallProgress?: number; // 0..1 overall
+  statusMessage?: string;
+  testingProgress?: number; // optional explicit progress for testing ring
+  loadingProgress?: number; // optional explicit progress for loading ring
+}
+
+const LoaderV2: React.FC<LoaderProps> = ({
+  phase = 'starting',
   phaseProgress = 0,
   overallProgress = 0,
   statusMessage = '',
   testingProgress = 0,
   loadingProgress = 0
 }) => {
-  const [smoothOverall, setSmoothOverall] = useState(0);
-  const [smoothPhase, setSmoothPhase] = useState(0);
-  const [smoothTesting, setSmoothTesting] = useState(0);
-  const [smoothLoading, setSmoothLoading] = useState(0);
-  
-  const animationFrameRef = useRef();
+  // Loader dimensions
+  const size = 260; // matches CSS meter size
+  const stroke = parseFloat(
+    getComputedStyle(document.documentElement).getPropertyValue('--ringStroke')
+  ) || 6;
 
-  // Smooth progress animation
-  useEffect(() => {
-    const animate = () => {
-      setSmoothOverall(prev => {
-        const diff = overallProgress - prev;
-        return prev + diff * 0.1; // Smooth interpolation
-      });
-      
-      setSmoothPhase(prev => {
-        const diff = phaseProgress - prev;
-        return prev + diff * 0.15;
-      });
-      
-      setSmoothTesting(prev => {
-        const diff = testingProgress - prev;
-        return prev + diff * 0.12;
-      });
-      
-      setSmoothLoading(prev => {
-        const diff = loadingProgress - prev;
-        return prev + diff * 0.12;
-      });
-      
-      animationFrameRef.current = requestAnimationFrame(animate);
-    };
-    
-    animationFrameRef.current = requestAnimationFrame(animate);
-    
-    return () => {
-      if (animationFrameRef.current) {
-        cancelAnimationFrame(animationFrameRef.current);
-      }
-    };
-  }, [overallProgress, phaseProgress, testingProgress, loadingProgress]);
-
-  // FIXED: Correct ring mapping
-  const ringProgress = {
-    // Outer ring: Overall progress (0-100% of entire initialization)
-    outer: Math.min(smoothOverall * 100, 100),
-    
-    // Middle ring: Current phase progress (resets for each phase)
-    middle: Math.min(smoothPhase * 100, 100),
-    
-    // Inner ring: Sub-task progress (testing or loading specific progress)
-    inner: phase === 'testing' 
-      ? Math.min(smoothTesting * 100, 100)
-      : Math.min(smoothLoading * 100, 100)
-  };
-
-  const getPhaseText = () => {
-    switch (phase) {
-      case 'initializing':
-        return 'Initializing System';
-      case 'testing':
-        return 'Testing Performance';
-      case 'loading':
-        return 'Loading Assets';
-      default:
-        return 'Starting...';
-    }
-  };
-
-  const getStatusText = () => {
-    if (statusMessage) {
-      return statusMessage;
-    }
-    
-    switch (phase) {
-      case 'testing':
-        return 'Finding optimal quality settings...';
-      case 'loading':
-        return 'Loading 3D models and textures...';
-      default:
-        return 'Preparing crystal experience...';
-    }
-  };
-
-  // Ring colors
-  const ringColors = {
-    outer: '#64ffda',   // Teal - overall progress
-    middle: '#bb86fc',  // Purple - phase progress  
-    inner: '#ffd600'    // Gold - sub-task progress
-  };
-
-  const ringSize = 120;
-  const strokeWidth = 8;
-  const center = ringSize;
   const radii = [
-    ringSize - strokeWidth,      // Outer ring
-    ringSize - strokeWidth * 3,  // Middle ring  
-    ringSize - strokeWidth * 5   // Inner ring
+    size / 2 - stroke / 2,
+    size / 2 - stroke * 3 / 2,
+    size / 2 - stroke * 5 / 2
   ];
 
+  // Determine per-ring progress
+  let testing = phase === 'testing' ? phaseProgress : testingProgress;
+  let loading = phase === 'loading' ? phaseProgress : loadingProgress;
+
+  // Lock completed rings at 100%
+  if (phase === 'loading' || phase === 'starting') {
+    testing = 1;
+  }
+  if (phase === 'starting') {
+    loading = 0;
+  }
+
+  const ringProgress = {
+    outer: clamp(overallProgress) * 100,
+    middle: clamp(loading) * 100,
+    inner: clamp(testing) * 100
+  };
+
+  // Diamond sizing based on spec
+  const gap = 10;
+  const safeRadius = radii[0] - stroke * 1.5 - gap;
+  const box = safeRadius * 2.2; // safeRadius*1.1*2
+
   return (
-    <div style={{
-      position: 'fixed',
-      top: 0,
-      left: 0,
-      width: '100vw',
-      height: '100vh',
-      backgroundColor: '#0B0B0C',
-      display: 'flex',
-      flexDirection: 'column',
-      justifyContent: 'center',
-      alignItems: 'center',
-      color: '#E9E7F0',
-      fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
-      zIndex: 100000
-    }}>
-      
-      {/* Main Title */}
-      <h1 style={{
-        fontSize: 'clamp(2rem, 6vw, 4rem)',
-        fontWeight: '700',
-        background: 'linear-gradient(90deg, #64ffda, #bb86fc)',
-        WebkitBackgroundClip: 'text',
-        WebkitTextFillColor: 'transparent',
-        marginBottom: '2rem',
-        textAlign: 'center'
-      }}>
+    <div className={styles.overlay}>
+      <h1 className={styles.headline}>
         Multifaceted Designer
+        <span className={styles.subhead}></span>
       </h1>
 
-      {/* Progress Rings Container */}
-      <div style={{
-        position: 'relative',
-        width: ringSize * 2,
-        height: ringSize * 2,
-        marginBottom: '2rem'
-      }}>
-        
-        {/* SVG Progress Rings */}
-        <svg 
-          width={ringSize * 2} 
-          height={ringSize * 2}
-          style={{ position: 'absolute', top: 0, left: 0 }}
+      <div className={styles.meter}>
+        <svg
+          className={styles.svg}
+          viewBox={`-${size / 2} -${size / 2} ${size} ${size}`}
         >
-          {/* Ring backgrounds */}
-          {radii.map((radius, index) => (
+          {radii.map((r, i) => (
             <circle
-              key={`bg-${index}`}
-              cx={center}
-              cy={center}
-              r={radius}
+              key={`track-${i}`}
+              className={styles.track}
+              cx={0}
+              cy={0}
+              r={r}
               fill="none"
-              stroke="rgba(255,255,255,0.08)"
-              strokeWidth={strokeWidth}
+              stroke="var(--ringTrack)"
+              strokeWidth={stroke}
             />
           ))}
-          
-          {/* Progress rings */}
+
           {[
-            { radius: radii[0], progress: ringProgress.outer, color: ringColors.outer },
-            { radius: radii[1], progress: ringProgress.middle, color: ringColors.middle },
-            { radius: radii[2], progress: ringProgress.inner, color: ringColors.inner }
-          ].map((ring, index) => {
-            const circumference = 2 * Math.PI * ring.radius;
-            const strokeDashoffset = circumference - (ring.progress / 100) * circumference;
-            
+            { r: radii[0], color: 'var(--ring1)', progress: ringProgress.outer },
+            { r: radii[1], color: 'var(--ring2)', progress: ringProgress.middle },
+            { r: radii[2], color: 'var(--ring3)', progress: ringProgress.inner }
+          ].map((ring, i) => {
+            const circumference = 2 * Math.PI * ring.r;
+            const offset = circumference * (1 - ring.progress / 100);
             return (
               <circle
-                key={`progress-${index}`}
-                cx={center}
-                cy={center}
-                r={ring.radius}
+                key={`progress-${i}`}
+                className={styles.progress}
+                cx={0}
+                cy={0}
+                r={ring.r}
                 fill="none"
                 stroke={ring.color}
-                strokeWidth={strokeWidth}
-                strokeLinecap="round"
+                strokeWidth={stroke}
                 strokeDasharray={circumference}
-                strokeDashoffset={strokeDashoffset}
-                transform={`rotate(-90 ${center} ${center})`}
-                style={{
-                  transition: 'stroke-dashoffset 0.3s ease'
-                }}
+                strokeDashoffset={offset}
+                strokeLinecap="round"
               />
             );
           })}
+
+          <g style={{ transform: 'scale(var(--diamond-scale,1))' }}>
+            <image
+              href="/assets/ui/diamond.svg"
+              x={-box / 2}
+              y={-box / 2}
+              width={box}
+              height={box}
+              preserveAspectRatio="xMidYMid meet"
+              className={styles.diamond}
+            />
+          </g>
         </svg>
 
-        {/* Center Text */}
-        <div style={{
-          position: 'absolute',
-          top: '50%',
-          left: '50%',
-          transform: 'translate(-50%, -50%)',
-          textAlign: 'center'
-        }}>
-          <div style={{
-            fontSize: '2rem',
-            fontWeight: '600',
-            color: '#F4F2E6',
-            marginBottom: '0.25rem'
-          }}>
-            {Math.round(smoothOverall * 100)}%
-          </div>
-          <div style={{
-            fontSize: '0.875rem',
-            color: 'rgba(244, 242, 230, 0.7)',
-            fontWeight: '500'
-          }}>
-            {getPhaseText()}
-          </div>
-        </div>
+        <div className={styles.percent}>{Math.round(ringProgress.outer)}%</div>
       </div>
 
-      {/* Status Information */}
-      <div style={{
-        textAlign: 'center',
-        maxWidth: '500px',
-        padding: '0 2rem'
-      }}>
-        <div style={{
-          fontSize: '1.125rem',
-          color: '#E9E7F0',
-          marginBottom: '0.5rem',
-          fontWeight: '500'
-        }}>
-          {getStatusText()}
-        </div>
-        
-        {/* Progress Details */}
-        <div style={{
-          display: 'grid',
-          gridTemplateColumns: 'repeat(3, 1fr)',
-          gap: '1rem',
-          marginTop: '1.5rem',
-          fontSize: '0.875rem'
-        }}>
-          <div style={{ textAlign: 'center' }}>
-            <div style={{ color: ringColors.outer, fontWeight: '600' }}>
-              Overall
-            </div>
-            <div style={{ color: 'rgba(244, 242, 230, 0.8)' }}>
-              {Math.round(ringProgress.outer)}%
-            </div>
-          </div>
-          
-          <div style={{ textAlign: 'center' }}>
-            <div style={{ color: ringColors.middle, fontWeight: '600' }}>
-              {phase === 'testing' ? 'Testing' : phase === 'loading' ? 'Loading' : 'Phase'}
-            </div>
-            <div style={{ color: 'rgba(244, 242, 230, 0.8)' }}>
-              {Math.round(ringProgress.middle)}%
-            </div>
-          </div>
-          
-          <div style={{ textAlign: 'center' }}>
-            <div style={{ color: ringColors.inner, fontWeight: '600' }}>
-              {phase === 'testing' ? 'Quality' : 'Assets'}
-            </div>
-            <div style={{ color: 'rgba(244, 242, 230, 0.8)' }}>
-              {Math.round(ringProgress.inner)}%
-            </div>
-          </div>
-        </div>
-      </div>
-
-      {/* Loading Animation */}
-      <div style={{
-        marginTop: '2rem',
-        display: 'flex',
-        gap: '0.5rem'
-      }}>
-        {[0, 1, 2].map(i => (
-          <div
-            key={i}
-            style={{
-              width: '8px',
-              height: '8px',
-              borderRadius: '50%',
-              backgroundColor: '#64ffda',
-              animation: `pulse 1.5s ease-in-out ${i * 0.2}s infinite alternate`,
-              opacity: 0.7
-            }}
-          />
-        ))}
-      </div>
-
-      {/* CSS Animation */}
-      <style>
-        {`
-          @keyframes pulse {
-            0% { opacity: 0.3; transform: scale(0.8); }
-            100% { opacity: 1; transform: scale(1.2); }
-          }
-        `}
-      </style>
+      <p className={styles.status} aria-live="polite">
+        {statusMessage}
+        <span className={styles.dots}><i/><i/><i/></span>
+      </p>
     </div>
   );
 };
 
 export default LoaderV2;
+


### PR DESCRIPTION
## Summary
- Implement phase-specific LoaderV2 with diamond center and accurate radial rings
- Display performance test progress and status in debug panel
- Weight overall progress to reflect testing and asset loading phases

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689ea64dbf7c83288a224574210519ce