### PR TITLE
Normalize focused facet values for stable hover colors

### DIFF
--- a/src/components/three/MasterAnimationCoordinator.jsx
+++ b/src/components/three/MasterAnimationCoordinator.jsx
@@ -105,7 +105,8 @@ const MasterAnimationCoordinator = ({
     state: animationController.animationState.state,
     crystalForm: animationController.animationState.crystalForm,
     cameraState: animationController.animationState.cameraState,
-    focusedFacet: animationController.animationState.focusedFacet,
+    // Normalize undefined to null so consumers can rely on explicit null check
+    focusedFacet: animationController.animationState.focusedFacet ?? null,
     focusedProject: animationController.animationState.projectInfo?.project,
     projectProgress: animationController.animationState.projectInfo?.progress,
     isTransitioning: animationController.animationState.isTransitioning,

--- a/src/components/three/UnifiedCrystalScene.jsx
+++ b/src/components/three/UnifiedCrystalScene.jsx
@@ -427,7 +427,7 @@ const UnifiedCrystalScene = forwardRef(({
       });
       activeFacetRef.current = nextFacet;
     }
-  }, [animationData?.focusedFacet, materialVersion, facetKeys, projectColors, hoveredFacet]);
+  }, [animationData?.focusedFacet ?? null, materialVersion, facetKeys, projectColors, hoveredFacet]);
   
   // Crystal form change detection
   useEffect(() => {


### PR DESCRIPTION
## Summary
- ensure `focusedFacet` in `animationData` defaults to `null`
- use explicit `null` in `UnifiedCrystalScene` effect dependencies to avoid unnecessary resets

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a681b13a2c8328b14a8190d73b87d3