### PR TITLE
Use delta time for gradient lerp

### DIFF
--- a/src/components/three/GradientBackground.jsx
+++ b/src/components/three/GradientBackground.jsx
@@ -81,11 +81,11 @@ const GradientBackground = forwardRef(({ backgrounds, initialKey = 'default', ra
     colorB: { value: currentB.current.clone() }
   }), []);
 
-  useFrame(() => {
+  useFrame((state, deltaTime) => {
     if (!materialRef.current) return;
 
-    currentA.current.lerp(targetA.current, 0.05);
-    currentB.current.lerp(targetB.current, 0.05);
+    currentA.current.lerp(targetA.current, 0.05 * deltaTime * 60);
+    currentB.current.lerp(targetB.current, 0.05 * deltaTime * 60);
 
     uniforms.colorA.value.copy(currentA.current);
     uniforms.colorB.value.copy(currentB.current);


### PR DESCRIPTION
## Summary
- Use useFrame deltaTime to scale background gradient lerp

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a8696512b083289780e5ca4bdec095