### PR TITLE
fix: delay label positioning until offsets ready

### DIFF
--- a/src/components/three/FacetLabels.jsx
+++ b/src/components/three/FacetLabels.jsx
@@ -79,8 +79,22 @@ const FacetLabels = React.memo(function FacetLabels({
     };
   }, []);
 
+  if (import.meta.env.DEV) {
+    console.log('📍 FacetLabels: anchorOffsets state:', {
+      hasOffsets: Object.keys(anchorOffsets).length > 0,
+      offsets: anchorOffsets,
+    });
+  }
+
   // Convert static exploded positions plus anchor offsets to screen space
   const screenPositions = useMemo(() => {
+    // Don't calculate positions until we have anchor offsets
+    if (Object.keys(anchorOffsets).length === 0) {
+      if (import.meta.env.DEV)
+        console.log('📍 Waiting for anchor offsets...');
+      return {};
+    }
+
     const vec = new Vector3();
     const offset = new Vector3(); // ✅ Reuse this Vector3 instance
     const result = {};


### PR DESCRIPTION
## Summary
- guard facet label screen-space calculation until anchor offsets are ready
- add dev logging to track anchor offsets state

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac84533ca08328b4e7394994df143a