### PR TITLE
Flatten performance results for current tier

### DIFF
--- a/src/components/ui/PerformanceDebugPanel.jsx
+++ b/src/components/ui/PerformanceDebugPanel.jsx
@@ -119,13 +119,18 @@ const PerformanceDebugPanel = ({
         {testResults && (
           <div>
             <div style={{ color: '#bb86fc', fontWeight: 'bold', marginBottom: '8px' }}>Test Results:</div>
-            <div>Average FPS: <span style={{ color: '#64ffda' }}>{Math.round(testResults.avgFps || 0)}</span></div>
-            <div>Min FPS: <span style={{ color: testResults.minFps > 25 ? '#4CAF50' : '#F44336' }}>{Math.round(testResults.minFps || 0)}</span></div>
-            <div>Max FPS: <span style={{ color: '#4CAF50' }}>{Math.round(testResults.maxFps || 0)}</span></div>
-            <div>Test Tier: {testResults.tier}</div>
-            <div>Frame Count: {testResults.frameCount || 0}</div>
-            <div>Samples: {testResults.samples || 0}</div>
-            {testResults.recommendedTier && (
+            <div>Average FPS: <span style={{ color: '#64ffda' }}>{Math.round(testResults?.avgFps ?? 0)}</span></div>
+            <div>
+              Min FPS:{' '}
+              <span style={{ color: (testResults?.minFps ?? 0) > 25 ? '#4CAF50' : '#F44336' }}>
+                {Math.round(testResults?.minFps ?? 0)}
+              </span>
+            </div>
+            <div>Max FPS: <span style={{ color: '#4CAF50' }}>{Math.round(testResults?.maxFps ?? 0)}</span></div>
+            <div>Test Tier: {testResults?.tier ?? 'unknown'}</div>
+            <div>Frame Count: {testResults?.frameCount ?? 0}</div>
+            <div>Samples: {testResults?.samples ?? 0}</div>
+            {testResults?.recommendedTier && (
               <div>Recommended: <span style={{ color: '#ffd600' }}>{testResults.recommendedTier}</span></div>
             )}
           </div>

--- a/src/hooks/usePerformanceV2.js
+++ b/src/hooks/usePerformanceV2.js
@@ -13,7 +13,7 @@ export const usePerformanceV2 = () => {
   const [isReady, setIsReady] = useState(manager.isReady());
   const [isInitializing, setIsInitializing] = useState(false);
   const [error, setError] = useState(null);
-  const [testResults, setTestResults] = useState(manager.getTestResults());
+  const [testResults, setTestResults] = useState(manager.getTestResults() || null);
   const [testProgress, setTestProgress] = useState(0);
   const [testStatus, setTestStatus] = useState('');
 
@@ -27,7 +27,7 @@ export const usePerformanceV2 = () => {
         setProfile(manager.getProfile());
         setTier(manager.getTier());
         setIsReady(true);
-        setTestResults(manager.getTestResults());
+        setTestResults(manager.getTestResults() || null);
         
         if (import.meta.env.DEV) {
           console.log('🔧 Using cached performance profile:', manager.getTier());
@@ -66,7 +66,7 @@ export const usePerformanceV2 = () => {
           setProfile(manager.getProfile());
           setTier(manager.getTier());
           setIsReady(true);
-          setTestResults(manager.getTestResults());
+          setTestResults(manager.getTestResults() || null);
           setIsInitializing(false);
           setTestProgress(100);
 
@@ -124,6 +124,7 @@ export const usePerformanceV2 = () => {
       manager.setProfile(newTier, overrides);
       setProfile(manager.getProfile());
       setTier(manager.getTier());
+      setTestResults(manager.getTestResults() || null);
       console.log('usePerformanceV2: profile updated to', newTier);
     } catch (err) {
       console.error('Failed to update performance profile:', err);
@@ -160,7 +161,7 @@ export const usePerformanceV2 = () => {
 
       setProfile(manager.getProfile());
       setTier(manager.getTier());
-      setTestResults(manager.getTestResults());
+      setTestResults(manager.getTestResults() || null);
       setIsReady(true);
       setIsInitializing(false);
       setTestProgress(100);
@@ -202,22 +203,6 @@ export const usePerformanceV2 = () => {
       });
     }
     
-    if (testResults && Object.keys(testResults).length > 1) {
-      const availableTiers = Object.keys(testResults);
-      const higherTiers = availableTiers.filter(t => 
-        (tier === 'low' && (t === 'medium' || t === 'high')) ||
-        (tier === 'medium' && t === 'high')
-      );
-      
-      if (higherTiers.length > 0) {
-        recommendations.push({
-          type: 'upgrade',
-          message: `Your device may support ${higherTiers.join(' or ')} quality`,
-          action: () => updateProfile(higherTiers[0])
-        });
-      }
-    }
-    
     if (error) {
       recommendations.push({
         type: 'error',
@@ -225,9 +210,9 @@ export const usePerformanceV2 = () => {
         action: 'Try refreshing the page or retesting'
       });
     }
-    
+
     return recommendations;
-  }, [tier, testResults, error, updateProfile]);
+  }, [tier, error]);
 
   // Debug info
   const debugInfo = {

--- a/src/utils/PerformanceManagerV2.js
+++ b/src/utils/PerformanceManagerV2.js
@@ -41,10 +41,13 @@ export default class PerformanceManagerV2 {
       if (import.meta.env.DEV) {
         console.log('🔧 Using cached performance profile:', cachedData.tier);
       }
-      
+
       this.tier = cachedData.tier;
       this.profile = { ...PERFORMANCE_PROFILES[cachedData.tier] };
-      this._testResults = cachedData.testResults;
+      // Store only the flattened result for the active tier
+      this._testResults = cachedData.testResults?.tier
+        ? cachedData.testResults
+        : { ...cachedData.testResults, tier: cachedData.tier };
       this._ready = true;
       return;
     }
@@ -58,10 +61,13 @@ export default class PerformanceManagerV2 {
 
       this.tier = tier;
       this.profile = { ...PERFORMANCE_PROFILES[tier] };
-      this._testResults = testResults;
 
-      // Cache results
-      this._cacheResults(tier, testResults);
+      // Store only the result for the selected tier
+      const tierResult = testResults?.[tier] || null;
+      this._testResults = tierResult;
+
+      // Cache flattened results
+      this._cacheResults(tier, tierResult);
 
       if (import.meta.env.DEV) {
         console.log('🔧 Conservative performance test complete:', {
@@ -434,7 +440,18 @@ export default class PerformanceManagerV2 {
   }
 
   getTestResults() {
-    return this._testResults;
+    // Always return a flattened result for the active tier
+    if (!this._testResults) return null;
+
+    // If already flattened, return as-is
+    if (this._testResults.tier) return this._testResults;
+
+    // Backwards compatibility: if results for all tiers were stored, pick current tier
+    if (this._testResults[this.tier]) {
+      return this._testResults[this.tier];
+    }
+
+    return null;
   }
 
   setProfile(tier, overrides = {}) {


### PR DESCRIPTION
## Summary
- Persist performance test results as a flattened object for the active tier
- Update hook to retrieve results with null guards and simpler recommendations
- Guard debug panel metrics against null/undefined values

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a54ef3d91c8328b8ab436665087f1c