### PR TITLE
Clone anchor positions for facet label offsets

### DIFF
--- a/src/components/three/UnifiedCrystalScene.jsx
+++ b/src/components/three/UnifiedCrystalScene.jsx
@@ -232,8 +232,7 @@ const UnifiedCrystalScene = forwardRef(({
       if (!model?.scene) return;
       const anchor = model.scene.getObjectByName(`anchor_${facetKey}`);
       if (anchor) {
-        const localOffset = anchor.position.clone();
-        offsets[facetKey] = localOffset.toArray();
+        offsets[facetKey] = anchor.position.clone().toArray();
       }
     });
     setAnchorOffsets(offsets);


### PR DESCRIPTION
## Summary
- derive facet label offsets from cloned anchor positions

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68acae75f39c83288342cf27b56594f0