### PR TITLE
Remove StrictMode wrapper for App rendering

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,12 +1,7 @@
-import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App.jsx';
 
 const rootEl = document.getElementById('root');
 
-createRoot(rootEl).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
-);
+createRoot(rootEl).render(<App />);


### PR DESCRIPTION
## Summary
- render `App` directly without `React.StrictMode`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a676af73f4832893d55f9eaf952efb