### PR TITLE
Fix repeated material recreation interfering with hover colors

### DIFF
--- a/src/components/three/MaterialManager.jsx
+++ b/src/components/three/MaterialManager.jsx
@@ -492,4 +492,4 @@ const MaterialManager = ({
   );
 };
 
-export default MaterialManager;
+export default React.memo(MaterialManager);

--- a/src/components/three/MaterialManager.jsx
+++ b/src/components/three/MaterialManager.jsx
@@ -492,4 +492,26 @@ const MaterialManager = ({
   );
 };
 
-export default React.memo(MaterialManager);
+// Prevent unnecessary re-renders that recreate materials and reset facet colors
+const propsAreEqual = (prevProps, nextProps) => {
+  // Compare primitive props normally
+  if (prevProps.materialVariant !== nextProps.materialVariant) return false;
+
+  // Compare performance profile deeply since parent may pass a new object each render
+  const prevPerf = JSON.stringify(prevProps.performanceProfile || {});
+  const nextPerf = JSON.stringify(nextProps.performanceProfile || {});
+  if (prevPerf !== nextPerf) return false;
+
+  // Only react to config changes when crystal colors actually change
+  const prevColor = prevProps.config?.materials?.crystal?.color?.getHexString?.();
+  const nextColor = nextProps.config?.materials?.crystal?.color?.getHexString?.();
+  if (prevColor !== nextColor) return false;
+
+  const prevEmissive = prevProps.config?.materials?.crystal?.emissive?.getHexString?.();
+  const nextEmissive = nextProps.config?.materials?.crystal?.emissive?.getHexString?.();
+  if (prevEmissive !== nextEmissive) return false;
+
+  return true;
+};
+
+export default React.memo(MaterialManager, propsAreEqual);

--- a/src/components/three/UnifiedCrystalScene.jsx
+++ b/src/components/three/UnifiedCrystalScene.jsx
@@ -59,12 +59,16 @@ const UnifiedCrystalScene = forwardRef(({
 
   // Track material updates so we can reapply when ready
   const [materialVersion, setMaterialVersion] = useState(0);
+  const lastMaterialRef = useRef(null);
 
   // Track when GLTF models have loaded
   const [modelsLoaded, setModelsLoaded] = useState(false);
 
-  const handleMaterialReady = useCallback(() => {
-    setMaterialVersion(v => v + 1);
+  const handleMaterialReady = useCallback((mat) => {
+    if (mat && lastMaterialRef.current !== mat) {
+      lastMaterialRef.current = mat;
+      setMaterialVersion(v => v + 1);
+    }
   }, []);
 
   


### PR DESCRIPTION
## Summary
- Memoize MaterialManager to prevent rerenders from recreating materials every frame
- Track last material reference so UnifiedCrystalScene only reacts to real material changes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a66bd1023c832887b3546c4dca8787