### PR TITLE
Add interactive facet labels to crystal overview

### DIFF
--- a/src/components/three/FacetLabels.jsx
+++ b/src/components/three/FacetLabels.jsx
@@ -1,0 +1,96 @@
+import React, { useRef, useState } from 'react';
+import { Html } from '@react-three/drei';
+import { useFrame } from '@react-three/fiber';
+import Headline from '../ui/Headline';
+import { deriveGlowFromBase } from '../../utils/color';
+import { ANIMATION_CONFIG } from '../../hooks/useUnifiedAnimationController';
+
+const FacetLabels = ({ anchors = {}, projects = [], animationData }) => {
+  const groupRefs = useRef({});
+
+  useFrame(() => {
+    Object.entries(anchors).forEach(([key, anchor]) => {
+      const group = groupRefs.current[key];
+      if (anchor && group) {
+        anchor.getWorldPosition(group.position);
+      }
+    });
+  });
+
+  return (
+    <>
+      {projects.map((project) => {
+        const { facetKey } = project;
+        const anchor = anchors[facetKey];
+        if (!anchor) return null;
+
+        const { glow1, glow2 } = deriveGlowFromBase(project.headlineColor);
+
+        return (
+          <group
+            key={facetKey}
+            ref={(ref) => {
+              if (ref) groupRefs.current[facetKey] = ref;
+            }}
+          >
+            <Html center style={{ pointerEvents: 'auto' }}>
+              <Label
+                project={project}
+                glow1={glow1}
+                glow2={glow2}
+                onClick={() =>
+                  animationData.scrollToProgress(
+                    ANIMATION_CONFIG.projectSections[facetKey].start
+                  )
+                }
+              />
+            </Html>
+          </group>
+        );
+      })}
+    </>
+  );
+};
+
+const Label = ({ project, onClick, glow1, glow2 }) => {
+  const [hovered, setHovered] = useState(false);
+
+  return (
+    <div
+      onPointerEnter={() => setHovered(true)}
+      onPointerLeave={() => setHovered(false)}
+      onClick={onClick}
+      style={{
+        cursor: 'pointer',
+        transform: hovered ? 'scale(1.1)' : 'scale(1)',
+        transition: 'transform 0.2s',
+        textAlign: 'center',
+        userSelect: 'none',
+      }}
+    >
+      <Headline
+        as="h3"
+        style={{
+          margin: 0,
+          fontSize: '1rem',
+          '--headline-ink': project.headlineColor,
+          '--headline-glow1': glow1,
+          '--headline-glow2': glow2,
+        }}
+      >
+        {project.label}
+      </Headline>
+      <div
+        style={{
+          marginTop: '0.25rem',
+          fontSize: '0.75rem',
+          color: 'rgba(255, 255, 255, 0.8)',
+        }}
+      >
+        {project.tagline}
+      </div>
+    </div>
+  );
+};
+
+export default FacetLabels;

--- a/src/components/three/UnifiedCrystalScene.jsx
+++ b/src/components/three/UnifiedCrystalScene.jsx
@@ -12,6 +12,8 @@ import MaterialManager from './MaterialManager'
 // Import enhanced sphere component
 import GlowingSphereImage, { BLENDING_MODES } from './GlowingSphereImage'
 import { getProjectColorByFacetKey } from '../../data/projects'
+import FacetLabels from './FacetLabels'
+import projects from '../../data/projects'
 
 const UnifiedCrystalScene = forwardRef(({ 
   animationData,
@@ -168,6 +170,18 @@ const UnifiedCrystalScene = forwardRef(({
       setModelsLoaded(true);
     }
   }, [wholeCrystal, ...facetModels]);
+
+  const facetAnchors = useMemo(() => {
+    const anchors = {}
+    facetKeys.forEach((facetKey, index) => {
+      const facetRef = facetRefs.current[index]?.current
+      if (facetRef) {
+        const anchor = facetRef.getObjectByName(`anchor_${facetKey}`)
+        if (anchor) anchors[facetKey] = anchor
+      }
+    })
+    return anchors
+  }, [facetKeys, showFacets, modelsLoaded])
   
   // Keyboard listener for debug toggle
   useEffect(() => {
@@ -508,13 +522,17 @@ const UnifiedCrystalScene = forwardRef(({
         return (
           <primitive
             key={facetKey}
-            ref={facetRefs.current[index]} 
+            ref={facetRefs.current[index]}
             object={model.scene}
             position={[0, 0, 0]} // Position will be animated via useFrame
           />
         );
       })}
-      
+
+      {animationData.currentZone === 'overview' && animationData.crystalForm === 'exploded' && (
+        <FacetLabels anchors={facetAnchors} projects={projects} animationData={animationData} />
+      )}
+
       {/* Debug visualization when enabled */}
       {showCrystalDebug && showFacets && !simplifiedAnimations && (
         <group name="anchor-debug-system">


### PR DESCRIPTION
## Summary
- Render clickable facet labels anchored to crystal facets
- Display facet names and taglines with 1970s headline styling
- Integrate labels into UnifiedCrystalScene and link to project sections

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a624a119b88328aac1d0b75141715c