### PR TITLE
Smooth LoaderV2 completion animation

### DIFF
--- a/src/ui/LoaderV2.module.css
+++ b/src/ui/LoaderV2.module.css
@@ -47,6 +47,7 @@
 
 .track{ transition: stroke 0.2s ease-out; }
 .progress{ transition: stroke-dashoffset 0.35s ease-out, stroke 0.2s ease-out; }
+.complete{ transition: stroke-dashoffset 0.6s ease-out, stroke 0.2s ease-out; }
 
 .diamond{ filter: drop-shadow(0 0 10px rgba(255,255,230,0.18)); }
 

--- a/src/ui/LoaderV2.tsx
+++ b/src/ui/LoaderV2.tsx
@@ -1,7 +1,7 @@
 // src/ui/LoaderV2.tsx
 // Radial loader showing initialization, asset loading, and performance testing
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import styles from './LoaderV2.module.css';
 
 const clamp = (v: number) => Math.min(1, Math.max(0, v));
@@ -34,14 +34,26 @@ const LoaderV2: React.FC<LoaderProps> = ({
     size / 2 - (stroke * 5) / 2
   ];
 
-  const ringProgress = {
-    outer: clamp(initProgress) * 100,
-    middle: clamp(assetProgress) * 100,
-    inner: clamp(testProgress) * 100
-  };
+  const [outer, setOuter] = useState(0);
+  const [middle, setMiddle] = useState(0);
+  const [inner, setInner] = useState(0);
+
+  useEffect(() => {
+    if (exiting) {
+      setOuter(100);
+      setMiddle(100);
+      setInner(100);
+    } else {
+      setOuter(clamp(initProgress) * 100);
+      setMiddle(clamp(assetProgress) * 100);
+      setInner(clamp(testProgress) * 100);
+    }
+  }, [initProgress, assetProgress, testProgress, exiting]);
 
   const overall = Math.round(
-    (ringProgress.outer + ringProgress.middle + ringProgress.inner) / 3
+    clamp(initProgress) * 33 +
+    clamp(testProgress) * 33 +
+    clamp(assetProgress) * 34
   );
 
   // Diamond sizing based on spec
@@ -75,16 +87,16 @@ const LoaderV2: React.FC<LoaderProps> = ({
           ))}
 
           {[
-            { r: radii[0], color: 'var(--ring1)', progress: ringProgress.outer },
-            { r: radii[1], color: 'var(--ring2)', progress: ringProgress.middle },
-            { r: radii[2], color: 'var(--ring3)', progress: ringProgress.inner }
+            { r: radii[0], color: 'var(--ring1)', progress: outer },
+            { r: radii[1], color: 'var(--ring2)', progress: middle },
+            { r: radii[2], color: 'var(--ring3)', progress: inner }
           ].map((ring, i) => {
             const circumference = 2 * Math.PI * ring.r;
             const offset = circumference * (1 - ring.progress / 100);
             return (
               <circle
                 key={`progress-${i}`}
-                className={styles.progress}
+                className={`${styles.progress} ${exiting ? styles.complete : ''}`}
                 cx={0}
                 cy={0}
                 r={ring.r}


### PR DESCRIPTION
## Summary
- compute weighted overall percentage across init, test, and asset progress
- add ring progress state and exit handler so rings animate to 100% before fadeout
- introduce CSS class for smooth ring completion transition

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68ad189dc3b48328918a365d349f6324