### PR TITLE
refactor: centralize fracture and explosion settings

### DIFF
--- a/src/components/three/FractureBurstParticles.jsx
+++ b/src/components/three/FractureBurstParticles.jsx
@@ -5,10 +5,18 @@ import * as THREE from 'three';
 /**
  * Particle burst that erupts from the crystal center when triggered.
  */
-const FractureBurstParticles = ({ trigger, count = 200, duration = 1.2 }) => {
+const FractureBurstParticles = ({
+  trigger,
+  delay = 0,
+  count = 200,
+  duration = 1.2,
+  color = '#66ffcc',
+  spread = 0.5
+}) => {
   const linesRef = useRef();
   const startTimeRef = useRef(0);
   const velocitiesRef = useRef();
+  const delayRef = useRef();
 
   const { geometry, velocities } = useMemo(() => {
     const positions = new Float32Array(count * 6);
@@ -29,7 +37,7 @@ const FractureBurstParticles = ({ trigger, count = 200, duration = 1.2 }) => {
       velocities[i3 + 1] = dir.y * speed;
       velocities[i3 + 2] = dir.z * speed;
 
-      const length = 1 + Math.random() * 0.5;
+      const length = 1 + Math.random() * spread;
       positions[i6] = positions[i6 + 1] = positions[i6 + 2] = 0;
       positions[i6 + 3] = dir.x * length;
       positions[i6 + 4] = dir.y * length;
@@ -40,7 +48,7 @@ const FractureBurstParticles = ({ trigger, count = 200, duration = 1.2 }) => {
     geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
 
     return { geometry, velocities };
-  }, [count]);
+  }, [count, spread]);
 
   velocitiesRef.current = velocities;
 
@@ -50,42 +58,58 @@ const FractureBurstParticles = ({ trigger, count = 200, duration = 1.2 }) => {
         transparent: true,
         depthWrite: false,
         blending: THREE.AdditiveBlending,
-        color: '#66ffcc',
+        color,
         opacity: 0,
       }),
-    []
+    [color]
   );
 
   useEffect(() => {
     if (!geometry) return;
-    // Reset positions and regenerate velocities
-    const positions = geometry.attributes.position.array;
-    const velocities = velocitiesRef.current;
-    for (let i = 0; i < count; i++) {
-      const i6 = i * 6;
-      const i3 = i * 3;
 
-      const dir = new THREE.Vector3(
-        Math.random() - 0.5,
-        Math.random() - 0.5,
-        Math.random() - 0.5
-      ).normalize();
+    const reset = () => {
+      // Reset positions and regenerate velocities
+      const positions = geometry.attributes.position.array;
+      const velocities = velocitiesRef.current;
+      for (let i = 0; i < count; i++) {
+        const i6 = i * 6;
+        const i3 = i * 3;
 
-      const speed = 20 + Math.random() * 10;
-      velocities[i3] = dir.x * speed;
-      velocities[i3 + 1] = dir.y * speed;
-      velocities[i3 + 2] = dir.z * speed;
+        const dir = new THREE.Vector3(
+          Math.random() - 0.5,
+          Math.random() - 0.5,
+          Math.random() - 0.5
+        ).normalize();
 
-      const length = 1 + Math.random() * 0.5;
-      positions[i6] = positions[i6 + 1] = positions[i6 + 2] = 0;
-      positions[i6 + 3] = dir.x * length;
-      positions[i6 + 4] = dir.y * length;
-      positions[i6 + 5] = dir.z * length;
+        const speed = 20 + Math.random() * 10;
+        velocities[i3] = dir.x * speed;
+        velocities[i3 + 1] = dir.y * speed;
+        velocities[i3 + 2] = dir.z * speed;
+
+        const length = 1 + Math.random() * spread;
+        positions[i6] = positions[i6 + 1] = positions[i6 + 2] = 0;
+        positions[i6 + 3] = dir.x * length;
+        positions[i6 + 4] = dir.y * length;
+        positions[i6 + 5] = dir.z * length;
+      }
+      geometry.attributes.position.needsUpdate = true;
+      material.opacity = 1;
+      startTimeRef.current = performance.now();
+    };
+
+    if (delay > 0) {
+      delayRef.current = setTimeout(reset, delay * 1000);
+    } else {
+      reset();
     }
-    geometry.attributes.position.needsUpdate = true;
-    material.opacity = 1;
-    startTimeRef.current = performance.now();
-  }, [trigger, geometry, material, count]);
+
+    return () => {
+      if (delayRef.current) {
+        clearTimeout(delayRef.current);
+        delayRef.current = null;
+      }
+    };
+  }, [trigger, geometry, material, count, delay, spread]);
 
   useFrame((_, dt) => {
     if (!startTimeRef.current) return;

--- a/src/components/three/UnifiedCrystalScene.jsx
+++ b/src/components/three/UnifiedCrystalScene.jsx
@@ -36,7 +36,6 @@ const UnifiedCrystalScene = forwardRef(({
   const [sphereVisible, setSphereVisible] = useState(false);
   const [ringVisible, setRingVisible] = useState(false);
   const [burstId, setBurstId] = useState(0);
-  const burstTimeoutRef = useRef();
   
   // Crystal state tracking
   const [showWholeCrystal, setShowWholeCrystal] = useState(true);
@@ -80,7 +79,8 @@ const UnifiedCrystalScene = forwardRef(({
   const fractureGlowStartRef = useRef(null);
 
   const triggerFractureGlow = useCallback(() => {
-    fractureGlowStartRef.current = performance.now();
+    const delay = config?.fracture?.emissive?.delay ?? 0;
+    fractureGlowStartRef.current = performance.now() + delay * 1000;
     facetMaterialsRef.current.forEach((mat) => {
       // Start from no glow and fade in during the fracture pause
       mat.emissive.set(0, 0, 0);
@@ -88,7 +88,7 @@ const UnifiedCrystalScene = forwardRef(({
       mat.userData = { ...(mat.userData || {}), isFading: true };
       mat.needsUpdate = true;
     });
-  }, []);
+  }, [config]);
 
   // Track when GLTF models have loaded
   const [modelsLoaded, setModelsLoaded] = useState(false);
@@ -492,7 +492,7 @@ const UnifiedCrystalScene = forwardRef(({
 
       facetMaterialsRef.current.forEach((mat, idx) => {
         const baseIntensity = mat.userData?.baseEmissiveIntensity ?? 0.02;
-        const startIntensity = (config?.effects?.fracture?.initialGlow ?? 2.0) * 0.15;
+        const startIntensity = (config?.fracture?.emissive?.intensity ?? 2.0) * 0.15;
         const baseColor = mat.userData?.baseEmissiveColor || defaultColorRef.current;
         const startColor = projectColors[idx];
 
@@ -685,8 +685,7 @@ const UnifiedCrystalScene = forwardRef(({
           setSphereVisible(true);
           setRingVisible(true);
           explosionStartRef.current = performance.now();
-          if (burstTimeoutRef.current) clearTimeout(burstTimeoutRef.current);
-          burstTimeoutRef.current = setTimeout(() => setBurstId(id => id + 1), 150);
+          setBurstId(id => id + 1);
 
           // Capture hero rotation so facets start from same orientation
           if (wholeCrystalRef.current && facetsGroupRef.current) {
@@ -706,7 +705,7 @@ const UnifiedCrystalScene = forwardRef(({
                 const fallback = explodedPos
                   .clone()
                   .normalize()
-                  .multiplyScalar(Math.min(explodedPos.length(), fractureDistance));
+                  .multiplyScalar(explodedPos.length() * fractureDistance);
                 const fracturePos = configuredFracture ? configuredFracture.clone() : fallback;
                 facetRef.current.position.copy(fracturePos);
 
@@ -744,13 +743,7 @@ const UnifiedCrystalScene = forwardRef(({
     }
 
     lastCrystalForm.current = currentForm;
-    return () => {
-      if (burstTimeoutRef.current) {
-        clearTimeout(burstTimeoutRef.current);
-        burstTimeoutRef.current = null;
-      }
-    };
-  }, [animationData?.crystalForm]);
+  }, [animationData?.crystalForm, triggerFractureGlow]);
 
   // Main animation loop
   useFrame((state, deltaTime) => {
@@ -818,7 +811,7 @@ const UnifiedCrystalScene = forwardRef(({
             const fallback = explodedPos
               .clone()
               .normalize()
-              .multiplyScalar(Math.min(explodedPos.length(), fractureDistance));
+              .multiplyScalar(explodedPos.length() * fractureDistance);
             facetRef.current.position.copy(configured ? configured : fallback);
           }
         });
@@ -874,7 +867,7 @@ const UnifiedCrystalScene = forwardRef(({
           const facetKey = facetKeys[index];
           const end = animationData.crystalConfig.positions[facetKey];
           const start = fracture?.[facetKey] ||
-            end?.clone().normalize().multiplyScalar(Math.min(end.length(), fractureDistance));
+            end?.clone().normalize().multiplyScalar(end.length() * fractureDistance);
           if (start && end) {
             const interpolated = start.clone().lerp(end, eased);
             facetRef.current.position.copy(interpolated);
@@ -976,10 +969,7 @@ const UnifiedCrystalScene = forwardRef(({
       {/* Fracture expanding ring */}
       {ringVisible && !simplifiedAnimations && (
         <FractureRingImage
-          imagePath="/assets/textures/fractureRing02.jpg"
-          baseSize={0.5}
-          maxScale={24}
-          duration={0.4}
+          {...config.fracture.image}
           visible={ringVisible}
           animationData={animationData}
           simplifiedAnimations={simplifiedAnimations}
@@ -1007,7 +997,12 @@ const UnifiedCrystalScene = forwardRef(({
         />
       )}
 
-      {!simplifiedAnimations && <FractureBurstParticles trigger={burstId} />}
+      {!simplifiedAnimations && (
+        <FractureBurstParticles
+          trigger={burstId}
+          {...config.fracture.particles}
+        />
+      )}
 
       {/* Whole Crystal */}
       {showWholeCrystal && (

--- a/src/crystalConfig.js
+++ b/src/crystalConfig.js
@@ -24,13 +24,39 @@ export const explodedPositions = {
   exploration: [-0.6, 0.7, 0.0]   // More dynamic position
 }
 
-// Define the fracture positions (3% of the way to final positions)
-const FRACTURE_SCALE = 0.3;
+// === FRACTURE SETTINGS ===
+// Centralized controls for fracture/explosion effects
+export const fracture = {
+  duration: 0.5,          // Seconds facets remain in fractured state
+  distance: 0.3,          // Percentage of explode distance applied during fracture
+  particles: {
+    delay: 0.15,          // Delay before particle burst (seconds)
+    count: 200,           // Number of burst particles
+    color: '#66ffcc',     // Particle color
+    duration: 1.2,        // Particle fade duration (seconds)
+    spread: 0.5           // How far particles initially spread from origin
+  },
+  image: {
+    imagePath: '/assets/textures/fractureRing02.jpg',
+    baseSize: 0.5,
+    maxScale: 24,
+    duration: 0.4,
+    triggerDelay: 0,
+    fadeInDuration: 0.1,
+    fadeOutDuration: 0.3,
+    scaleEasing: 'linear'
+  },
+  emissive: {
+    intensity: 1.0,       // Bright glow intensity at fracture
+    delay: 0              // Delay before emissive glow starts (seconds)
+  }
+};
+
+// Define the fracture positions based on distance percentage
 export const fracturePositions = Object.fromEntries(
   Object.entries(explodedPositions).map(([key, coords]) => [
     key,
-    // Use full precision to keep the 3% snap exact for tiny movements
-    coords.map(c => c * FRACTURE_SCALE)
+    coords.map(c => c * fracture.distance)
   ])
 );
 
@@ -75,7 +101,7 @@ export const timing = {
   
   // Fracture phase
   fracture: {
-    duration: 350,         // ms - how long the fracture phase lasts
+    duration: fracture.duration * 1000, // ms - how long the fracture phase lasts
     pulseDuration: 100,    // ms - initial pulse animation
     glowFadeDuration: 200, // ms - how long the glow fades after pulse
   },
@@ -182,7 +208,7 @@ export const effects = {
   // Fracture effect
   fracture: {
     maxScaleFactor: 0.1,     // Maximum scale increase during fracture (10%)
-    initialGlow: 1.0,        // Initial bright glow
+    initialGlow: fracture.emissive.intensity, // Initial bright glow
     secondaryGlow: 1.0       // Secondary glow after initial pulse
   }
 }

--- a/src/hooks/useUnifiedAnimationController.js
+++ b/src/hooks/useUnifiedAnimationController.js
@@ -3,10 +3,10 @@
 
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { Vector3, Quaternion } from 'three';
+import { fracture as fractureConfig } from '../crystalConfig';
 
-// Distance in world units that facets snap outward before the full explosion
-// Using a constant lets us tweak how far facets move without modifying config
-const FRACTURE_DISTANCE = 0.3;
+// Percentage of explode distance facets travel during fracture
+const FRACTURE_DISTANCE = fractureConfig.distance;
 
 /**
  * SIMPLIFIED: Animation Configuration with immediate state changes
@@ -116,18 +116,18 @@ export const ANIMATION_CONFIG = {
   }
 };
 
-// Derive fracture positions based on a fixed outward distance along explode vectors
+// Derive fracture positions based on percentage of explode distance
 ANIMATION_CONFIG.crystal.fracturePositions = Object.fromEntries(
   Object.entries(ANIMATION_CONFIG.crystal.explodedPositions).map(([key, vec]) => {
     const direction = vec.clone().normalize();
-    const distance = Math.min(vec.length(), FRACTURE_DISTANCE);
+    const distance = vec.length() * FRACTURE_DISTANCE;
     return [key, direction.multiplyScalar(distance)];
   })
 );
 // Expose the distance so components can consistently compute fallback positions
 ANIMATION_CONFIG.crystal.fractureDistance = FRACTURE_DISTANCE;
 // How long to hold the facets at their fractured positions (seconds)
-ANIMATION_CONFIG.crystal.fracturePause = 0.5;
+ANIMATION_CONFIG.crystal.fracturePause = fractureConfig.duration;
 // Total time for fracture + explosion (seconds). Matches previous explode duration
 // Total time for fracture + explosion (seconds). Matches original explode timing
 ANIMATION_CONFIG.crystal.explodeDuration = 1.6;


### PR DESCRIPTION
## Summary
- centralize fracture configuration for distance, timing, particles, ring image, and emissive glow
- derive fracture positions and timing from config
- expose configurable particle burst and ring components

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b33fe83e9c8328a92605eb037dc90a