### PR TITLE
fix: connect normal map toggle to all performance tiers

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -304,7 +304,9 @@ function App() {
       if (newConfig.pbrQuality === 'high') newTier = 'high';
       else if (newConfig.pbrQuality === 'low') newTier = 'low';
 
-      const overrides = newTier === 'low' ? { simplifiedAnimations: false } : {};
+      const overrides = {};
+      if (newTier === 'low') overrides.simplifiedAnimations = false;
+      if (typeof newConfig.useNormalMaps === 'boolean') overrides.useNormalMaps = newConfig.useNormalMaps;
       updateProfile(newTier, overrides);
     } else if (
       typeof newConfig.renderScale === 'number' &&
@@ -317,6 +319,11 @@ function App() {
       newConfig.simplifiedAnimations !== performanceProfile.simplifiedAnimations
     ) {
       updateProfile(performanceTier, { simplifiedAnimations: newConfig.simplifiedAnimations });
+    } else if (
+      typeof newConfig.useNormalMaps === 'boolean' &&
+      newConfig.useNormalMaps !== performanceProfile.useNormalMaps
+    ) {
+      updateProfile(performanceTier, { useNormalMaps: newConfig.useNormalMaps });
     } else {
       // For other config changes, update local effects
       if (newConfig.postProcessing) {


### PR DESCRIPTION
## Summary
- update performance config handler to track normal map toggles
- persist normal map setting when switching between tiers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68afd8210c94832885ac7d9afa15ca3b