### PR TITLE
Expose anchor world positions for facet labels

### DIFF
--- a/src/components/three/FacetLabels.jsx
+++ b/src/components/three/FacetLabels.jsx
@@ -5,7 +5,6 @@ import { Vector3 } from 'three';
 import Headline from '../ui/Headline';
 import { deriveGlowFromBase } from '../../utils/color';
 import { ANIMATION_CONFIG } from '../../hooks/useUnifiedAnimationController';
-import { explodedPositions } from '../../crystalConfig';
 import '../../styles/facet-label.css';
 
 // Individual label rendered without card styling
@@ -50,7 +49,7 @@ const FacetLabels = React.memo(function FacetLabels({
   onHoverChange,
   animationData,
   performanceProfile,
-  anchorOffsets = {},
+  anchorWorldPositions = {},
 }) {
   const { camera, size } = useThree();
   const [visible, setVisible] = useState(false);
@@ -78,30 +77,6 @@ const FacetLabels = React.memo(function FacetLabels({
       document.body.removeChild(layer);
     };
   }, []);
-
-  // Calculate final world-space positions by combining exploded positions with rotated offsets
-  const anchorWorldPositions = useMemo(() => {
-    const result = {};
-    Object.entries(anchorOffsets).forEach(([facetKey, offsetArray]) => {
-      const exploded = explodedPositions[facetKey];
-      if (!exploded) return;
-
-      // Translate by exploded position then apply rotated anchor offset
-      const explodedVec = new Vector3().fromArray(exploded);
-      const rotatedOffset = new Vector3().fromArray(offsetArray);
-      const finalWorld = explodedVec.add(rotatedOffset);
-
-      console.log('Facet anchor position:', {
-        facetKey,
-        exploded,
-        anchorOffset: offsetArray,
-        finalWorld: finalWorld.toArray(),
-      });
-
-      result[facetKey] = finalWorld;
-    });
-    return result;
-  }, [anchorOffsets]);
 
   // Convert final world positions to screen space
   const screenPositions = useMemo(() => {

--- a/src/components/three/UnifiedCrystalScene.jsx
+++ b/src/components/three/UnifiedCrystalScene.jsx
@@ -67,8 +67,8 @@ const UnifiedCrystalScene = forwardRef(({
 
   // Track when GLTF models have loaded
   const [modelsLoaded, setModelsLoaded] = useState(false);
-  // Store precomputed anchor offsets for label placement
-  const [anchorOffsets, setAnchorOffsets] = useState({});
+  // Store computed anchor world positions for label placement
+  const [anchorWorldPositions, setAnchorWorldPositions] = useState({});
 
   const handleMaterialReady = useCallback(() => {
     setMaterialVersion(v => v + 1);
@@ -247,45 +247,18 @@ const UnifiedCrystalScene = forwardRef(({
     [facetKeys, facetModels, animationData?.crystalConfig?.explodedPositions]
   );
 
-  // Calculate anchor offsets relative to facet centers once models are ready
+  // Calculate anchor world positions once models are ready
   useEffect(() => {
     if (!modelsLoaded) return;
-    const offsets = {};
-    facetKeys.forEach((facetKey, index) => {
-      const model = facetModels[index];
-      if (!model?.scene) return;
-      const anchor = model.scene.getObjectByName(`anchor_${facetKey}`);
-      if (anchor) {
-        anchor.updateMatrixWorld(true);
-        const worldAnchor = new THREE.Vector3();
-        anchor.getWorldPosition(worldAnchor);
-        const worldFacet = new THREE.Vector3();
-        model.scene.getWorldPosition(worldFacet);
-        const offset = worldAnchor.sub(worldFacet);
-        offsets[facetKey] = offset.toArray();
-
-        const worldPos = computeAnchorWorldPosition(facetKey);
-        const exploded = animationData?.crystalConfig?.explodedPositions?.[facetKey];
-        if (worldPos && exploded && import.meta.env.DEV) {
-          const manualWorld = new THREE.Vector3()
-            .fromArray(exploded)
-            .add(offset);
-          const diff = worldPos.clone().sub(manualWorld);
-          const distance = diff.length();
-          if (distance > 0.001) {
-            console.warn(`❌ Anchor mismatch for ${facetKey}`, {
-              viaMatrix: worldPos.toArray(),
-              manual: manualWorld.toArray(),
-              delta: diff.toArray()
-            });
-          } else {
-            console.log(`✅ Anchor match for ${facetKey}`, worldPos.toArray());
-          }
-        }
+    const positions = {};
+    facetKeys.forEach((facetKey) => {
+      const worldPos = computeAnchorWorldPosition(facetKey);
+      if (worldPos) {
+        positions[facetKey] = worldPos;
       }
     });
-    setAnchorOffsets(offsets);
-  }, [modelsLoaded, facetKeys, facetModels, computeAnchorWorldPosition, animationData?.crystalConfig?.explodedPositions]);
+    setAnchorWorldPositions(positions);
+  }, [modelsLoaded, facetKeys, computeAnchorWorldPosition]);
 
   // FIXED: Improved handleLabelHover with better state management
   const handleLabelHover = useCallback(
@@ -768,7 +741,7 @@ const UnifiedCrystalScene = forwardRef(({
         onHoverChange={handleLabelHover}
         animationData={animationData}
         performanceProfile={performanceProfile}
-        anchorOffsets={anchorOffsets}
+        anchorWorldPositions={anchorWorldPositions}
       />
 
       {/* Debug visualization when enabled */}


### PR DESCRIPTION
## Summary
- compute world-space anchor positions for each facet and provide them to `FacetLabels`
- project supplied anchor positions to screen space in `FacetLabels`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68acc6e227588328907b2120df13b92f