### PR TITLE
Enable native touch scrolling for portfolio

### DIFF
--- a/src/components/layout/ScrollablePortfolio.jsx
+++ b/src/components/layout/ScrollablePortfolio.jsx
@@ -63,30 +63,7 @@ const ScrollablePortfolio = ({
     return () => window.removeEventListener('wheel', handleWheel);
   }, []);
 
-  // Enable touch scrolling while allowing pointer events to pass through
-  useEffect(() => {
-    const container = document.querySelector('.scroll-container');
-    if (!container) return;
-
-    let startY = 0;
-    const handleTouchStart = (e) => {
-      startY = e.touches[0].clientY;
-    };
-
-    const handleTouchMove = (e) => {
-      const currentY = e.touches[0].clientY;
-      const deltaY = startY - currentY;
-      container.scrollBy({ top: deltaY });
-      startY = currentY;
-    };
-
-    window.addEventListener('touchstart', handleTouchStart, { passive: true });
-    window.addEventListener('touchmove', handleTouchMove, { passive: true });
-    return () => {
-      window.removeEventListener('touchstart', handleTouchStart);
-      window.removeEventListener('touchmove', handleTouchMove);
-    };
-  }, []);
+  // Touch scrolling handled natively
   
   return (
     <div 
@@ -113,7 +90,8 @@ const ScrollablePortfolio = ({
         
         // Clean styling
         backgroundColor: 'transparent',
-        pointerEvents: 'none',
+        pointerEvents: 'auto',
+        touchAction: 'pan-y',
         
         // Clean box model
         margin: 0,

--- a/src/styles/scroll-snap.css
+++ b/src/styles/scroll-snap.css
@@ -68,6 +68,7 @@ body {
   
   /* Mobile scroll support */
   -webkit-overflow-scrolling: touch;
+  touch-action: pan-y;
   
   /* Clean box model */
   margin: 0 !important;


### PR DESCRIPTION
## Summary
- Allow pointer events on scroll container and enable native vertical swiping via `touch-action: pan-y`
- Remove custom touch listeners; keep click-through pointer behavior for hero and overview while keeping project and about sections interactive
- Add matching `touch-action: pan-y` style in scroll-snap CSS

## Testing
- ⚠️ `npm test` (missing script)
- ✅ `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a739e4e7a8832895637dc64d0dcf87