### PR TITLE
feat: add debugging utilities for crystal scene

### DIFF
--- a/src/components/three/FacetLabels.jsx
+++ b/src/components/three/FacetLabels.jsx
@@ -201,3 +201,19 @@ const FacetLabels = React.memo(function FacetLabels({
 });
 
 export default FacetLabels;
+
+export function testScreenProjection(worldVec, camera, size) {
+  const vec = worldVec.clone();
+  vec.project(camera);
+  const screen = [
+    (vec.x * 0.5 + 0.5) * size.width,
+    (-vec.y * 0.5 + 0.5) * size.height,
+  ];
+  if (import.meta.env.DEV) {
+    console.log('🔍 testScreenProjection:', {
+      world: worldVec.toArray(),
+      screen,
+    });
+  }
+  return screen;
+}

--- a/src/components/three/UnifiedCrystalScene.jsx
+++ b/src/components/three/UnifiedCrystalScene.jsx
@@ -157,6 +157,48 @@ const UnifiedCrystalScene = forwardRef(({
           });
           if (import.meta.env.DEV) console.groupEnd();
         }
+      },
+      inspectAnchors: () => {
+        if (import.meta.env.DEV) {
+          console.group('🔍 Anchor Check');
+          facetModels.forEach((model, index) => {
+            const facetKey = facetKeys[index];
+            const anchorName = `anchor_${facetKey}`;
+            const anchor = model?.scene?.getObjectByName(anchorName);
+            if (anchor) {
+              const pos = anchor.position.toArray().map(n => Number(n.toFixed(3)));
+              console.log(`${anchorName} exists at`, pos);
+            } else {
+              console.warn(`${anchorName} missing`);
+            }
+          });
+          console.groupEnd();
+        }
+      },
+      verifyExplodedPositions: () => {
+        if (import.meta.env.DEV) {
+          console.group('📐 Verifying exploded facet positions');
+          facetRefs.current.forEach((facetRef, index) => {
+            const facetKey = facetKeys[index];
+            const expected = config?.explodedPositions?.[facetKey];
+            if (!facetRef?.current || !expected) {
+              console.warn(`Facet ${facetKey}: missing ref or expected position`);
+              return;
+            }
+            const expectedVec = new THREE.Vector3().fromArray(expected);
+            const actual = facetRef.current.position.clone();
+            const delta = actual.clone().sub(expectedVec);
+            const distance = delta.length();
+            if (distance > 0.01) {
+              console.warn(
+                `❌ ${facetKey} discrepancy: expected [${expectedVec.x.toFixed(3)}, ${expectedVec.y.toFixed(3)}, ${expectedVec.z.toFixed(3)}], actual [${actual.x.toFixed(3)}, ${actual.y.toFixed(3)}, ${actual.z.toFixed(3)}], delta ${distance.toFixed(3)}`
+              );
+            } else {
+              console.log(`✅ ${facetKey} position verified`);
+            }
+          });
+          console.groupEnd();
+        }
       }
     }
   }), [facetKeys, showWholeCrystal, showFacets, sphereVisible, showCrystalDebug, modelsLoaded]);


### PR DESCRIPTION
## Summary
- expose `inspectAnchors` debug helper to check facet anchor nodes and positions
- add `verifyExplodedPositions` to validate facet transforms against configuration
- provide `testScreenProjection` utility for verifying screen-space projections of world vectors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68acaa3215588328bb0450985118c13c