### PR TITLE
Apply quaternion to facet anchor offsets

### DIFF
--- a/src/components/three/UnifiedCrystalScene.jsx
+++ b/src/components/three/UnifiedCrystalScene.jsx
@@ -232,7 +232,10 @@ const UnifiedCrystalScene = forwardRef(({
       if (!model?.scene) return;
       const anchor = model.scene.getObjectByName(`anchor_${facetKey}`);
       if (anchor) {
-        offsets[facetKey] = anchor.position.clone().toArray();
+        const rotatedOffset = anchor.position
+          .clone()
+          .applyQuaternion(model.scene.quaternion);
+        offsets[facetKey] = rotatedOffset.toArray();
       }
     });
     setAnchorOffsets(offsets);


### PR DESCRIPTION
## Summary
- adjust anchor offset calculations to respect facet rotation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68acb5ecdec883288a3ec5c2588da2ba