### PR TITLE
Clean up projectBackgrounds helpers

### DIFF
--- a/src/data/projectBackgrounds.js
+++ b/src/data/projectBackgrounds.js
@@ -50,29 +50,3 @@ export const projectBackgrounds = {
     colorB: '#4d0026'  // deep fuchsia
   }
 };
-
-// ADDED: Helper function to get background info
-export const getBackgroundInfo = (key) => {
-  const background = projectBackgrounds[key] || projectBackgrounds.default;
-  return {
-    colorA: background.colorA,
-    colorB: background.colorB,
-    exists: !!projectBackgrounds[key]
-  };
-};
-
-// ADDED: Helper to get all available background keys
-export const getAvailableBackgroundKeys = () => {
-  return Object.keys(projectBackgrounds);
-};
-
-// ADDED: Debug helper to log all colors
-export const logAllBackgrounds = () => {
-  if (import.meta.env.DEV) {
-    console.group('🎨 All Project Backgrounds:');
-    Object.entries(projectBackgrounds).forEach(([key, colors]) => {
-      console.log(`${key}:`, colors);
-    });
-    console.groupEnd();
-  }
-};


### PR DESCRIPTION
## Summary
- remove unused background helper functions
- keep projectBackgrounds as the only export

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a36a497ec083289d3620a5fba95812