### PR TITLE
chore: remove unused project headline color hook import

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -36,7 +36,6 @@ import PerformanceDebugPanel from './components/ui/PerformanceDebugPanel';
 import * as defaultConfig from './crystalConfig';
 
 // Cinematic Movie Titles Effects
-import useProjectHeadlineColor from './hooks/useProjectHeadlineColor';
 import './styles/glow-70s.css';
 
 // Convert UI config into animation config


### PR DESCRIPTION
## Summary
- delete `useProjectHeadlineColor` import from App component

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a3636142a4832891211867018db404