### PR TITLE
handle facet rotations when deriving anchor positions

### DIFF
--- a/src/components/three/UnifiedCrystalScene.jsx
+++ b/src/components/three/UnifiedCrystalScene.jsx
@@ -225,7 +225,7 @@ const UnifiedCrystalScene = forwardRef(({
 
   // Compute anchor world position using matrix transforms
   const computeAnchorWorldPosition = useCallback(
-    (facetKey) => {
+    (facetKey, finalQuaternion = null, finalScale = null) => {
       const index = facetKeys.indexOf(facetKey);
       if (index === -1) return null;
 
@@ -239,8 +239,20 @@ const UnifiedCrystalScene = forwardRef(({
       // Ensure we have an up-to-date matrixWorld
       model.scene.updateMatrixWorld(true);
 
-      const matrixWorld = model.scene.matrixWorld.clone();
-      matrixWorld.setPosition(new THREE.Vector3().fromArray(exploded));
+      const position = new THREE.Vector3().fromArray(exploded);
+      const quaternion = finalQuaternion
+        ? (Array.isArray(finalQuaternion)
+            ? new THREE.Quaternion().fromArray(finalQuaternion)
+            : finalQuaternion)
+        : model.scene.quaternion;
+      const scale = finalScale
+        ? (Array.isArray(finalScale)
+            ? new THREE.Vector3().fromArray(finalScale)
+            : finalScale)
+        : model.scene.scale;
+
+      const matrixWorld = new THREE.Matrix4();
+      matrixWorld.compose(position, quaternion, scale);
 
       return anchor.position.clone().applyMatrix4(matrixWorld);
     },
@@ -264,12 +276,16 @@ const UnifiedCrystalScene = forwardRef(({
         const offset = worldAnchor.sub(worldFacet);
         offsets[facetKey] = offset.toArray();
 
-        const worldPos = computeAnchorWorldPosition(facetKey);
+        const rotation = animationData?.crystalConfig?.explodedRotations?.[facetKey];
+        const worldPos = computeAnchorWorldPosition(facetKey, rotation);
         const exploded = animationData?.crystalConfig?.explodedPositions?.[facetKey];
         if (worldPos && exploded && import.meta.env.DEV) {
+          const rotQuat = rotation
+            ? new THREE.Quaternion().fromArray(rotation)
+            : model.scene.quaternion;
           const manualWorld = new THREE.Vector3()
             .fromArray(exploded)
-            .add(offset);
+            .add(offset.clone().applyQuaternion(rotQuat));
           const diff = worldPos.clone().sub(manualWorld);
           const distance = diff.length();
           if (distance > 0.001) {

--- a/src/crystalConfig.js
+++ b/src/crystalConfig.js
@@ -24,6 +24,16 @@ export const explodedPositions = {
   exploration: [-0.6, 0.7, 0.0]   // More dynamic position
 }
 
+// Optional final rotations for exploded facets (quaternions)
+export const explodedRotations = {
+  empathy: [0, 0, 0, 1],
+  narrative: [0, 0, 0, 1],
+  craft: [0, 0, 0, 1],
+  system: [0, 0, 0, 1],
+  leadership: [0, 0, 0, 1],
+  exploration: [0, 0, 0, 1]
+}
+
 // === CAMERA POSITIONS ===
 export const cameraPositions = {
   hero: [0, 3.2, 2.4],

--- a/src/hooks/useUnifiedAnimationController.js
+++ b/src/hooks/useUnifiedAnimationController.js
@@ -2,7 +2,7 @@
 // Simplified animation system with immediate state changes + enhanced debugging for background issues
 
 import { useState, useEffect, useRef, useCallback } from 'react';
-import { Vector3 } from 'three';
+import { Vector3, Quaternion } from 'three';
 
 /**
  * SIMPLIFIED: Animation Configuration with immediate state changes
@@ -76,6 +76,14 @@ export const ANIMATION_CONFIG = {
       system: new Vector3(-0.5, 0.2, -1.8),
       leadership: new Vector3(0.4, 1.2, 0.9),
       exploration: new Vector3(-0.6, 0.7, 0.0)
+    },
+    explodedRotations: {
+      empathy: new Quaternion(0, 0, 0, 1),
+      narrative: new Quaternion(0, 0, 0, 1),
+      craft: new Quaternion(0, 0, 0, 1),
+      system: new Quaternion(0, 0, 0, 1),
+      leadership: new Quaternion(0, 0, 0, 1),
+      exploration: new Quaternion(0, 0, 0, 1)
     },
     wholePosition: new Vector3(0, 0, 0)
   },
@@ -433,10 +441,11 @@ export const useUnifiedAnimationController = (options = {}) => {
   const getCurrentCrystalConfig = useCallback(() => {
     return {
       form: animationState.crystalForm,
-      positions: animationState.crystalForm === 'exploded' 
-        ? config.crystal.explodedPositions 
+      positions: animationState.crystalForm === 'exploded'
+        ? config.crystal.explodedPositions
         : { center: config.crystal.wholePosition },
-      shouldRotate: animationState.crystalForm === 'whole' && 
+      rotations: config.crystal.explodedRotations,
+      shouldRotate: animationState.crystalForm === 'whole' &&
                    animationState.state === ANIMATION_STATES.HERO,
       rotationSpeed: 0.0003
     };


### PR DESCRIPTION
## Summary
- allow `computeAnchorWorldPosition` to apply final rotation and scale when deriving anchor positions
- expose optional `explodedRotations` configuration and forward through animation controller
- use composed matrix and rotation-aware offset check for anchor verification

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`
- `npx eslint src/components/three/UnifiedCrystalScene.jsx src/hooks/useUnifiedAnimationController.js src/crystalConfig.js` *(fails: Global "AudioWorkletGlobalScope " has leading or trailing whitespace)*

------
https://chatgpt.com/codex/tasks/task_e_68accf37e2a08328a8211fd13f1d88d6