### PR TITLE
Align medium benchmark scene with runtime preset

### DIFF
--- a/docs/performance-test-differences.md
+++ b/docs/performance-test-differences.md
@@ -1,0 +1,14 @@
+# Performance Test vs Runtime Differences
+
+The benchmark scene used by `PerformanceManagerV2` mirrors the runtime **medium** profile but intentionally simplifies a few details. Use this list to keep the test scene and runtime visuals in sync.
+
+## Medium Tier Alignment
+- Removed advanced PBR features (`transmission`, `clearcoat`, `iridescence`) for medium profile to match `MaterialManager`.
+- Directional and point light intensities now match values from `crystalConfig.js`.
+
+## Remaining Differences
+- The test scene only applies a bloom pass. Runtime medium also enables noise and vignette effects which are omitted here for simplicity.
+- Runtime uses additional lights (spot light, pulsing omni light) that are not recreated in the benchmark.
+- Bloom in the test uses `UnrealBloomPass` whereas runtime uses the react-postprocessing `Bloom` effect.
+
+Documenting these gaps helps future performance tuning stay aligned with gameplay visuals.

--- a/src/utils/PerformanceManager.js
+++ b/src/utils/PerformanceManager.js
@@ -266,7 +266,8 @@ export default class PerformanceManager {
           color: 0x0d042b,
           metalness: 0.0,
           roughness: 0.11,
-          transmission: profile.pbrQuality === 'high' ? 0.7 : 0.4,
+          // Medium tier mirrors runtime by disabling transmission
+          transmission: profile.pbrQuality === 'high' ? 0.7 : 0.0,
           ior: 2.3,
           transparent: true,
           opacity: 0.8,
@@ -293,13 +294,14 @@ export default class PerformanceManager {
       const ambientLight = new THREE.AmbientLight(0x404040, 0.4);
       scene.add(ambientLight);
 
-      const directionalLight = new THREE.DirectionalLight(0xffffff, 1.8);
+      // Match runtime lighting intensity
+      const directionalLight = new THREE.DirectionalLight(0xffffff, 10.8);
       directionalLight.position.set(2, 8, 5);
       scene.add(directionalLight);
 
       // Add only as many lights as the profile allows
       if (profile.maxLights > 2) {
-        const pointLight1 = new THREE.PointLight(0x00ad1d, 1.0);
+        const pointLight1 = new THREE.PointLight(0x00ad1d, 10.0);
         pointLight1.position.set(-5, 3, -5);
         scene.add(pointLight1);
       }
@@ -312,7 +314,9 @@ export default class PerformanceManager {
       const composer = new EffectComposer(renderer);
       composer.setSize(256 * profile.renderScale, 256 * profile.renderScale);
       composer.addPass(new RenderPass(scene, camera));
-      composer.addPass(new UnrealBloomPass(new THREE.Vector2(256, 256), 0.6, 0.4, 0.85));
+      if (profile.postProcessing.bloom) {
+        composer.addPass(new UnrealBloomPass(new THREE.Vector2(256, 256), 0.6, 0.4, 0.85));
+      }
 
       const samples = [];
       const warmup = 500; // Ignore first 500ms to allow shader compilation

--- a/src/utils/PerformanceManagerV2.js
+++ b/src/utils/PerformanceManagerV2.js
@@ -258,13 +258,15 @@ export default class PerformanceManagerV2 {
           color: 0x0d042b,
           metalness: 0.0,
           roughness: 0.11,
-          transmission: profile.pbrQuality === 'high' ? 0.7 : 0.4,
+          // Medium tier omits transmission for parity with runtime material
+          transmission: profile.pbrQuality === 'high' ? 0.7 : 0.0,
           ior: 2.3,
           transparent: true,
           opacity: 0.8,
           envMapIntensity: profile.pbrQuality === 'high' ? 2.0 : 1.5,
-          clearcoat: profile.pbrQuality === 'high' ? 0.8 : 0.4,
-          iridescence: profile.pbrQuality === 'high' ? 0.3 : 0.1
+          // Advanced features like clearcoat/iridescence are only enabled on high tier
+          clearcoat: profile.pbrQuality === 'high' ? 0.8 : 0.0,
+          iridescence: profile.pbrQuality === 'high' ? 0.3 : 0.0
         });
       }
 
@@ -287,15 +289,16 @@ export default class PerformanceManagerV2 {
       const ambientLight = new THREE.AmbientLight(0x404040, 0.4);
       scene.add(ambientLight);
 
-      const directionalLight = new THREE.DirectionalLight(0xffffff, 1.8);
+      // Match runtime directional intensity for medium profile
+      const directionalLight = new THREE.DirectionalLight(0xffffff, 10.8);
       directionalLight.position.set(2, 8, 5);
       scene.add(directionalLight);
 
       // Add point lights according to profile limits
       const pointLights = [
-        { position: [-5, 3, -5], color: 0x00ad1d, intensity: 1.0 },
+        { position: [-5, 3, -5], color: 0x00ad1d, intensity: 10.0 },
         { position: [0, -8, -10], color: 0x00e380, intensity: 1.8 },
-        { position: [5, -3, 5], color: 0xFFE8CC, intensity: 0.6 }
+        { position: [5, -3, 5], color: 0xFFE8CC, intensity: 5.6 }
       ];
 
       pointLights.slice(0, Math.max(0, profile.maxLights - 2)).forEach(config => {


### PR DESCRIPTION
## Summary
- disable transmission, clearcoat and iridescence for medium-tier benchmark material
- match benchmark lighting intensities to runtime config and gate bloom pass to profile
- document remaining differences between benchmark and runtime medium visuals

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint src/utils/PerformanceManager.js src/utils/PerformanceManagerV2.js docs/performance-test-differences.md` *(fails: Global "AudioWorkletGlobalScope " has leading or trailing whitespace)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ade07b93ec8328a71c3b13c1fd0f86