### PR TITLE
Add fracture pause before crystal explosion

### DIFF
--- a/src/components/three/UnifiedCrystalScene.jsx
+++ b/src/components/three/UnifiedCrystalScene.jsx
@@ -65,6 +65,9 @@ const UnifiedCrystalScene = forwardRef(({
     [facetKeys]
   );
 
+  // Track explosion timing so we can implement fracture pause
+  const explosionStartRef = useRef(null);
+
   // Track when GLTF models have loaded
   const [modelsLoaded, setModelsLoaded] = useState(false);
   // Store precomputed anchor offsets for label placement
@@ -600,6 +603,19 @@ const UnifiedCrystalScene = forwardRef(({
           setShowWholeCrystal(false);
           setShowFacets(true);
           setSphereVisible(true);
+          explosionStartRef.current = performance.now();
+
+          // Snap facets immediately to fracture positions (small initial offset)
+          const fracture = animationData?.crystalConfig?.fracturePositions;
+          if (fracture) {
+            facetRefs.current.forEach((facetRef, idx) => {
+              const facetKey = facetKeys[idx];
+              const pos = fracture[facetKey];
+              if (facetRef?.current && pos) {
+                facetRef.current.position.copy(pos);
+              }
+            });
+          }
         } else {
           // In simplified mode keep the whole crystal visible
           setShowWholeCrystal(true);
@@ -616,6 +632,7 @@ const UnifiedCrystalScene = forwardRef(({
           setShowWholeCrystal(true);
           setShowFacets(false);
         }
+        explosionStartRef.current = null;
       }
       
       lastCrystalForm.current = currentForm;
@@ -652,24 +669,56 @@ const UnifiedCrystalScene = forwardRef(({
 
     // Handle facet animations
     if (showFacets && animationData.crystalConfig?.positions) {
+      // Custom fracture/explosion timing
+      if (animationData.crystalForm === 'exploded' && explosionStartRef.current) {
+        const fracturePause = animationData.crystalConfig.fracturePause || 0.5;
+        const totalDuration = animationData.crystalConfig.explodeDuration || 1.2;
+        const elapsedExplosion = (performance.now() - explosionStartRef.current) / 1000;
+
+        if (elapsedExplosion < fracturePause) {
+          // Stay at fracture positions during the pause
+          return;
+        }
+
+        const progress = Math.min((elapsedExplosion - fracturePause) / (totalDuration - fracturePause), 1);
+        const fracture = animationData.crystalConfig.fracturePositions;
+
+        facetRefs.current.forEach((facetRef, index) => {
+          if (!facetRef || !facetRef.current) return;
+
+          const facetKey = facetKeys[index];
+          const start = fracture?.[facetKey];
+          const end = animationData.crystalConfig.positions[facetKey];
+          if (start && end) {
+            const interpolated = start.clone().lerp(end, progress);
+            facetRef.current.position.copy(interpolated);
+          }
+        });
+
+        if (progress >= 1) {
+          explosionStartRef.current = null; // Animation finished
+        }
+        return;
+      }
+
       const isReforming = animationData.crystalForm === 'whole' && showFacets;
-      
+
       const speeds = {
         explosion: 0.04,
         reform: 0.12,
         projectFocus: 0.05,
         floating: 0.02
       };
-      
+
       let lerpSpeed;
       if (animationData.focusedFacet) {
         lerpSpeed = speeds.projectFocus;
       } else {
         lerpSpeed = speeds.explosion;
       }
-      
+
       let allFacetsAtCenter = true;
-      
+
       facetRefs.current.forEach((facetRef, index) => {
         if (!facetRef || !facetRef.current) return;
 
@@ -705,7 +754,7 @@ const UnifiedCrystalScene = forwardRef(({
           }
         }
       });
-      
+
       if (isReforming && allFacetsAtCenter && !showWholeCrystal) {
         if (import.meta.env.DEV) {
           console.log('💎 Reform complete - swapping to whole crystal');

--- a/src/crystalConfig.js
+++ b/src/crystalConfig.js
@@ -24,6 +24,15 @@ export const explodedPositions = {
   exploration: [-0.6, 0.7, 0.0]   // More dynamic position
 }
 
+// Define the fracture positions (3% of the way to final positions)
+const FRACTURE_SCALE = 0.03;
+export const fracturePositions = Object.fromEntries(
+  Object.entries(explodedPositions).map(([key, coords]) => [
+    key,
+    coords.map(c => Number((c * FRACTURE_SCALE).toFixed(3)))
+  ])
+);
+
 // Optional final rotations for exploded facets (quaternions)
 export const explodedRotations = {
   empathy: [0, 0, 0, 1],
@@ -49,15 +58,6 @@ export const cameraPositions = {
   }
 }
 
-// Define the fracture positions (5% of the way to final positions)
-export const fracturePositions = {
-  empathy: [0.015, -0.035, -0.010],
-  narrative: [0.015, -0.005, -0.035],
-  craft: [0.065, 0.040, 0.025],
-  system: [-0.025, 0.010, -0.090],
-  leadership: [0.020, 0.060, 0.045],
-  exploration: [-0.030, 0.035, 0.000],
-}
 
 // === ANIMATION TIMING ===
 export const timing = {

--- a/src/hooks/useUnifiedAnimationController.js
+++ b/src/hooks/useUnifiedAnimationController.js
@@ -4,6 +4,9 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { Vector3, Quaternion } from 'three';
 
+// Percentage of total facet travel used for the instantaneous fracture snap
+const FRACTURE_RATIO = 0.03;
+
 /**
  * SIMPLIFIED: Animation Configuration with immediate state changes
  */
@@ -109,6 +112,18 @@ export const ANIMATION_CONFIG = {
     exploration:{ start: 0.7566, end: 0.875 }
   }
 };
+
+// Derive fracture positions and timing based on exploded targets
+ANIMATION_CONFIG.crystal.fracturePositions = Object.fromEntries(
+  Object.entries(ANIMATION_CONFIG.crystal.explodedPositions).map(([key, vec]) => [
+    key,
+    vec.clone().multiplyScalar(FRACTURE_RATIO)
+  ])
+);
+// How long to hold the facets at their fractured positions (seconds)
+ANIMATION_CONFIG.crystal.fracturePause = 0.5;
+// Total time for fracture + explosion (seconds). Matches previous explode duration
+ANIMATION_CONFIG.crystal.explodeDuration = 1.2;
 
 // SIMPLIFIED: Only essential states (no intermediate transition states)
 const ANIMATION_STATES = {
@@ -452,6 +467,9 @@ export const useUnifiedAnimationController = (options = {}) => {
       positions: animationState.crystalForm === 'exploded'
         ? config.crystal.explodedPositions
         : { center: config.crystal.wholePosition },
+      fracturePositions: config.crystal.fracturePositions,
+      fracturePause: config.crystal.fracturePause,
+      explodeDuration: config.crystal.explodeDuration,
       rotations: config.crystal.explodedRotations,
       shouldRotate: animationState.crystalForm === 'whole' &&
                    animationState.state === ANIMATION_STATES.HERO,


### PR DESCRIPTION
## Summary
- Snap facets 3% toward their final positions and pause briefly before full explosion
- Drive fracture/explosion timing from shared config
- Derive fracture positions dynamically and expose pause/explosion durations

## Testing
- `npm test` *(fails: Missing script "test"*

------
https://chatgpt.com/codex/tasks/task_e_68af34de29fc8328b3c68e3a8323d47b