### PR TITLE
refactor: memoize animation data and optimize scene rerenders

### DIFF
--- a/src/components/layout/Fixed3DCanvas.jsx
+++ b/src/components/layout/Fixed3DCanvas.jsx
@@ -62,7 +62,8 @@ const Fixed3DCanvas = forwardRef(({
   config,
   canvasProps = {},
   environmentProps = {},
-  isMobile = false
+  isMobile = false,
+  scrollToProgress
 }, ref) => {
   // NEW: Ref to access crystal scene for debug panels
   const crystalSceneRef = useRef();
@@ -298,6 +299,7 @@ const Fixed3DCanvas = forwardRef(({
             performanceProfile={performanceProfile}
             isMobile={isMobile}
             simplifiedAnimations={simplifiedAnimations}
+            scrollToProgress={scrollToProgress}
           />
           
           {/* Environment used for reflections only */}

--- a/src/components/three/FacetLabels.jsx
+++ b/src/components/three/FacetLabels.jsx
@@ -6,7 +6,7 @@ import { deriveGlowFromBase } from '../../utils/color';
 import { ANIMATION_CONFIG } from '../../hooks/useUnifiedAnimationController';
 import '../../styles/facet-label.css';
 
-const FacetLabels = ({ anchors = {}, projects = [], animationData, onHoverChange }) => {
+const FacetLabels = ({ anchors = {}, projects = [], scrollToProgress, onHoverChange }) => {
   const groupRefs = useRef({});
 
   useFrame(() => {
@@ -41,7 +41,7 @@ const FacetLabels = ({ anchors = {}, projects = [], animationData, onHoverChange
                 glow1={glow1}
                 glow2={glow2}
                 onClick={() =>
-                  animationData.scrollToProgress(
+                  scrollToProgress(
                     ANIMATION_CONFIG.projectSections[facetKey].start
                   )
                 }

--- a/src/components/three/MasterAnimationCoordinator.jsx
+++ b/src/components/three/MasterAnimationCoordinator.jsx
@@ -5,6 +5,7 @@ import { useScrollProgress } from '../../hooks/useScrollProgress';
 import { useUnifiedAnimationController } from '../../hooks/useUnifiedAnimationController';
 
 let exportedAnimationData = {};
+let exportedScrollMetrics = {};
 
 /**
  * SIMPLIFIED: Master Animation Coordinator with keyboard-controlled debug
@@ -72,58 +73,63 @@ const MasterAnimationCoordinator = ({
     }
   }, [scrollData.scrollProgress, animationController]);
 
-  // SIMPLIFIED: Animation data with immediate state information
-  const animationData = useMemo(() => ({
-    // Core animation state (immediate)
-    ...animationController.animationState,
-
-    // Enhanced scroll info
+  // Memoize scroll metrics separately so components that don't care about
+  // scrolling won't re-render on every scroll tick
+  const scrollMetrics = useMemo(() => ({
     scrollProgress: scrollData.scrollProgress,
     isScrolling: scrollData.isScrolling,
     isFastScrolling: scrollData.isFastScrolling,
-    scrollVelocity: scrollData.velocity,
-
-    // Immediate configurations (no complex coordination needed)
-    cameraConfig: animationController.cameraConfig,
-    crystalConfig: animationController.crystalConfig,
-
-    // Enhanced zone information
-    currentZone: animationController.animationState.zoneInfo?.zone,
-    zoneProgress: animationController.animationState.zoneInfo?.progress,
-    isEnteringZone: animationController.animationState.zoneInfo?.isEntering,
-    isLeavingZone: animationController.animationState.zoneInfo?.isLeaving,
-
-    // Enhanced project information
-    focusedProject: animationController.animationState.focusedFacet,
-    projectProgress: animationController.animationState.projectInfo?.progress,
-
-    // SIMPLIFIED: isTransitioning is managed by individual components
-    isTransitioning: false, // Components handle their own smooth transitions
-
-    // Utility functions
-    scrollToProgress: scrollData.scrollToProgress,
-    scrollToZone: (zoneName) => scrollData.scrollToZone?.(zoneName, animationController.config.scrollZones),
-    overrideAnimationState: animationController.overrideState || (() => {})
+    scrollVelocity: scrollData.velocity
   }), [
-    animationController.animationState,
-    animationController.cameraConfig,
-    animationController.crystalConfig,
     scrollData.scrollProgress,
     scrollData.isScrolling,
     scrollData.isFastScrolling,
-    scrollData.velocity,
+    scrollData.velocity
+  ]);
+
+  exportedScrollMetrics = scrollMetrics;
+
+  // Stable scroll controls - primarily used for label clicks
+  const scrollControls = useMemo(() => ({
+    scrollToProgress: scrollData.scrollToProgress,
+    scrollToZone: (zoneName) =>
+      scrollData.scrollToZone?.(zoneName, animationController.config.scrollZones)
+  }), [
     scrollData.scrollToProgress,
     scrollData.scrollToZone,
-    animationController.config?.scrollZones,
-    animationController.overrideState
+    animationController.config?.scrollZones
+  ]);
+
+  // Core animation data consumed by 3D components
+  const animationData = useMemo(() => ({
+    state: animationController.animationState.state,
+    crystalForm: animationController.animationState.crystalForm,
+    cameraState: animationController.animationState.cameraState,
+    focusedFacet: animationController.animationState.focusedFacet,
+    focusedProject: animationController.animationState.projectInfo?.project,
+    projectProgress: animationController.animationState.projectInfo?.progress,
+    isTransitioning: animationController.animationState.isTransitioning,
+    cameraConfig: animationController.cameraConfig,
+    crystalConfig: animationController.crystalConfig,
+    currentZone: animationController.animationState.zoneInfo?.zone,
+    zoneProgress: animationController.animationState.zoneInfo?.progress,
+    isEnteringZone: animationController.animationState.zoneInfo?.isEntering,
+    isLeavingZone: animationController.animationState.zoneInfo?.isLeaving
+  }), [
+    animationController.animationState,
+    animationController.cameraConfig,
+    animationController.crystalConfig
   ]);
 
   exportedAnimationData = animationData;
 
-  // Clone children and pass simplified animation data
+  // Clone children and pass only required fields
   const childrenWithProps = React.Children.map(children, child => {
     if (React.isValidElement(child)) {
-      return React.cloneElement(child, { animationData });
+      return React.cloneElement(child, {
+        animationData,
+        scrollToProgress: scrollControls.scrollToProgress
+      });
     }
     return child;
   });
@@ -232,5 +238,5 @@ const DebugOverlay = ({ scrollData, animationData, animationController }) => {
   );
 };
 
-export { exportedAnimationData as animationData };
+export { exportedAnimationData as animationData, exportedScrollMetrics as scrollMetrics };
 export default MasterAnimationCoordinator;

--- a/src/components/three/MaterialManager.jsx
+++ b/src/components/three/MaterialManager.jsx
@@ -492,4 +492,4 @@ const MaterialManager = ({
   );
 };
 
-export default MaterialManager;
+export default React.memo(MaterialManager);

--- a/src/components/three/UnifiedCrystalScene.jsx
+++ b/src/components/three/UnifiedCrystalScene.jsx
@@ -21,7 +21,8 @@ const UnifiedCrystalScene = forwardRef(({
   materialVariant = 'default',
   performanceProfile = { useNormalMaps: true, textureQuality: 'high', pbrQuality: 'high', usePBR: true },
   isMobile = false,
-  simplifiedAnimations = false
+  simplifiedAnimations = false,
+  scrollToProgress
 }, ref) => {
   // Component refs for crystal animation
   const crystalGroupRef = useRef();
@@ -634,7 +635,7 @@ const UnifiedCrystalScene = forwardRef(({
         <FacetLabels
           anchors={facetAnchors}
           projects={projects}
-          animationData={animationData}
+          scrollToProgress={scrollToProgress}
           onHoverChange={handleLabelHover}
         />
       )}
@@ -704,4 +705,4 @@ const UnifiedCrystalScene = forwardRef(({
 // Set display name for debugging
 UnifiedCrystalScene.displayName = 'UnifiedCrystalScene';
 
-export default UnifiedCrystalScene;
+export default React.memo(UnifiedCrystalScene);


### PR DESCRIPTION
## Summary
- split animation state and scroll metrics in `MasterAnimationCoordinator`
- pass only needed scroll controls downstream
- memoize `MaterialManager` and `UnifiedCrystalScene` to limit rerenders

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint src/components/three/MasterAnimationCoordinator.jsx src/components/three/UnifiedCrystalScene.jsx src/components/three/MaterialManager.jsx src/components/three/FacetLabels.jsx src/components/layout/Fixed3DCanvas.jsx` *(fails: Key "languageOptions" ...)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a67898a2f08328ae7b155d74bd0f3b