### PR TITLE
Delay facet labels until explosion completes

### DIFF
--- a/src/components/layout/Fixed3DCanvas.jsx
+++ b/src/components/layout/Fixed3DCanvas.jsx
@@ -53,6 +53,7 @@ const PulsingOmniLight = ({ simplified = false }) => {
 const Fixed3DCanvas = forwardRef(({
   // Animation data from MasterAnimationCoordinator
   animationData,
+  setCameraSettled,
   
   // Material and effects (unchanged)
   materialVariant = 'default',
@@ -288,6 +289,7 @@ const Fixed3DCanvas = forwardRef(({
             isMobile={isMobile}
             simplifiedAnimations={simplifiedAnimations}
             facetRefs={getFacetRefs()} // FIXED: Pass exposed facet refs for anchor targeting
+            onCameraSettledChange={setCameraSettled}
           />
           
           {/* UPDATED: Crystal Scene with ref for accessing debug state */}

--- a/src/components/three/FacetLabels.jsx
+++ b/src/components/three/FacetLabels.jsx
@@ -1,6 +1,7 @@
 import React, { useRef, useState, useEffect } from 'react';
 import { Html } from '@react-three/drei';
 import { useFrame } from '@react-three/fiber';
+import { useSprings, animated } from '@react-spring/web';
 import Headline from '../ui/Headline';
 import { deriveGlowFromBase } from '../../utils/color';
 import { ANIMATION_CONFIG } from '../../hooks/useUnifiedAnimationController';
@@ -8,6 +9,11 @@ import '../../styles/facet-label.css';
 
 const FacetLabels = ({ anchors = {}, projects = [], scrollToProgress, onHoverChange }) => {
   const groupRefs = useRef({});
+  const [springs, api] = useSprings(projects.length, () => ({ opacity: 0 }));
+
+  useEffect(() => {
+    api.start(index => ({ opacity: 1, delay: index * 100 }));
+  }, [api]);
 
   useFrame(() => {
     Object.entries(anchors).forEach(([key, anchor]) => {
@@ -20,7 +26,7 @@ const FacetLabels = ({ anchors = {}, projects = [], scrollToProgress, onHoverCha
 
   return (
     <>
-      {projects.map((project) => {
+      {projects.map((project, index) => {
         const { facetKey } = project;
         const anchor = anchors[facetKey];
         if (!anchor) return null;
@@ -35,18 +41,20 @@ const FacetLabels = ({ anchors = {}, projects = [], scrollToProgress, onHoverCha
             }}
           >
             <Html center style={{ pointerEvents: 'auto' }}>
-              <Label
-                project={project}
-                facetKey={facetKey}
-                glow1={glow1}
-                glow2={glow2}
-                onClick={() =>
-                  scrollToProgress(
-                    ANIMATION_CONFIG.projectSections[facetKey].start
-                  )
-                }
-                onHoverChange={onHoverChange}
-              />
+              <animated.div style={springs[index]}>
+                <Label
+                  project={project}
+                  facetKey={facetKey}
+                  glow1={glow1}
+                  glow2={glow2}
+                  onClick={() =>
+                    scrollToProgress(
+                      ANIMATION_CONFIG.projectSections[facetKey].start
+                    )
+                  }
+                  onHoverChange={onHoverChange}
+                />
+              </animated.div>
             </Html>
           </group>
         );

--- a/src/components/three/MasterAnimationCoordinator.jsx
+++ b/src/components/three/MasterAnimationCoordinator.jsx
@@ -115,7 +115,8 @@ const MasterAnimationCoordinator = ({
     currentZone: animationController.animationState.zoneInfo?.zone,
     zoneProgress: animationController.animationState.zoneInfo?.progress,
     isEnteringZone: animationController.animationState.zoneInfo?.isEntering,
-    isLeavingZone: animationController.animationState.zoneInfo?.isLeaving
+    isLeavingZone: animationController.animationState.zoneInfo?.isLeaving,
+    explosionComplete: animationController.animationState.explosionComplete
   }), [
     animationController.animationState,
     animationController.cameraConfig,

--- a/src/components/three/MasterAnimationCoordinator.jsx
+++ b/src/components/three/MasterAnimationCoordinator.jsx
@@ -116,7 +116,8 @@ const MasterAnimationCoordinator = ({
     zoneProgress: animationController.animationState.zoneInfo?.progress,
     isEnteringZone: animationController.animationState.zoneInfo?.isEntering,
     isLeavingZone: animationController.animationState.zoneInfo?.isLeaving,
-    explosionComplete: animationController.animationState.explosionComplete
+    explosionComplete: animationController.animationState.explosionComplete,
+    cameraSettled: animationController.animationState.cameraSettled
   }), [
     animationController.animationState,
     animationController.cameraConfig,
@@ -130,7 +131,8 @@ const MasterAnimationCoordinator = ({
     if (React.isValidElement(child)) {
       return React.cloneElement(child, {
         animationData,
-        scrollToProgress: scrollControls.scrollToProgress
+        scrollToProgress: scrollControls.scrollToProgress,
+        setCameraSettled: animationController.setCameraSettled
       });
     }
     return child;

--- a/src/components/three/UnifiedCameraController.jsx
+++ b/src/components/three/UnifiedCameraController.jsx
@@ -7,7 +7,8 @@ const UnifiedCameraController = ({
   config,
   isMobile = false,
   simplifiedAnimations = false,
-  facetRefs = null // Facet refs passed from UnifiedCrystalScene
+  facetRefs = null, // Facet refs passed from UnifiedCrystalScene
+  onCameraSettledChange = () => {}
 }) => {
   const { camera } = useThree();
   
@@ -27,6 +28,7 @@ const UnifiedCameraController = ({
   
   // Track last camera config to detect changes
   const lastCameraConfig = useRef(null);
+  const cameraSettledRef = useRef(false);
 
   const findAnchorInFacet = (facetKey) => {
     if (!facetRefs) {
@@ -173,13 +175,19 @@ const UnifiedCameraController = ({
       if (enhancedConfig.position) {
         currentTarget.current.position.copy(enhancedConfig.position);
       }
-      
+
       if (enhancedConfig.target) {
         currentTarget.current.lookAt.copy(enhancedConfig.target);
       }
-      
+
       if (enhancedConfig.fov !== undefined) {
         currentTarget.current.fov = enhancedConfig.fov;
+      }
+
+      // Mark camera as moving toward new target
+      if (cameraSettledRef.current) {
+        cameraSettledRef.current = false;
+        onCameraSettledChange(false);
       }
 
       
@@ -240,35 +248,56 @@ const UnifiedCameraController = ({
       camera.lookAt(currentTarget.current.lookAt);
       camera.fov = currentTarget.current.fov;
       camera.updateProjectionMatrix();
-      return;
+    } else {
+      const currentSpeeds = animationSpeed.current;
+
+      // Smooth position interpolation
+      camera.position.lerp(currentTarget.current.position, currentSpeeds.position);
+
+      // Smooth look-at interpolation
+      const currentDirection = new THREE.Vector3();
+      camera.getWorldDirection(currentDirection);
+
+      const targetDirection = new THREE.Vector3()
+        .subVectors(currentTarget.current.lookAt, camera.position)
+        .normalize();
+
+      // Interpolate direction vectors
+      currentDirection.lerp(targetDirection, currentSpeeds.lookAt);
+
+      // Apply new look direction
+      const newLookAt = new THREE.Vector3()
+        .addVectors(camera.position, currentDirection);
+
+      camera.lookAt(newLookAt);
+
+      // Smooth FOV interpolation
+      const fovDiff = currentTarget.current.fov - camera.fov;
+      camera.fov += fovDiff * currentSpeeds.fov;
+      camera.updateProjectionMatrix();
+
+      // Determine if camera has essentially stopped moving
+      const positionDiff = camera.position.distanceTo(currentTarget.current.position);
+      const directionDiff = currentDirection.angleTo(targetDirection);
+      const fovDiffAbs = Math.abs(fovDiff);
+      const settled = positionDiff < 0.005 && directionDiff < 0.005 && fovDiffAbs < 0.01;
+
+      if (settled && !cameraSettledRef.current) {
+        cameraSettledRef.current = true;
+        onCameraSettledChange(true);
+      } else if (!settled && cameraSettledRef.current) {
+        cameraSettledRef.current = false;
+        onCameraSettledChange(false);
+      }
     }
 
-    const currentSpeeds = animationSpeed.current;
-
-    // Smooth position interpolation
-    camera.position.lerp(currentTarget.current.position, currentSpeeds.position);
-    
-    // Smooth look-at interpolation
-    const currentDirection = new THREE.Vector3();
-    camera.getWorldDirection(currentDirection);
-    
-    const targetDirection = new THREE.Vector3()
-      .subVectors(currentTarget.current.lookAt, camera.position)
-      .normalize();
-    
-    // Interpolate direction vectors
-    currentDirection.lerp(targetDirection, currentSpeeds.lookAt);
-    
-    // Apply new look direction
-    const newLookAt = new THREE.Vector3()
-      .addVectors(camera.position, currentDirection);
-    
-    camera.lookAt(newLookAt);
-    
-    // Smooth FOV interpolation
-    const fovDiff = currentTarget.current.fov - camera.fov;
-    camera.fov += fovDiff * currentSpeeds.fov;
-    camera.updateProjectionMatrix();
+    if (simplifiedAnimations) {
+      // In simplified mode, camera reaches target instantly, so mark as settled
+      if (!cameraSettledRef.current) {
+        cameraSettledRef.current = true;
+        onCameraSettledChange(true);
+      }
+    }
   });
 
   /**

--- a/src/components/three/UnifiedCameraController.jsx
+++ b/src/components/three/UnifiedCameraController.jsx
@@ -29,6 +29,7 @@ const UnifiedCameraController = ({
   // Track last camera config to detect changes
   const lastCameraConfig = useRef(null);
   const cameraSettledRef = useRef(false);
+  const settledFramesRef = useRef(0);
 
   const findAnchorInFacet = (facetKey) => {
     if (!facetRefs) {
@@ -189,6 +190,7 @@ const UnifiedCameraController = ({
         cameraSettledRef.current = false;
         onCameraSettledChange(false);
       }
+      settledFramesRef.current = 0;
 
       
       const positionDistance = camera.position.distanceTo(currentTarget.current.position);
@@ -280,14 +282,19 @@ const UnifiedCameraController = ({
       const positionDiff = camera.position.distanceTo(currentTarget.current.position);
       const directionDiff = currentDirection.angleTo(targetDirection);
       const fovDiffAbs = Math.abs(fovDiff);
-      const settled = positionDiff < 0.005 && directionDiff < 0.005 && fovDiffAbs < 0.01;
+      const settled =
+        positionDiff < 0.02 &&
+        directionDiff < 0.02 &&
+        fovDiffAbs < 0.05;
 
-      if (settled && !cameraSettledRef.current) {
-        cameraSettledRef.current = true;
-        onCameraSettledChange(true);
-      } else if (!settled && cameraSettledRef.current) {
-        cameraSettledRef.current = false;
-        onCameraSettledChange(false);
+      if (settled) {
+        settledFramesRef.current += 1;
+        if (!cameraSettledRef.current && settledFramesRef.current >= 5) {
+          cameraSettledRef.current = true;
+          onCameraSettledChange(true);
+        }
+      } else {
+        settledFramesRef.current = 0;
       }
     }
 

--- a/src/components/three/UnifiedCrystalScene.jsx
+++ b/src/components/three/UnifiedCrystalScene.jsx
@@ -181,7 +181,11 @@ const UnifiedCrystalScene = forwardRef(({
     }
   }, [wholeCrystal, ...facetModels]);
 
-  const facetAnchors = useMemo(() => {
+  const [facetAnchors, setFacetAnchors] = useState({})
+
+  useEffect(() => {
+    if (!modelsLoaded || !showFacets) return
+
     const anchors = {}
     facetKeys.forEach((facetKey, index) => {
       const facetRef = facetRefs.current[index]?.current
@@ -190,8 +194,8 @@ const UnifiedCrystalScene = forwardRef(({
         if (anchor) anchors[facetKey] = anchor
       }
     })
-    return anchors
-  }, [facetKeys, showFacets, modelsLoaded])
+    setFacetAnchors(anchors)
+  }, [modelsLoaded, showFacets, facetKeys])
 
   // FIXED: Improved handleLabelHover with better state management
   const handleLabelHover = useCallback(

--- a/src/components/three/UnifiedCrystalScene.jsx
+++ b/src/components/three/UnifiedCrystalScene.jsx
@@ -658,7 +658,9 @@ const UnifiedCrystalScene = forwardRef(({
         );
       })}
 
-      {animationData.currentZone === 'overview' && animationData.crystalForm === 'exploded' && (
+      {animationData.currentZone === 'overview' &&
+       animationData.crystalForm === 'exploded' &&
+       animationData.explosionComplete && (
         <FacetLabels
           anchors={facetAnchors}
           projects={projects}

--- a/src/components/three/UnifiedCrystalScene.jsx
+++ b/src/components/three/UnifiedCrystalScene.jsx
@@ -660,7 +660,8 @@ const UnifiedCrystalScene = forwardRef(({
 
       {animationData.currentZone === 'overview' &&
        animationData.crystalForm === 'exploded' &&
-       animationData.explosionComplete && (
+       animationData.explosionComplete &&
+       animationData.cameraSettled && (
         <FacetLabels
           anchors={facetAnchors}
           projects={projects}

--- a/src/hooks/useUnifiedAnimationController.js
+++ b/src/hooks/useUnifiedAnimationController.js
@@ -3,6 +3,7 @@
 
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { Vector3 } from 'three';
+import { timing } from '../crystalConfig.js';
 
 /**
  * SIMPLIFIED: Animation Configuration with immediate state changes
@@ -199,13 +200,15 @@ export const useUnifiedAnimationController = (options = {}) => {
     isTransitioning: false, // Will be managed by individual components
     scrollProgress: 0,
     zoneInfo: { zone: 'hero', progress: 0 },
-    projectInfo: { project: null, progress: 0 }
+    projectInfo: { project: null, progress: 0 },
+    explosionComplete: false
   });
 
   // Simplified refs for tracking changes
   const lastZone = useRef('hero');
   const lastProject = useRef(null);
   const updateTimeout = useRef(null);
+  const explosionTimeout = useRef(null);
 
   /**
    * FIXED: Handle zone transitions with immediate state changes
@@ -433,14 +436,39 @@ export const useUnifiedAnimationController = (options = {}) => {
   const getCurrentCrystalConfig = useCallback(() => {
     return {
       form: animationState.crystalForm,
-      positions: animationState.crystalForm === 'exploded' 
-        ? config.crystal.explodedPositions 
+      positions: animationState.crystalForm === 'exploded'
+        ? config.crystal.explodedPositions
         : { center: config.crystal.wholePosition },
-      shouldRotate: animationState.crystalForm === 'whole' && 
+      shouldRotate: animationState.crystalForm === 'whole' &&
                    animationState.state === ANIMATION_STATES.HERO,
       rotationSpeed: 0.0003
     };
   }, [animationState.crystalForm, animationState.state, config]);
+
+  // Track when the explosion animation completes
+  const EXPLOSION_DURATION = timing?.camera?.explodeDuration ?? 1600;
+  const EXPLOSION_BUFFER = 200;
+
+  useEffect(() => {
+    if (animationState.crystalForm === 'exploded') {
+      if (explosionTimeout.current) {
+        clearTimeout(explosionTimeout.current);
+      }
+      // reset completion flag and start timer
+      setAnimationState(prev => ({ ...prev, explosionComplete: false }));
+      explosionTimeout.current = setTimeout(() => {
+        setAnimationState(prev => ({ ...prev, explosionComplete: true }));
+      }, EXPLOSION_DURATION + EXPLOSION_BUFFER);
+    } else {
+      if (explosionTimeout.current) {
+        clearTimeout(explosionTimeout.current);
+        explosionTimeout.current = null;
+      }
+      if (animationState.explosionComplete) {
+        setAnimationState(prev => ({ ...prev, explosionComplete: false }));
+      }
+    }
+  }, [animationState.crystalForm]);
 
   /**
    * Cleanup on unmount
@@ -449,6 +477,9 @@ export const useUnifiedAnimationController = (options = {}) => {
     return () => {
       if (updateTimeout.current) {
         clearTimeout(updateTimeout.current);
+      }
+      if (explosionTimeout.current) {
+        clearTimeout(explosionTimeout.current);
       }
     };
   }, []);

--- a/src/hooks/useUnifiedAnimationController.js
+++ b/src/hooks/useUnifiedAnimationController.js
@@ -201,7 +201,8 @@ export const useUnifiedAnimationController = (options = {}) => {
     scrollProgress: 0,
     zoneInfo: { zone: 'hero', progress: 0 },
     projectInfo: { project: null, progress: 0 },
-    explosionComplete: false
+    explosionComplete: false,
+    cameraSettled: false
   });
 
   // Simplified refs for tracking changes
@@ -445,6 +446,16 @@ export const useUnifiedAnimationController = (options = {}) => {
     };
   }, [animationState.crystalForm, animationState.state, config]);
 
+  // External components can update when the camera stops moving
+  const setCameraSettled = useCallback((settled) => {
+    setAnimationState(prev => ({ ...prev, cameraSettled: settled }));
+  }, []);
+
+  // Reset camera settled state whenever camera target changes
+  useEffect(() => {
+    setAnimationState(prev => ({ ...prev, cameraSettled: false }));
+  }, [animationState.cameraState, animationState.focusedFacet]);
+
   // Track when the explosion animation completes
   const EXPLOSION_DURATION = timing?.camera?.explodeDuration ?? 1600;
   const EXPLOSION_BUFFER = 200;
@@ -493,6 +504,7 @@ export const useUnifiedAnimationController = (options = {}) => {
     
     // Update functions
     updateFromScrollProgress,
+    setCameraSettled,
     
     // Current configs for 3D components
     cameraConfig: getCurrentCameraConfig(),
@@ -505,7 +517,8 @@ export const useUnifiedAnimationController = (options = {}) => {
       lastZone: lastZone.current,
       lastProject: lastProject.current,
       cameraState: animationState.cameraState,
-      crystalForm: animationState.crystalForm
+      crystalForm: animationState.crystalForm,
+      cameraSettled: animationState.cameraSettled
     } : null
   };
 };


### PR DESCRIPTION
## Summary
- Track explosion completion in animation controller and expose `explosionComplete` state
- Show facet labels only after explosion settles
- Fade labels in with staggered opacity animation for smoother reveal

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a741ed78d88328af9631eeb70ee142