### PR TITLE
Add project metadata fields and logos

### DIFF
--- a/public/assets/logos/craft.svg
+++ b/public/assets/logos/craft.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <polygon points="50,20 80,50 50,80 20,50" fill="#03dac6" />
+</svg>

--- a/public/assets/logos/empathy.svg
+++ b/public/assets/logos/empathy.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="40" fill="#64ffda" />
+</svg>

--- a/public/assets/logos/exploration.svg
+++ b/public/assets/logos/exploration.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <polygon points="50,20 80,80 20,80" fill="#ff7043" />
+</svg>

--- a/public/assets/logos/leadership.svg
+++ b/public/assets/logos/leadership.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <polygon points="50,15 61,39 88,39 66,57 74,84 50,68 26,84 34,57 12,39 39,39" fill="#ffd600" />
+</svg>

--- a/public/assets/logos/narrative.svg
+++ b/public/assets/logos/narrative.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="20" y="20" width="60" height="60" fill="#bb86fc" />
+</svg>

--- a/public/assets/logos/system.svg
+++ b/public/assets/logos/system.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="30" y="10" width="40" height="80" fill="#cf6679" />
+  <rect x="10" y="30" width="80" height="40" fill="#cf6679" />
+</svg>

--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -11,6 +11,10 @@ export const projects = [
     id: "project1",
     facetKey: "empathy", // Maps to existing facet
     title: "User-Centered Dashboard",
+    label: "EMPATHY",
+    tagline: "Data with heart",
+    shortDescription: "User-focused dashboard simplifying complex data",
+    logo: "/assets/logos/empathy.svg",
     description: "A dashboard designed with user needs at the forefront, featuring intuitive navigation and data visualization. Uses research-driven design to simplify complex data for quick decision making.",
     technologies: ["React", "D3.js", "Figma", "User Research"],
     color: "#64ffda", // Match the facet color
@@ -27,6 +31,10 @@ export const projects = [
     id: "project2",
     facetKey: "narrative",
     title: "Interactive Storytelling Platform",
+    label: "NARRATIVE",
+    tagline: "Stories that move",
+    shortDescription: "Interactive platform weaving narratives with rich visuals",
+    logo: "/assets/logos/narrative.svg",
     description: "A platform that guides users through narratives with compelling visuals and interaction. Creates immersive experiences that communicate complex ideas through story-driven interfaces.",
     technologies: ["Three.js", "GSAP", "React", "Storyboarding"],
     color: "#bb86fc", // Match the facet color
@@ -43,6 +51,10 @@ export const projects = [
     id: "project3",
     facetKey: "craft",
     title: "Design System Implementation",
+    label: "CRAFT",
+    tagline: "Precision in every component",
+    shortDescription: "Design system enabling scalable, polished UI patterns",
+    logo: "/assets/logos/craft.svg",
     description: "A meticulously crafted design system with attention to detail and consistency. Provides a foundation for scalable product development with precision-engineered components.",
     technologies: ["Styled Components", "Storybook", "Figma", "Design Tokens"],
     color: "#03dac6", // Match the facet color
@@ -59,6 +71,10 @@ export const projects = [
     id: "project4",
     facetKey: "system",
     title: "Component Architecture",
+    label: "SYSTEM",
+    tagline: "Structure for scale",
+    shortDescription: "Reusable component architecture backed by thorough docs",
+    logo: "/assets/logos/system.svg",
     description: "A comprehensive component library with scalable architecture and documentation. Built for maximum reusability and maintainability across multiple applications and teams.",
     technologies: ["React", "TypeScript", "Monorepo", "CI/CD"],
     color: "#cf6679", // Match the facet color
@@ -75,6 +91,10 @@ export const projects = [
     id: "project5",
     facetKey: "leadership",
     title: "Team Collaboration Platform",
+    label: "LEADERSHIP",
+    tagline: "Leading teams to synergy",
+    shortDescription: "Collaboration platform aligning cross-discipline teams",
+    logo: "/assets/logos/leadership.svg",
     description: "A tool designed to empower teams and facilitate collaboration across disciplines. Streamlines communication and workflow between design, development, and product teams.",
     technologies: ["Next.js", "Firebase", "Tailwind CSS", "User Testing"],
     color: "#ffd600", // Match the facet color
@@ -91,6 +111,10 @@ export const projects = [
     id: "project6",
     facetKey: "exploration",
     title: "Experimental Interactions",
+    label: "EXPLORATION",
+    tagline: "Pushing interaction boundaries",
+    shortDescription: "Experimental prototypes exploring novel interface ideas",
+    logo: "/assets/logos/exploration.svg",
     description: "A collection of experimental interaction prototypes exploring new paradigms. Pushes boundaries with cutting-edge techniques and technologies to discover novel ways of engaging users.",
     technologies: ["WebGL", "React Three Fiber", "Shaders", "Motion Design"],
     color: "#ff7043", // Match the facet color


### PR DESCRIPTION
## Summary
- enrich project data with label, tagline, shortDescription, and logo fields for each facet
- include corresponding SVG logo placeholders

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a621201fb083288ab303119c328866