### PR TITLE
Measure scroll sections dynamically

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -148,6 +148,7 @@ function App() {
     }
   });
   const [animationConfig, setAnimationConfig] = useState(buildAnimationConfig(defaultConfig));
+  const [projectSections, setProjectSections] = useState({});
   const [materialVariant, setMaterialVariant] = useState('default');
   const [showUI, setShowUI] = useState(false);
   const [activeTab, setActiveTab] = useState(0);
@@ -477,6 +478,7 @@ function App() {
         debugMode={import.meta.env.DEV}
         onAnimationStateChange={handleAnimationStateChange}
         config={animationConfig}
+        projectSections={projectSections}
       >
         {/* Fixed 3D Canvas */}
         <Fixed3DCanvas
@@ -494,9 +496,10 @@ function App() {
       </MasterAnimationCoordinator>
 
       {/* Scrollable Content */}
-      <ScrollablePortfolio 
+      <ScrollablePortfolio
         snapSpeed={snapSpeed}
         hideContent={hideAllUI}
+        onSectionsMeasured={setProjectSections}
       />
 
       {/* UI Controls */}

--- a/src/components/layout/Fixed3DCanvas.jsx
+++ b/src/components/layout/Fixed3DCanvas.jsx
@@ -50,7 +50,7 @@ const PulsingOmniLight = ({ simplified = false }) => {
 /**
  * UPDATED: Fixed3DCanvas with corrected background color logic
  */
-const Fixed3DCanvas = forwardRef(({
+const Fixed3DCanvas = forwardRef(({ 
   // Animation data from MasterAnimationCoordinator
   animationData,
   
@@ -63,7 +63,8 @@ const Fixed3DCanvas = forwardRef(({
   canvasProps = {},
   environmentProps = {},
   isMobile = false,
-  scrollToProgress
+  scrollToProgress,
+  projectSections
 }, ref) => {
   // NEW: Ref to access crystal scene for debug panels
   const crystalSceneRef = useRef();
@@ -300,6 +301,7 @@ const Fixed3DCanvas = forwardRef(({
             isMobile={isMobile}
             simplifiedAnimations={simplifiedAnimations}
             scrollToProgress={scrollToProgress}
+            projectSections={projectSections}
           />
           
           {/* Environment used for reflections only */}

--- a/src/components/layout/ScrollablePortfolio.jsx
+++ b/src/components/layout/ScrollablePortfolio.jsx
@@ -9,7 +9,8 @@ import { projects } from '../../data/projects';
 
 const ScrollablePortfolio = ({
   snapSpeed = 'medium', // 'fast', 'medium', 'slow', 'extra-slow', 'no-snap'
-  hideContent = false  // NEW: Hide content for screenshots
+  hideContent = false,  // NEW: Hide content for screenshots
+  onSectionsMeasured
 }) => {
   // Detect mobile via user agent to keep desktop interactions intact
   const isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini|Mobi/i.test(navigator.userAgent);
@@ -40,11 +41,47 @@ const ScrollablePortfolio = ({
     
     return () => clearTimeout(timeoutId);
   }, [snapSpeed]);
-  
+
   // Debug logging
   useEffect(() => {
     if (import.meta.env.DEV) console.log('📏 ScrollablePortfolio received snapSpeed:', snapSpeed);
   }, [snapSpeed]);
+
+  // Measure project sections after layout to provide dynamic scroll thresholds
+  useEffect(() => {
+    const container = document.querySelector('.scroll-container');
+    if (!container) return;
+
+    const measure = () => {
+      const scrollableHeight = container.scrollHeight - container.clientHeight;
+      if (scrollableHeight <= 0) return;
+
+      const sections = Array.from(container.querySelectorAll('.scroll-section'));
+      const projectSections = {};
+
+      sections.forEach(section => {
+        const id = section.id;
+        if (!id || !id.startsWith('project-')) return;
+
+        const start = section.offsetTop / scrollableHeight;
+        const end = Math.min(
+          (section.offsetTop + section.scrollHeight) / scrollableHeight,
+          1
+        );
+        const facetKey = id.replace('project-', '');
+        projectSections[facetKey] = { start, end };
+      });
+
+      onSectionsMeasured?.(projectSections);
+    };
+
+    const raf = requestAnimationFrame(measure);
+    window.addEventListener('resize', measure);
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener('resize', measure);
+    };
+  }, [onSectionsMeasured]);
 
   // Allow scrolling when overlay sections disable pointer events
   useEffect(() => {

--- a/src/components/three/FacetLabels.jsx
+++ b/src/components/three/FacetLabels.jsx
@@ -3,10 +3,9 @@ import { Html } from '@react-three/drei';
 import { useFrame } from '@react-three/fiber';
 import Headline from '../ui/Headline';
 import { deriveGlowFromBase } from '../../utils/color';
-import { ANIMATION_CONFIG } from '../../hooks/useUnifiedAnimationController';
 import '../../styles/facet-label.css';
 
-const FacetLabels = ({ anchors = {}, projects = [], scrollToProgress, onHoverChange }) => {
+const FacetLabels = ({ anchors = {}, projects = [], projectSections = {}, scrollToProgress, onHoverChange }) => {
   const groupRefs = useRef({});
 
   useFrame(() => {
@@ -46,7 +45,7 @@ const FacetLabels = ({ anchors = {}, projects = [], scrollToProgress, onHoverCha
                 glow2={glow2}
                 onClick={() =>
                   scrollToProgress(
-                    ANIMATION_CONFIG.projectSections[facetKey].start
+                    projectSections[facetKey]?.start || 0
                   )
                 }
                 onHoverChange={onHoverChange}

--- a/src/components/three/MasterAnimationCoordinator.jsx
+++ b/src/components/three/MasterAnimationCoordinator.jsx
@@ -14,7 +14,8 @@ const MasterAnimationCoordinator = ({
   children,
   debugMode = false,
   onAnimationStateChange = null,
-  config = null
+  config = null,
+  projectSections = {}
 }) => {
   const [showAnimationDebug, setShowAnimationDebug] = useState(false);
 
@@ -29,7 +30,8 @@ const MasterAnimationCoordinator = ({
   const animationController = useUnifiedAnimationController({
     debugMode: debugMode,
     onStateChange: onAnimationStateChange,
-    config: config || undefined
+    config: config || undefined,
+    projectSections
   });
 
   useEffect(() => {
@@ -129,7 +131,8 @@ const MasterAnimationCoordinator = ({
     if (React.isValidElement(child)) {
       return React.cloneElement(child, {
         animationData,
-        scrollToProgress: scrollControls.scrollToProgress
+        scrollToProgress: scrollControls.scrollToProgress,
+        projectSections
       });
     }
     return child;

--- a/src/components/three/UnifiedCrystalScene.jsx
+++ b/src/components/three/UnifiedCrystalScene.jsx
@@ -22,7 +22,8 @@ const UnifiedCrystalScene = forwardRef(({
   performanceProfile = { useNormalMaps: true, textureQuality: 'high', pbrQuality: 'high', usePBR: true },
   isMobile = false,
   simplifiedAnimations = false,
-  scrollToProgress
+  scrollToProgress,
+  projectSections
 }, ref) => {
   // Component refs for crystal animation
   const crystalGroupRef = useRef();
@@ -670,6 +671,7 @@ const UnifiedCrystalScene = forwardRef(({
         <FacetLabels
           anchors={facetAnchors}
           projects={projects}
+          projectSections={projectSections}
           scrollToProgress={scrollToProgress}
           onHoverChange={handleLabelHover}
         />

--- a/src/hooks/useUnifiedAnimationController.js
+++ b/src/hooks/useUnifiedAnimationController.js
@@ -1,7 +1,7 @@
 // FIXED: src/hooks/useUnifiedAnimationController.js
 // Simplified animation system with immediate state changes + enhanced debugging for background issues
 
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { Vector3 } from 'three';
 
 /**
@@ -90,15 +90,6 @@ export const ANIMATION_CONFIG = {
     overview: { start: 0.12, end: 0.24 },
     projects: { start: 0.24, end: 0.875 },
     about: { start: 0.875, end: 1.0 }
-  },
-
-  projectSections: {
-    empathy:    { start: 0.24,   end: 0.3433 },
-    narrative:  { start: 0.3433, end: 0.4466 },
-    craft:      { start: 0.4466, end: 0.5499 },
-    system:     { start: 0.5499, end: 0.6533 },
-    leadership: { start: 0.6533, end: 0.7566 },
-    exploration:{ start: 0.7566, end: 0.875 }
   }
 };
 
@@ -155,13 +146,11 @@ const calculateCurrentZone = (scrollProgress, config = ANIMATION_CONFIG) => {
   };
 };
 
-const calculateActiveProject = (scrollProgress, config = ANIMATION_CONFIG) => {
+const calculateActiveProject = (scrollProgress, projectSections = {}, config = ANIMATION_CONFIG) => {
   if (scrollProgress < config.scrollZones.projects.start) {
     return { project: null, progress: 0 };
   }
-  
-  const projectSections = config.projectSections;
-  
+
   for (const [projectKey, section] of Object.entries(projectSections)) {
     if (scrollProgress >= section.start && scrollProgress < section.end) {
       const progress = (scrollProgress - section.start) / (section.end - section.start);
@@ -187,9 +176,15 @@ const calculateActiveProject = (scrollProgress, config = ANIMATION_CONFIG) => {
 export const useUnifiedAnimationController = (options = {}) => {
   const {
     config = ANIMATION_CONFIG,
+    projectSections = {},
     debugMode = false,
     onStateChange = null
   } = options;
+
+  const mergedConfig = useMemo(() => ({
+    ...config,
+    projectSections
+  }), [config, projectSections]);
 
   const [animationState, setAnimationState] = useState({
     state: ANIMATION_STATES.HERO,
@@ -284,8 +279,8 @@ export const useUnifiedAnimationController = (options = {}) => {
    * FIXED: Main scroll update with hysteresis to prevent boundary flickering + enhanced debugging
    */
   const updateFromScrollProgress = useCallback((scrollProgress) => {
-    const currentZone = calculateCurrentZone(scrollProgress, config);
-    const activeProject = calculateActiveProject(scrollProgress, config);
+    const currentZone = calculateCurrentZone(scrollProgress, mergedConfig);
+    const activeProject = calculateActiveProject(scrollProgress, projectSections, mergedConfig);
     
     // ENHANCED: Log scroll updates for background debugging
     if (import.meta.env.DEV && Math.random() < 0.05) { // Sample 5% of updates
@@ -401,7 +396,8 @@ export const useUnifiedAnimationController = (options = {}) => {
       onStateChange(animationState);
     }
   }, [
-    config, 
+    mergedConfig,
+    projectSections,
     handleZoneTransition,
     handleProjectFocus,
     onStateChange,
@@ -417,15 +413,15 @@ export const useUnifiedAnimationController = (options = {}) => {
     
     if (animationState.cameraState === 'project') {
       cameraConfig = animationState.focusedFacet
-        ? config.camera.projects[animationState.focusedFacet]
+        ? mergedConfig.camera.projects[animationState.focusedFacet]
         // When no facet is focused, default to overview camera instead of hero fallback
-        : config.camera.overview;
+        : mergedConfig.camera.overview;
     } else {
-      cameraConfig = config.camera[animationState.cameraState] || config.camera.hero;
+      cameraConfig = mergedConfig.camera[animationState.cameraState] || mergedConfig.camera.hero;
     }
     
     return cameraConfig;
-  }, [animationState.cameraState, animationState.focusedFacet, animationState.state, config, debugMode]);
+  }, [animationState.cameraState, animationState.focusedFacet, animationState.state, mergedConfig, debugMode]);
 
   /**
    * Get current crystal configuration (same as before)
@@ -434,13 +430,13 @@ export const useUnifiedAnimationController = (options = {}) => {
     return {
       form: animationState.crystalForm,
       positions: animationState.crystalForm === 'exploded' 
-        ? config.crystal.explodedPositions 
-        : { center: config.crystal.wholePosition },
-      shouldRotate: animationState.crystalForm === 'whole' && 
+        ? mergedConfig.crystal.explodedPositions
+        : { center: mergedConfig.crystal.wholePosition },
+      shouldRotate: animationState.crystalForm === 'whole' &&
                    animationState.state === ANIMATION_STATES.HERO,
       rotationSpeed: 0.0003
     };
-  }, [animationState.crystalForm, animationState.state, config]);
+  }, [animationState.crystalForm, animationState.state, mergedConfig]);
 
   /**
    * Cleanup on unmount
@@ -458,7 +454,7 @@ export const useUnifiedAnimationController = (options = {}) => {
     animationState,
     
     // Configuration
-    config,
+    config: mergedConfig,
     
     // Update functions
     updateFromScrollProgress,


### PR DESCRIPTION
## Summary
- compute project section offsets and heights after layout
- drive animation controller with measured section ranges
- pass dynamic project section mapping to label navigation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `npx eslint src` *(fails: Global "AudioWorkletGlobalScope " has leading/trailing whitespace)*

------
https://chatgpt.com/codex/tasks/task_e_68a8cb17ec5c83289e2254c4b11e7605