### PR TITLE
Refactor anchor offset calculation to use local anchor position

### DIFF
--- a/src/components/three/UnifiedCrystalScene.jsx
+++ b/src/components/three/UnifiedCrystalScene.jsx
@@ -189,13 +189,9 @@ const UnifiedCrystalScene = forwardRef(({
       const model = facetModels[index];
       if (!model?.scene) return;
       const anchor = model.scene.getObjectByName(`anchor_${facetKey}`);
-      if (!anchor) return;
-      const anchorPos = new THREE.Vector3();
-      anchor.getWorldPosition(anchorPos);
-      const centerPos = new THREE.Vector3();
-      model.scene.getWorldPosition(centerPos);
-      anchorPos.sub(centerPos);
-      offsets[facetKey] = anchorPos.toArray();
+      if (anchor) {
+        offsets[facetKey] = anchor.position.clone().toArray();
+      }
     });
     setAnchorOffsets(offsets);
   }, [modelsLoaded]);


### PR DESCRIPTION
## Summary
- Simplify anchor offset computation to use each anchor's local position clone

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68aca13290f48328a45500d6bc960361