### PR TITLE
refactor: clone anchor offsets

### DIFF
--- a/src/components/three/UnifiedCrystalScene.jsx
+++ b/src/components/three/UnifiedCrystalScene.jsx
@@ -190,7 +190,8 @@ const UnifiedCrystalScene = forwardRef(({
       if (!model?.scene) return;
       const anchor = model.scene.getObjectByName(`anchor_${facetKey}`);
       if (anchor) {
-        offsets[facetKey] = anchor.position.clone().toArray();
+        const localOffset = anchor.position.clone();
+        offsets[facetKey] = localOffset.toArray();
       }
     });
     setAnchorOffsets(offsets);


### PR DESCRIPTION
## Summary
- refactor anchor offset calculation to clone local anchor positions and store them per facet

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aca7930834832884deef06da157843