### PR TITLE
Avoid redundant performance profile updates

### DIFF
--- a/src/hooks/usePerformanceV2.js
+++ b/src/hooks/usePerformanceV2.js
@@ -1,261 +1,32 @@
 // src/hooks/usePerformanceV2.js
-// FIXED: Enhanced performance hook with proper error handling and progress tracking
+// TEMPORARY: Return a static performance profile for debugging UI color stability
 
-import { useState, useEffect, useCallback } from 'react';
-import PerformanceManagerV2 from '../utils/PerformanceManagerV2.js';
-
-// Single manager instance to avoid multiple tests
-const manager = new PerformanceManagerV2();
+import { PERFORMANCE_PROFILES } from '../utils/deviceProfiles.js';
 
 export const usePerformanceV2 = () => {
-  const [profile, setProfile] = useState(manager.getProfile());
-  const [tier, setTier] = useState(manager.getTier());
-  const [isReady, setIsReady] = useState(manager.isReady());
-  const [isInitializing, setIsInitializing] = useState(false);
-  const [error, setError] = useState(null);
-  const [testResults, setTestResults] = useState(manager.getTestResults() || null);
-  const [testProgress, setTestProgress] = useState(0);
-  const [testStatus, setTestStatus] = useState('');
-
-  // Initialize performance manager with progress tracking
-  useEffect(() => {
-    let mounted = true;
-
-    const initializeManager = async () => {
-      if (manager.isReady()) {
-        // Already ready - use cached results
-        setProfile(manager.getProfile());
-        setTier(manager.getTier());
-        setIsReady(true);
-        setTestResults(manager.getTestResults() || null);
-        
-        if (import.meta.env.DEV) {
-          console.log('🔧 Using cached performance profile:', manager.getTier());
-        }
-        return;
-      }
-
-      setIsInitializing(true);
-      setError(null);
-      setTestProgress(0);
-      setTestStatus('');
-
-      // Set up progress callback for real-time updates
-      manager.setProgressCallback((percentage, message) => {
-        if (mounted) {
-          setTestProgress(percentage);
-          setTestStatus(message || '');
-          
-          // Update global HTML loader with testing progress
-          window.updateImmediateLoader?.({
-            test: percentage,
-            phase: 'Testing Performance',
-            currentAsset: message,
-          });
-        }
-      });
-
-      try {
-        if (import.meta.env.DEV) {
-          console.log('🔧 Starting conservative performance testing...');
-        }
-
-        await manager.initialize();
-
-        if (mounted) {
-          setProfile(manager.getProfile());
-          setTier(manager.getTier());
-          setIsReady(true);
-          setTestResults(manager.getTestResults() || null);
-          setIsInitializing(false);
-          setTestProgress(100);
-
-          if (import.meta.env.DEV) {
-            console.log('🔧 Conservative performance testing complete:', {
-              tier: manager.getTier(),
-              profile: manager.getProfile(),
-              testResults: manager.getTestResults()
-            });
-          }
-        }
-      } catch (err) {
-        console.error('Performance testing failed:', err);
-        
-        if (mounted) {
-          setError(err.message);
-          setIsInitializing(false);
-          setTestProgress(100);
-          setTestStatus('Test failed - using safe defaults');
-          
-          // Fall back to low profile
-          setProfile(manager.getProfile());
-          setTier(manager.getTier());
-          setIsReady(true);
-        }
-      }
-    };
-
-    initializeManager();
-
-    return () => {
-      mounted = false;
-      // Clean up progress callback
-      manager.setProgressCallback(null);
-    };
-  }, []);
-
-  // Listen for automatic profile changes
-  useEffect(() => {
-    const unsubscribe = manager.subscribe(({ tier: t, profile: p }) => {
-      setTier(t);
-      setProfile(p);
-      
-      if (import.meta.env.DEV) {
-        console.log('🔧 Performance profile changed:', t);
-      }
-    });
-    return unsubscribe;
-  }, []);
-
-  // Update profile manually
-  const updateProfile = useCallback((newTier, overrides = {}) => {
-    console.log('usePerformanceV2: updateProfile called', { newTier, overrides });
-    try {
-      // Explicitly allow renderScale overrides (numeric only)
-      const allowedOverrides = { ...overrides };
-      if (overrides.renderScale !== undefined) {
-        const numeric = Number(overrides.renderScale);
-        if (!Number.isNaN(numeric)) {
-          allowedOverrides.renderScale = numeric;
-        }
-      }
-
-      manager.setProfile(newTier, allowedOverrides);
-      setProfile(manager.getProfile());
-      setTier(manager.getTier());
-      setTestResults(manager.getTestResults() || null);
-      console.log('usePerformanceV2: profile updated to', newTier);
-    } catch (err) {
-      console.error('Failed to update performance profile:', err);
-      setError(err.message);
-    }
-  }, []);
-
-  // Force retest with progress tracking
-  const forceRetest = useCallback(async () => {
-    console.log('usePerformanceV2: forceRetest called');
-    setIsInitializing(true);
-    setError(null);
-    setIsReady(false);
-    setTestProgress(0);
-    setTestStatus('');
-
-    // Set up progress callback for retest
-    manager.setProgressCallback((percentage, message) => {
-      setTestProgress(percentage);
-      setTestStatus(message || '');
-
-      // Update global HTML loader
-      window.updateImmediateLoader?.({
-        test: percentage,
-        phase: 'Retesting Performance',
-        currentAsset: message,
-      });
-    });
-
-    try {
-      console.log('usePerformanceV2: starting performance retest');
-
-      await manager.forceRetest();
-
-      setProfile(manager.getProfile());
-      setTier(manager.getTier());
-      setTestResults(manager.getTestResults() || null);
-      setIsReady(true);
-      setIsInitializing(false);
-      setTestProgress(100);
-
-      console.log('usePerformanceV2: performance retest complete', {
-        tier: manager.getTier(),
-        results: manager.getTestResults()
-      });
-    } catch (err) {
-      console.error('Performance retest failed:', err);
-      setError(err.message);
-      setIsInitializing(false);
-      setTestProgress(100);
-      setTestStatus('Retest failed');
-      setIsReady(true); // Still mark as ready with fallback profile
-    } finally {
-      // Clean up progress callback
-      manager.setProgressCallback(null);
-    }
-  }, []);
-
-  // Clear cache
-  const clearCache = useCallback(() => {
-    manager.clearCache();
-    if (import.meta.env.DEV) {
-      console.log('🔧 Performance cache cleared');
-    }
-  }, []);
-
-  // Get performance recommendations
-  const getRecommendations = useCallback(() => {
-    const recommendations = [];
-    
-    if (tier === 'low') {
-      recommendations.push({
-        type: 'info',
-        message: 'Using optimized settings for your device',
-        action: 'Try closing other applications for better performance'
-      });
-    }
-    
-    if (error) {
-      recommendations.push({
-        type: 'error',
-        message: 'Performance testing encountered issues',
-        action: 'Try refreshing the page or retesting'
-      });
-    }
-
-    return recommendations;
-  }, [tier, error]);
-
-  // Debug info
-  const debugInfo = {
-    isInitializing,
-    error,
-    testResults,
-    testProgress,
-    testStatus,
-    managerReady: manager.isReady(),
-    hasCache: !!testResults,
-    recommendations: getRecommendations()
-  };
+  const profile = PERFORMANCE_PROFILES.medium;
 
   return {
     // Core state
     profile,
-    tier,
-    isReady,
-    isInitializing,
-    error,
-    
+    tier: 'medium',
+    isReady: true,
+    isInitializing: false,
+    error: null,
+
     // Test information
-    testResults,
-    testProgress,
-    testStatus,
-    
-    // Actions
-    updateProfile,
-    forceRetest,
-    clearCache,
-    
+    testResults: null,
+    testProgress: 100,
+    testStatus: 'static',
+
+    // Actions (no-ops in static mode)
+    updateProfile: () => {},
+    forceRetest: async () => {},
+    clearCache: () => {},
+
     // Utilities
-    getRecommendations,
-    debugInfo
+    getRecommendations: () => [],
+    debugInfo: {}
   };
 };
 

--- a/src/utils/PerformanceManagerV2.js
+++ b/src/utils/PerformanceManagerV2.js
@@ -455,21 +455,26 @@ export default class PerformanceManagerV2 {
   }
 
   setProfile(tier, overrides = {}) {
-    if (PERFORMANCE_PROFILES[tier]) {
-      this.tier = tier;
-      this.profile = { ...PERFORMANCE_PROFILES[tier], ...overrides };
+    if (!PERFORMANCE_PROFILES[tier]) return;
 
-      // Update cache
-      if (this._testResults) {
-        this._cacheResults(tier, this._testResults);
-      }
+    const newProfile = { ...PERFORMANCE_PROFILES[tier], ...overrides };
+    const tierChanged = this.tier !== tier;
+    const profileChanged = tierChanged || JSON.stringify(this.profile) !== JSON.stringify(newProfile);
+    if (!profileChanged) return;
 
-      if (import.meta.env.DEV) {
-        console.log('🔧 Manually set performance tier:', tier);
-      }
+    this.tier = tier;
+    this.profile = newProfile;
 
-      this._notifyListeners();
+    // Update cache
+    if (this._testResults) {
+      this._cacheResults(tier, this._testResults);
     }
+
+    if (import.meta.env.DEV) {
+      console.log('🔧 Manually set performance tier:', tier);
+    }
+
+    this._notifyListeners();
   }
 
   async forceRetest() {


### PR DESCRIPTION
## Summary
- Temporarily return a static medium performance profile in `usePerformanceV2` for debugging
- Refine `PerformanceManagerV2.setProfile` to skip notifying when tier and settings haven't changed

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6842a0e548328a90dfc26bcffcb83