### PR TITLE
refactor: use performance hook v2

### DIFF
--- a/src/components/ui/FpsDisplay.jsx
+++ b/src/components/ui/FpsDisplay.jsx
@@ -3,7 +3,7 @@
 
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { useFrame } from '@react-three/fiber';
-import usePerformance from '../../hooks/usePerformance';
+import { usePerformanceV2 } from '../../hooks/usePerformanceV2';
 
 /**
  * FPS Monitor Hook for Canvas components
@@ -277,7 +277,7 @@ export const PerformanceAlert = ({
   onPerformanceIssue
 }) => {
   const { fps, avgFps } = useFPSMonitorDOM();
-  const { profile, tier, updateProfile, forceRetest } = usePerformance();
+  const { profile, tier, updateProfile, forceRetest } = usePerformanceV2();
   const threshold = profile?.minAcceptableFPS || 48; // Alert when avg FPS dips below ~48
   const [showAlert, setShowAlert] = useState(false);
   const [alertCount, setAlertCount] = useState(0);
@@ -339,7 +339,7 @@ export const PerformanceAlert = ({
   };
 
   const handleLowerQuality = () => {
-    const targetTier = tier === 'high' ? 'medium' : 'low';
+    const targetTier = tier === 'high' ? 'medium' : tier === 'medium' ? 'low' : 'low';
     console.log('PerformanceAlert: lowering quality', { from: tier, to: targetTier });
     updateProfile(targetTier);
     setShowAlert(false);

--- a/src/hooks/usePerformanceV2.js
+++ b/src/hooks/usePerformanceV2.js
@@ -119,14 +119,12 @@ export const usePerformanceV2 = () => {
 
   // Update profile manually
   const updateProfile = useCallback((newTier, overrides = {}) => {
+    console.log('usePerformanceV2: updateProfile called', { newTier, overrides });
     try {
       manager.setProfile(newTier, overrides);
       setProfile(manager.getProfile());
       setTier(manager.getTier());
-      
-      if (import.meta.env.DEV) {
-        console.log('🔧 Performance profile manually updated to:', newTier);
-      }
+      console.log('usePerformanceV2: profile updated to', newTier);
     } catch (err) {
       console.error('Failed to update performance profile:', err);
       setError(err.message);
@@ -135,6 +133,7 @@ export const usePerformanceV2 = () => {
 
   // Force retest with progress tracking
   const forceRetest = useCallback(async () => {
+    console.log('usePerformanceV2: forceRetest called');
     setIsInitializing(true);
     setError(null);
     setIsReady(false);
@@ -145,7 +144,7 @@ export const usePerformanceV2 = () => {
     manager.setProgressCallback((percentage, message) => {
       setTestProgress(percentage);
       setTestStatus(message || '');
-      
+
       // Update global HTML loader
       window.updateImmediateLoader?.({
         test: percentage,
@@ -155,12 +154,10 @@ export const usePerformanceV2 = () => {
     });
 
     try {
-      if (import.meta.env.DEV) {
-        console.log('🔧 Forcing performance retest...');
-      }
+      console.log('usePerformanceV2: starting performance retest');
 
       await manager.forceRetest();
-      
+
       setProfile(manager.getProfile());
       setTier(manager.getTier());
       setTestResults(manager.getTestResults());
@@ -168,12 +165,10 @@ export const usePerformanceV2 = () => {
       setIsInitializing(false);
       setTestProgress(100);
 
-      if (import.meta.env.DEV) {
-        console.log('🔧 Performance retest complete:', {
-          tier: manager.getTier(),
-          results: manager.getTestResults()
-        });
-      }
+      console.log('usePerformanceV2: performance retest complete', {
+        tier: manager.getTier(),
+        results: manager.getTestResults()
+      });
     } catch (err) {
       console.error('Performance retest failed:', err);
       setError(err.message);


### PR DESCRIPTION
## Summary
- refactor FpsDisplay to use usePerformanceV2 and sequential quality downgrades
- log forceRetest and updateProfile calls in usePerformanceV2

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a53c46e350832883f8e814046c9472