### PR TITLE
feat: increase fracture snap distance

### DIFF
--- a/src/components/three/FractureBurstParticles.jsx
+++ b/src/components/three/FractureBurstParticles.jsx
@@ -1,0 +1,104 @@
+import React, { useEffect, useMemo, useRef } from 'react';
+import { useFrame } from '@react-three/fiber';
+import { useTexture } from '@react-three/drei';
+import * as THREE from 'three';
+
+/**
+ * Particle burst that erupts from the crystal center when triggered.
+ */
+const FractureBurstParticles = ({ trigger, count = 80, duration = 1.2 }) => {
+  const pointsRef = useRef();
+  const startTimeRef = useRef(0);
+  const velocitiesRef = useRef();
+
+  const texture = useTexture('/assets/textures/particle-dust05.png');
+
+  const { geometry, velocities } = useMemo(() => {
+    const positions = new Float32Array(count * 3);
+    const velocities = new Float32Array(count * 3);
+
+    for (let i = 0; i < count; i++) {
+      const i3 = i * 3;
+      positions[i3] = positions[i3 + 1] = positions[i3 + 2] = 0;
+
+      const dir = new THREE.Vector3(
+        Math.random() - 0.5,
+        Math.random() - 0.5,
+        Math.random() - 0.5
+      )
+        .normalize()
+        .multiplyScalar(2 + Math.random());
+
+      velocities[i3] = dir.x;
+      velocities[i3 + 1] = dir.y;
+      velocities[i3 + 2] = dir.z;
+    }
+
+    const geometry = new THREE.BufferGeometry();
+    geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+
+    return { geometry, velocities };
+  }, [count]);
+
+  velocitiesRef.current = velocities;
+
+  const material = useMemo(() =>
+    new THREE.PointsMaterial({
+      map: texture,
+      transparent: true,
+      depthWrite: false,
+      blending: THREE.AdditiveBlending,
+      size: 0.15,
+      color: '#ffffff',
+      opacity: 0,
+    }),
+  [texture]);
+
+  useEffect(() => {
+    if (!geometry) return;
+    // Reset positions and regenerate velocities
+    const positions = geometry.attributes.position.array;
+    const velocities = velocitiesRef.current;
+    for (let i = 0; i < count; i++) {
+      const i3 = i * 3;
+      positions[i3] = positions[i3 + 1] = positions[i3 + 2] = 0;
+      const dir = new THREE.Vector3(
+        Math.random() - 0.5,
+        Math.random() - 0.5,
+        Math.random() - 0.5
+      )
+        .normalize()
+        .multiplyScalar(2 + Math.random());
+      velocities[i3] = dir.x;
+      velocities[i3 + 1] = dir.y;
+      velocities[i3 + 2] = dir.z;
+    }
+    geometry.attributes.position.needsUpdate = true;
+    material.opacity = 1;
+    startTimeRef.current = performance.now();
+  }, [trigger, geometry, material, count]);
+
+  useFrame((_, dt) => {
+    if (!startTimeRef.current) return;
+    const elapsed = (performance.now() - startTimeRef.current) / 1000;
+    const positions = geometry.attributes.position.array;
+    const velocities = velocitiesRef.current;
+
+    for (let i = 0; i < count; i++) {
+      const i3 = i * 3;
+      positions[i3] += velocities[i3] * dt;
+      positions[i3 + 1] += velocities[i3 + 1] * dt;
+      positions[i3 + 2] += velocities[i3 + 2] * dt;
+    }
+    geometry.attributes.position.needsUpdate = true;
+
+    material.opacity = Math.max(1 - elapsed / duration, 0);
+    if (elapsed > duration) {
+      startTimeRef.current = 0;
+    }
+  });
+
+  return <points ref={pointsRef} geometry={geometry} material={material} />;
+};
+
+export default FractureBurstParticles;

--- a/src/components/three/UnifiedCrystalScene.jsx
+++ b/src/components/three/UnifiedCrystalScene.jsx
@@ -5,6 +5,7 @@ import React, { useRef, useState, useEffect, useCallback, forwardRef, useImperat
 import { useFrame } from '@react-three/fiber'
 import { useGLTF, Html } from '@react-three/drei'
 import * as THREE from 'three'
+import FractureBurstParticles from './FractureBurstParticles'
 
 // Import existing material manager
 import MaterialManager from './MaterialManager'
@@ -33,6 +34,7 @@ const UnifiedCrystalScene = forwardRef(({
 
   // Sphere state
   const [sphereVisible, setSphereVisible] = useState(false);
+  const [burstId, setBurstId] = useState(0);
   
   // Crystal state tracking
   const [showWholeCrystal, setShowWholeCrystal] = useState(true);
@@ -610,6 +612,7 @@ const UnifiedCrystalScene = forwardRef(({
           setShowFacets(true);
           setSphereVisible(true);
           explosionStartRef.current = performance.now();
+          setBurstId(id => id + 1);
 
           // Capture hero rotation so facets start from same orientation
           if (wholeCrystalRef.current && facetsGroupRef.current) {
@@ -826,7 +829,9 @@ const UnifiedCrystalScene = forwardRef(({
           debugMode={import.meta.env.DEV}
         />
       )}
-      
+
+      {!simplifiedAnimations && <FractureBurstParticles trigger={burstId} />}
+
       {/* Whole Crystal */}
       {showWholeCrystal && (
         <group ref={wholeCrystalRef}>

--- a/src/components/three/UnifiedCrystalScene.jsx
+++ b/src/components/three/UnifiedCrystalScene.jsx
@@ -75,6 +75,7 @@ const UnifiedCrystalScene = forwardRef(({
 
   // Track explosion timing so we can implement fracture pause
   const explosionStartRef = useRef(null);
+  const burstTriggeredRef = useRef(false);
 
   // Track when GLTF models have loaded
   const [modelsLoaded, setModelsLoaded] = useState(false);
@@ -612,7 +613,7 @@ const UnifiedCrystalScene = forwardRef(({
           setShowFacets(true);
           setSphereVisible(true);
           explosionStartRef.current = performance.now();
-          setBurstId(id => id + 1);
+          burstTriggeredRef.current = false;
 
           // Capture hero rotation so facets start from same orientation
           if (wholeCrystalRef.current && facetsGroupRef.current) {
@@ -691,6 +692,11 @@ const UnifiedCrystalScene = forwardRef(({
         if (elapsedExplosion < fracturePause) {
           // Stay at fracture positions during the pause
           return;
+        }
+
+        if (!burstTriggeredRef.current) {
+          setBurstId(id => id + 1);
+          burstTriggeredRef.current = true;
         }
 
         const progress = Math.min((elapsedExplosion - fracturePause) / (totalDuration - fracturePause), 1);

--- a/src/hooks/useUnifiedAnimationController.js
+++ b/src/hooks/useUnifiedAnimationController.js
@@ -5,7 +5,7 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { Vector3, Quaternion } from 'three';
 
 // Percentage of total facet travel used for the instantaneous fracture snap
-const FRACTURE_RATIO = 0.08; // 8%
+const FRACTURE_RATIO = 0.2; // 20%
 
 /**
  * SIMPLIFIED: Animation Configuration with immediate state changes

--- a/src/hooks/useUnifiedAnimationController.js
+++ b/src/hooks/useUnifiedAnimationController.js
@@ -5,7 +5,7 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { Vector3, Quaternion } from 'three';
 
 // Percentage of total facet travel used for the instantaneous fracture snap
-const FRACTURE_RATIO = 0.2; // 20%
+const FRACTURE_RATIO = 0.08; // 8%
 
 /**
  * SIMPLIFIED: Animation Configuration with immediate state changes

--- a/src/hooks/useUnifiedAnimationController.js
+++ b/src/hooks/useUnifiedAnimationController.js
@@ -5,7 +5,7 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { Vector3, Quaternion } from 'three';
 
 // Percentage of total facet travel used for the instantaneous fracture snap
-const FRACTURE_RATIO = 0.03; // 3%
+const FRACTURE_RATIO = 0.08; // 8%
 
 /**
  * SIMPLIFIED: Animation Configuration with immediate state changes


### PR DESCRIPTION
## Summary
- increase crystal fracture snap ratio from 3% to 8% for a more dramatic crack effect

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b11db235e48328bcbe1522a903e8b3