### PR TITLE
feat: support render scale updates

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -299,6 +299,12 @@ function App() {
       const overrides = newTier === 'low' ? { simplifiedAnimations: false } : {};
       updateProfile(newTier, overrides);
     } else if (
+      typeof newConfig.renderScale === 'number' &&
+      newConfig.renderScale !== performanceProfile.renderScale
+    ) {
+      // Allow manual adjustment of render scale
+      updateProfile(performanceTier, { renderScale: newConfig.renderScale });
+    } else if (
       typeof newConfig.simplifiedAnimations === 'boolean' &&
       newConfig.simplifiedAnimations !== performanceProfile.simplifiedAnimations
     ) {
@@ -376,7 +382,11 @@ function App() {
         antialias: performanceProfile.antialiasing !== false,
         powerPreference: performanceTier === 'high' ? 'high-performance' : 'default'
       },
-      dpr: [1, Math.min(performanceProfile.maxPixelRatio || 2, window.devicePixelRatio)]
+      dpr: [
+        1,
+        Math.min(performanceProfile.maxPixelRatio || 2, window.devicePixelRatio) *
+          (performanceProfile.renderScale || 1)
+      ]
     };
   }, [performanceProfile, performanceTier]);
 
@@ -471,6 +481,7 @@ function App() {
       >
         {/* Fixed 3D Canvas */}
         <Fixed3DCanvas
+          key={performanceProfile?.renderScale}
           ref={fixedCanvasRef}
           materialVariant={materialVariant}
           effectsEnabled={effectsEnabled}

--- a/src/components/layout/Fixed3DCanvas.jsx
+++ b/src/components/layout/Fixed3DCanvas.jsx
@@ -199,12 +199,13 @@ const Fixed3DCanvas = forwardRef(({
         pointerEvents: 'none', // Don't block scrolling
       }}>
         <Canvas
+          key={Array.isArray(canvasProps.dpr) ? canvasProps.dpr.join('-') : canvasProps.dpr}
           camera={{
             position: config?.camera?.startingPosition || [0, 0, 4.5],
             fov: config?.camera?.fov || 45
           }}
           {...canvasProps}
-          gl={{ 
+          gl={{
             toneMapping: THREE.ACESFilmicToneMapping,
             toneMappingExposure: 0.2,
             outputColorSpace: THREE.SRGBColorSpace,

--- a/src/hooks/usePerformanceV2.js
+++ b/src/hooks/usePerformanceV2.js
@@ -121,7 +121,16 @@ export const usePerformanceV2 = () => {
   const updateProfile = useCallback((newTier, overrides = {}) => {
     console.log('usePerformanceV2: updateProfile called', { newTier, overrides });
     try {
-      manager.setProfile(newTier, overrides);
+      // Explicitly allow renderScale overrides (numeric only)
+      const allowedOverrides = { ...overrides };
+      if (overrides.renderScale !== undefined) {
+        const numeric = Number(overrides.renderScale);
+        if (!Number.isNaN(numeric)) {
+          allowedOverrides.renderScale = numeric;
+        }
+      }
+
+      manager.setProfile(newTier, allowedOverrides);
       setProfile(manager.getProfile());
       setTier(manager.getTier());
       setTestResults(manager.getTestResults() || null);


### PR DESCRIPTION
## Summary
- allow updating renderScale via performance profile and propagate to canvas DPR
- include renderScale in DPR calculations and force canvas remounts when it changes
- ensure Canvas re-renders when device pixel ratio changes

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a55288f4888328bc2357a1995a1c18