### PR TITLE
Fix iPad touch detection for scrolling

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -37,6 +37,7 @@ import * as defaultConfig from './crystalConfig';
 
 // Cinematic Movie Titles Effects
 import './styles/glow-70s.css';
+import { isMobileDevice } from './utils/isMobileDevice.js';
 
 // Convert UI config into animation config
 const buildAnimationConfig = (uiConfig) => {
@@ -88,10 +89,6 @@ const buildAnimationConfig = (uiConfig) => {
   };
 };
 
-// Mobile detection - avoid misclassifying touch-enabled desktops
-const isMobileDevice = () => {
-  return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini|Mobi/i.test(navigator.userAgent);
-};
 
 function App() {
   // ========================================

--- a/src/components/layout/ScrollablePortfolio.jsx
+++ b/src/components/layout/ScrollablePortfolio.jsx
@@ -6,13 +6,14 @@ import HeroSection from '../sections/HeroSection';
 import ProjectFocusSection from '../sections/ProjectFocusSection';
 import AboutSection from '../sections/AboutSection';
 import { projects } from '../../data/projects';
+import { isMobileDevice } from '../../utils/isMobileDevice.js';
 
 const ScrollablePortfolio = ({
   snapSpeed = 'medium', // 'fast', 'medium', 'slow', 'extra-slow', 'no-snap'
   hideContent = false  // NEW: Hide content for screenshots
 }) => {
   // Detect mobile via user agent to keep desktop interactions intact
-  const isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini|Mobi/i.test(navigator.userAgent);
+  const isMobile = isMobileDevice();
   
   // Update snap speed when prop changes
   useEffect(() => {

--- a/src/utils/deviceProfiles.js
+++ b/src/utils/deviceProfiles.js
@@ -1,6 +1,8 @@
 // src/utils/deviceProfiles.js
 // FIXED: Better balanced performance profiles that respect working configurations
 
+import { isMobileDevice } from './isMobileDevice.js';
+
 export const PERFORMANCE_PROFILES = {
   high: {
     // Rendering settings
@@ -200,7 +202,7 @@ export const detectDeviceCapabilities = () => {
   const maxFragmentTextureUnits = gl.getParameter(gl.MAX_TEXTURE_IMAGE_UNITS);
 
   const rendererLower = renderer.toLowerCase();
-  const isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+  const isMobile = isMobileDevice();
   const deviceMemory = navigator.deviceMemory || null;
 
   const gpuBlacklist = ['mali-4', 'mali-3', 'adreno 3', 'adreno 4', 'intel hd', 'powervr', 'nouveau'];

--- a/src/utils/isMobileDevice.js
+++ b/src/utils/isMobileDevice.js
@@ -1,0 +1,8 @@
+export const isMobileDevice = () => {
+  const ua = navigator.userAgent;
+  const touchCapable = 'ontouchstart' in window || navigator.maxTouchPoints > 1;
+  const isIpadOS = ua.includes('Mac') && touchCapable;
+  return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini|Mobi/i.test(ua) || isIpadOS;
+};
+
+export default isMobileDevice;


### PR DESCRIPTION
## Summary
- add shared utility to detect mobile/touch devices including iPadOS desktop user agents
- apply new detection to scrolling layout, app, and performance profiling logic so iPad Pro can scroll

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ad12dd9b588328b09b8c27065bdcf0