### PR TITLE
Initialize performance debug off by default

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -135,7 +135,7 @@ function App() {
   
   // Basic state hooks
   const [hideAllUI, setHideAllUI] = useState(false);
-  const [perfDebug, setPerfDebug] = useState(window.__PERF_DEBUG__ || false);
+  const [perfDebug, setPerfDebug] = useState(false);
   const [snapSpeed, setSnapSpeed] = useState('medium');
   const [config, setConfig] = useState({
     ...defaultConfig,
@@ -589,7 +589,7 @@ function App() {
       )}
 
       {/* UPDATED: Enhanced Debug Panel with V2 performance system info */}
-      {(import.meta.env.DEV || perfDebug) && (
+      {perfDebug && (
         <PerformanceDebugPanel
           performanceConfig={performanceProfile}
           hasInitialized={performanceReady}


### PR DESCRIPTION
## Summary
- default `perfDebug` state to `false`
- only render `PerformanceDebugPanel` when `perfDebug` is enabled

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a550bf1c4883289e444bd50d9d8337