### PR TITLE
Simplify performance tier checks and lower FPS thresholds

### DIFF
--- a/src/utils/PerformanceManagerV2.js
+++ b/src/utils/PerformanceManagerV2.js
@@ -1,7 +1,7 @@
 // src/utils/PerformanceManagerV2.js
 // FIXED: Smart progressive performance testing system
 
-import { PERFORMANCE_PROFILES, detectDeviceCapabilities } from './deviceProfiles.js';
+import { PERFORMANCE_PROFILES } from './deviceProfiles.js';
 
 const STORAGE_KEY = 'crystal-performance-config-v2';
 const VERSION_KEY = 'crystal-performance-version-v2';
@@ -150,25 +150,15 @@ export default class PerformanceManagerV2 {
       const mediumResult = await this._testTier('medium', 33, 50, 384);
       results.medium = mediumResult;
 
-      // Require ~70 FPS headroom before probing higher quality
-      if (mediumResult.avgFps >= 70 && mediumResult.minFps >= 65) {
+      // Require ~55 FPS headroom before probing higher quality
+      if (mediumResult.avgFps >= 55 && mediumResult.minFps >= 50) {
         // Medium was strong enough, attempt the high tier
         const highResult = await this._testTier('high', 50, 66, 512);
         results.high = highResult;
-        if (highResult.avgFps >= 60 && highResult.minFps >= 55) {
-          // Only allow high tier for clearly high-end hardware
-          const { capabilities } = detectDeviceCapabilities();
-          const renderer = capabilities.renderer?.toLowerCase() || '';
-          const isHighEndMobile =
-            capabilities.isMobile && /m1|m2|a1[5-9]/i.test(renderer);
-          const isHighEndDesktop =
-            !capabilities.isMobile && /(rtx|gtx (1080|1070|2080|2070)|rx [6-9])/i.test(renderer);
-
-          if (isHighEndMobile || isHighEndDesktop) {
-            return { tier: 'high', testResults: results };
-          }
+        if (highResult.avgFps >= 50 && highResult.minFps >= 45) {
+          return { tier: 'high', testResults: results };
         }
-        // High failed or hardware not high-end, stay on medium
+        // High failed, stay on medium
         return { tier: 'medium', testResults: results };
       }
 


### PR DESCRIPTION
## Summary
- Loosen medium and high tier FPS gating to 55/50 and 50/45 respectively
- Remove GPU model whitelist so high tier relies solely on FPS results

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint src/utils/PerformanceManagerV2.js` *(fails: Key "languageOptions": Key "globals": Global "AudioWorkletGlobalScope " has leading or trailing whitespace.)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ad3f33cf348328b605e40caac1d343