### PR TITLE
Fix facet label anchor positions

### DIFF
--- a/src/components/three/FacetLabels.jsx
+++ b/src/components/three/FacetLabels.jsx
@@ -79,25 +79,60 @@ const FacetLabels = React.memo(function FacetLabels({
     };
   }, []);
 
-  // Convert static exploded positions plus anchor offsets to screen space
+  // Calculate final anchor world positions
+  const anchorWorldPositions = useMemo(() => {
+    const positions = {};
+
+    Object.entries(explodedPositions).forEach(([facetKey, facetPosition]) => {
+      const anchorOffset = anchorOffsets[facetKey];
+
+      if (anchorOffset) {
+        const facetPosVector = new Vector3().fromArray(facetPosition);
+        const anchorOffsetVector = new Vector3().fromArray(anchorOffset);
+        const finalPosition = facetPosVector.add(anchorOffsetVector);
+
+        positions[facetKey] = finalPosition;
+
+        if (import.meta.env.DEV) {
+          console.log(`📍 Final anchor position for ${facetKey}:`, {
+            explodedPos: facetPosition,
+            anchorOffset: anchorOffset,
+            finalPos: finalPosition.toArray(),
+          });
+        }
+      }
+    });
+
+    return positions;
+  }, [anchorOffsets]);
+
+  // Convert world positions to screen space
   const screenPositions = useMemo(() => {
     const vec = new Vector3();
-    const offset = new Vector3(); // ✅ Reuse this Vector3 instance
     const result = {};
-    Object.entries(explodedPositions).forEach(([key, pos]) => {
-      vec.fromArray(pos);
-      if (anchorOffsets[key]) {
-        offset.fromArray(anchorOffsets[key]); // ✅ Reuse existing Vector3
-        vec.add(offset);
-      }
-      vec.project(camera);
+
+    Object.entries(anchorWorldPositions).forEach(([key, pos]) => {
+      vec.copy(pos).project(camera);
       result[key] = [
         (vec.x * 0.5 + 0.5) * size.width,
         (-vec.y * 0.5 + 0.5) * size.height,
       ];
     });
+
     return result;
-  }, [camera, size.width, size.height, anchorOffsets]);
+  }, [camera, size.width, size.height, anchorWorldPositions]);
+
+  // Debug helper to inspect projection results
+  useEffect(() => {
+    if (!import.meta.env.DEV) return;
+
+    window.testScreenProjection = () => {
+      Object.entries(screenPositions).forEach(([key, screen]) => {
+        const world = anchorWorldPositions[key];
+        console.log(`${key}: world`, world ? world.toArray() : 'n/a', '-> screen', screen);
+      });
+    };
+  }, [anchorWorldPositions, screenPositions]);
 
   const shouldShow = useMemo(() => {
     if (performanceProfile?.simplifiedAnimations) return false;

--- a/src/components/three/UnifiedCrystalScene.jsx
+++ b/src/components/three/UnifiedCrystalScene.jsx
@@ -14,6 +14,7 @@ import GlowingSphereImage, { BLENDING_MODES } from './GlowingSphereImage'
 import { getProjectColorByFacetKey } from '../../data/projects'
 import FacetLabels from './FacetLabels'
 import projects from '../../data/projects'
+import { explodedPositions } from '../../crystalConfig'
 
 const UnifiedCrystalScene = forwardRef(({ 
   animationData,
@@ -181,24 +182,64 @@ const UnifiedCrystalScene = forwardRef(({
     }
   }, [wholeCrystal, ...facetModels]);
 
-  // Calculate anchor offsets relative to facet centers once models are ready
+  // When models load, extract anchor offsets relative to model origin
   useEffect(() => {
     if (!modelsLoaded) return;
+
     const offsets = {};
+
     facetKeys.forEach((facetKey, index) => {
       const model = facetModels[index];
       if (!model?.scene) return;
-      const anchor = model.scene.getObjectByName(`anchor_${facetKey}`);
-      if (!anchor) return;
-      const anchorPos = new THREE.Vector3();
-      anchor.getWorldPosition(anchorPos);
-      const centerPos = new THREE.Vector3();
-      model.scene.getWorldPosition(centerPos);
-      anchorPos.sub(centerPos);
-      offsets[facetKey] = anchorPos.toArray();
+
+      // CRITICAL: Find anchor in the GLB file
+      const anchorName = `anchor_${facetKey}`;
+      const anchor = model.scene.getObjectByName(anchorName);
+
+      if (anchor) {
+        // Get anchor's local position within the model (this is the offset we need)
+        const anchorLocalPosition = anchor.position.clone();
+        offsets[facetKey] = anchorLocalPosition.toArray();
+
+        if (import.meta.env.DEV) {
+          console.log(`📍 Extracted anchor offset for ${facetKey}:`, anchorLocalPosition.toArray());
+        }
+      } else if (import.meta.env.DEV) {
+        console.warn(`⚠️ Anchor not found for ${facetKey}`);
+      }
     });
+
     setAnchorOffsets(offsets);
   }, [modelsLoaded]);
+
+  // Debug helpers to verify anchor and facet positions
+  useEffect(() => {
+    if (!modelsLoaded || !import.meta.env.DEV) return;
+
+    window.inspectGLBAnchors = () => {
+      facetKeys.forEach((facetKey, index) => {
+        const model = facetModels[index];
+        const anchor = model?.scene?.getObjectByName(`anchor_${facetKey}`);
+        console.log(`anchor_${facetKey}:`, anchor ? anchor.position.toArray() : 'NOT FOUND');
+      });
+    };
+
+    window.verifyExplodedPositions = () => {
+      facetKeys.forEach((facetKey, index) => {
+        const ref = facetRefs.current[index];
+        if (ref?.current) {
+          const pos = new THREE.Vector3();
+          ref.current.getWorldPosition(pos);
+          console.log(
+            `${facetKey} world pos:`,
+            pos.toArray(),
+            'expected:',
+            explodedPositions[facetKey]
+          );
+        }
+      });
+    };
+  }, [modelsLoaded, facetKeys, facetModels]);
 
   // FIXED: Improved handleLabelHover with better state management
   const handleLabelHover = useCallback(


### PR DESCRIPTION
## Summary
- compute anchor offsets using local positions from GLB models
- precompute final facet label positions from exploded positions and anchor offsets
- add debug utilities for inspecting anchors, exploded positions, and screen projection

## Testing
- `npm test` *(fails: Missing script "test")*
- `CI=1 npm run build` *(passes with chunk size warnings)*
- `npx eslint src/components/three/UnifiedCrystalScene.jsx src/components/three/FacetLabels.jsx` *(fails: configuration error about global name)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8be60b9883289ebb2b411ee1abb6