### PR TITLE
Optimize facet labels with static positions and fades

### DIFF
--- a/src/components/three/FacetLabels.jsx
+++ b/src/components/three/FacetLabels.jsx
@@ -1,6 +1,5 @@
-import React, { useRef, useMemo } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Html } from '@react-three/drei';
-import { useFrame } from '@react-three/fiber';
 import Headline from '../ui/Headline';
 import { deriveGlowFromBase } from '../../utils/color';
 import { ANIMATION_CONFIG } from '../../hooks/useUnifiedAnimationController';
@@ -41,60 +40,73 @@ const OptimizedLabel = React.memo(function OptimizedLabel({
   );
 });
 
+// Pre-calculated static positions from camera configs
+const LABEL_POSITIONS = Object.fromEntries(
+  Object.entries(ANIMATION_CONFIG.camera.projects).map(([key, cfg]) => [
+    key,
+    cfg.position.toArray(),
+  ])
+);
+
 // Optimized facet labels component
 const FacetLabels = React.memo(function FacetLabels({
-  anchors = {},
   projects = [],
   scrollToProgress,
   onHoverChange,
   animationData,
   performanceProfile,
 }) {
-  const groupRefs = useRef({});
+  const [visible, setVisible] = useState(false);
+  const [fadeDuration, setFadeDuration] = useState(0.8);
 
-  const shouldShowLabels = useMemo(() => {
+  const shouldShow = useMemo(() => {
     if (performanceProfile?.simplifiedAnimations) return false;
     if (animationData?.isScrolling) return false;
-    return animationData?.crystalForm === 'exploded';
+    if (animationData?.crystalForm !== 'exploded') return false;
+    if (animationData?.currentZone !== 'overview') return false;
+    if (animationData?.focusedProject) return false;
+    return animationData?.zoneProgress > 0.8;
   }, [
     animationData?.crystalForm,
+    animationData?.currentZone,
+    animationData?.focusedProject,
+    animationData?.zoneProgress,
     animationData?.isScrolling,
     performanceProfile?.simplifiedAnimations,
   ]);
 
-  useFrame(() => {
-    if (!shouldShowLabels) return;
+  useEffect(() => {
+    if (shouldShow) {
+      setFadeDuration(0.8);
+      setVisible(true);
+    } else {
+      setFadeDuration(0.2);
+      setVisible(false);
+    }
+  }, [shouldShow]);
 
-    Object.entries(anchors).forEach(([key, anchor]) => {
-      const group = groupRefs.current[key];
-      if (anchor && group) {
-        anchor.getWorldPosition(group.position);
-      }
-    });
-  });
-
-  if (!shouldShowLabels) {
+  if (performanceProfile?.simplifiedAnimations && !visible) {
     return null;
   }
 
   return (
     <>
       {projects.map((project) => {
-        const anchor = anchors[project.facetKey];
-        if (!anchor) return null;
+        const position = LABEL_POSITIONS[project.facetKey];
+        if (!position) return null;
 
         return (
-          <group
-            key={project.facetKey}
-            ref={(ref) => {
-              if (ref) groupRefs.current[project.facetKey] = ref;
-            }}
-          >
+          <group key={project.facetKey} position={position}>
             <Html
               center
               portal={{ current: document.body }}
               distanceFactor={10}
-              style={{ pointerEvents: 'auto', zIndex: 20 }}
+              style={{
+                pointerEvents: visible ? 'auto' : 'none',
+                zIndex: 20,
+                opacity: visible ? 1 : 0,
+                transition: `opacity ${fadeDuration}s`,
+              }}
             >
               <OptimizedLabel
                 project={project}

--- a/src/components/three/UnifiedCrystalScene.jsx
+++ b/src/components/three/UnifiedCrystalScene.jsx
@@ -179,18 +179,6 @@ const UnifiedCrystalScene = forwardRef(({
     }
   }, [wholeCrystal, ...facetModels]);
 
-  const facetAnchors = useMemo(() => {
-    const anchors = {}
-    facetKeys.forEach((facetKey, index) => {
-      const facetRef = facetRefs.current[index]?.current
-      if (facetRef) {
-        const anchor = facetRef.getObjectByName(`anchor_${facetKey}`)
-        if (anchor) anchors[facetKey] = anchor
-      }
-    })
-    return anchors
-  }, [facetKeys, showFacets, modelsLoaded])
-
   // FIXED: Improved handleLabelHover with better state management
   const handleLabelHover = useCallback(
     (facetKey, hovering) => {

--- a/src/styles/facet-label.css
+++ b/src/styles/facet-label.css
@@ -1,36 +1,10 @@
 /* src/styles/facet-label.css */
 
-.facet-label {
-  background: rgba(0, 0, 0, 0.85);
-  padding: 0.5rem 0.75rem;
-  border-radius: 0.5rem;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.5);
+.facet-label-optimized {
   cursor: pointer;
   user-select: none;
   text-align: center;
-}
-
-.label-container {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-}
-
-.label-logo {
-  width: 2rem;
-  height: 2rem;
-  background: #fff;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  overflow: hidden;
-}
-
-.label-logo img {
-  width: 60%;
-  height: 60%;
-  object-fit: contain;
+  text-shadow: 0 0 4px rgba(0, 0, 0, 0.7);
 }
 
 .label-title {
@@ -41,20 +15,7 @@
 .label-description {
   margin-top: 0.25rem;
   font-size: 0.75rem;
-  color: rgba(255, 255, 255, 0.8);
-  text-shadow: 0 0 4px rgba(255, 255, 255, 0.4);
-}
-
-/* Optimized label styling */
-.facet-label-optimized {
-  background: rgba(0, 0, 0, 0.85);
-  border: 1px solid rgba(100, 255, 218, 0.3);
-  border-radius: 8px;
-  padding: 8px 12px;
-  cursor: pointer;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.5);
-  will-change: transform;
-  user-select: none;
-  text-align: center;
+  color: rgba(255, 255, 255, 0.85);
+  text-shadow: 0 0 4px rgba(0, 0, 0, 0.7);
 }
 


### PR DESCRIPTION
## Summary
- Drop per-frame anchor tracking and place facet labels at static camera-derived positions
- Fade labels in and out based on zone progress and focused project state
- Remove card-style backgrounds and borders from facet labels for lighter DOM

## Testing
- ⚠️ `npm test` *(script missing)*
- ✅ `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aab2ce60f88328b5723376ef2a7393