### PR TITLE
feat: add debug helpers for facet anchors and positions

### DIFF
--- a/src/components/three/FacetLabels.jsx
+++ b/src/components/three/FacetLabels.jsx
@@ -198,7 +198,11 @@ const FacetLabels = React.memo(function FacetLabels({
 
 export default FacetLabels;
 
-export function testScreenProjection(worldVec, camera, size) {
+export function testScreenProjection(worldVec, camera, size, label = 'vector') {
+  if (!worldVec || !camera || !size) {
+    console.warn('testScreenProjection requires a Vector3, camera, and size');
+    return null;
+  }
   const vec = worldVec.clone();
   vec.project(camera);
   const screen = [
@@ -206,7 +210,7 @@ export function testScreenProjection(worldVec, camera, size) {
     (-vec.y * 0.5 + 0.5) * size.height,
   ];
   if (import.meta.env.DEV) {
-    console.log('🔍 testScreenProjection:', {
+    console.log(`🔍 testScreenProjection (${label}):`, {
       world: worldVec.toArray(),
       screen,
     });

--- a/src/components/three/UnifiedCrystalScene.jsx
+++ b/src/components/three/UnifiedCrystalScene.jsx
@@ -180,7 +180,7 @@ const UnifiedCrystalScene = forwardRef(({
           console.group('📐 Verifying exploded facet positions');
           facetRefs.current.forEach((facetRef, index) => {
             const facetKey = facetKeys[index];
-            const expected = config?.explodedPositions?.[facetKey];
+            const expected = animationData?.crystalConfig?.explodedPositions?.[facetKey];
             if (!facetRef?.current || !expected) {
               console.warn(`Facet ${facetKey}: missing ref or expected position`);
               return;
@@ -201,7 +201,7 @@ const UnifiedCrystalScene = forwardRef(({
         }
       }
     }
-  }), [facetKeys, showWholeCrystal, showFacets, sphereVisible, showCrystalDebug, modelsLoaded]);
+  }), [facetKeys, showWholeCrystal, showFacets, sphereVisible, showCrystalDebug, modelsLoaded, animationData]);
 
   // Load models
   const wholeCrystal = useGLTF(config.assets.models.crystalWhole);


### PR DESCRIPTION
## Summary
- add `inspectAnchors` debug utility to enumerate facet anchors and local positions
- add `verifyExplodedPositions` debug method comparing facets against `crystalConfig.explodedPositions`
- expose `testScreenProjection` helper to log screen coordinates of arbitrary world vectors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68acb181b01483289ed83f1c136d1fc1