### PR TITLE
Add fracture flash to background

### DIFF
--- a/src/components/layout/Fixed3DCanvas.jsx
+++ b/src/components/layout/Fixed3DCanvas.jsx
@@ -1,7 +1,7 @@
 // FIXED: src/components/layout/Fixed3DCanvas.jsx
 // UPDATED: Fixed background color updates for project sections
 
-import React, { useRef, useState, useEffect, forwardRef, useImperativeHandle } from 'react';
+import React, { useRef, useState, useEffect, forwardRef, useImperativeHandle, useCallback } from 'react';
 import { Canvas, useFrame } from '@react-three/fiber';
 import { Environment, OrbitControls } from '@react-three/drei';
 import { EffectComposer, Bloom, ChromaticAberration, Noise, Vignette } from '@react-three/postprocessing';
@@ -69,6 +69,10 @@ const Fixed3DCanvas = forwardRef(({
   const crystalSceneRef = useRef();
   const backgroundRef = useRef();
   const lastZoneRef = useRef(null);
+
+  const handleFractureStart = useCallback(() => {
+    backgroundRef.current?.flash(1, 0.5);
+  }, []);
 
   // Expose internal state to parent components
   useImperativeHandle(ref, () => ({
@@ -280,6 +284,7 @@ const Fixed3DCanvas = forwardRef(({
             isMobile={isMobile}
             simplifiedAnimations={simplifiedAnimations}
             scrollToProgress={scrollToProgress}
+            onFractureStart={handleFractureStart}
           />
           
           {/* Environment used for reflections only */}

--- a/src/components/three/GradientBackground.jsx
+++ b/src/components/three/GradientBackground.jsx
@@ -14,6 +14,7 @@ const vertexShader = /* glsl */`
 const fragmentShader = /* glsl */`
 uniform vec3 colorA;
 uniform vec3 colorB;
+uniform float flash;
 varying vec3 vWorldPosition;
 
 // Hash function for scattered randomness
@@ -62,6 +63,7 @@ void main() {
   float t = clamp(baseT + bursts, 0.0, 1.0);
 
   vec3 color = mix(colorA, colorB, t);
+  color = mix(color, vec3(1.0), flash);
   gl_FragColor = vec4(color, 1.0);
 }
 `;
@@ -76,9 +78,13 @@ const GradientBackground = forwardRef(({ backgrounds, initialKey = 'default', ra
 
   const currentKey = useRef(initialKey);
 
+  const flashIntensityRef = useRef(0);
+  const flashDurationRef = useRef(1);
+
   const uniforms = useMemo(() => ({
     colorA: { value: currentA.current.clone() },
-    colorB: { value: currentB.current.clone() }
+    colorB: { value: currentB.current.clone() },
+    flash: { value: 0 }
   }), []);
 
   useFrame((state, deltaTime) => {
@@ -87,8 +93,16 @@ const GradientBackground = forwardRef(({ backgrounds, initialKey = 'default', ra
     currentA.current.lerp(targetA.current, 0.05 * deltaTime * 60);
     currentB.current.lerp(targetB.current, 0.05 * deltaTime * 60);
 
+    if (flashIntensityRef.current > 0) {
+      flashIntensityRef.current = Math.max(
+        flashIntensityRef.current - deltaTime / flashDurationRef.current,
+        0
+      );
+    }
+
     uniforms.colorA.value.copy(currentA.current);
     uniforms.colorB.value.copy(currentB.current);
+    uniforms.flash.value = flashIntensityRef.current;
     materialRef.current.needsUpdate = true;
   });
 
@@ -116,6 +130,11 @@ const GradientBackground = forwardRef(({ backgrounds, initialKey = 'default', ra
       } else if (import.meta.env.DEV) {
         console.log(`🎨 GradientBackground: Skipping update, already on "${key}"`);
       }
+    },
+
+    flash: (intensity = 1, duration = 0.5) => {
+      flashIntensityRef.current = intensity;
+      flashDurationRef.current = Math.max(duration, 0.001);
     },
 
     getCurrentKey: () => currentKey.current,

--- a/src/components/three/UnifiedCrystalScene.jsx
+++ b/src/components/three/UnifiedCrystalScene.jsx
@@ -23,7 +23,8 @@ const UnifiedCrystalScene = forwardRef(({
   materialVariant = 'default',
   performanceProfile = { useNormalMaps: true, textureQuality: 'high', pbrQuality: 'high', usePBR: true },
   simplifiedAnimations = false,
-  scrollToProgress
+  scrollToProgress,
+  onFractureStart
 }, ref) => {
   // Component refs for crystal animation
   const crystalGroupRef = useRef();
@@ -88,7 +89,8 @@ const UnifiedCrystalScene = forwardRef(({
       mat.userData = { ...(mat.userData || {}), isFading: true };
       mat.needsUpdate = true;
     });
-  }, [config]);
+    onFractureStart?.();
+  }, [config, onFractureStart]);
 
   // Track when GLTF models have loaded
   const [modelsLoaded, setModelsLoaded] = useState(false);


### PR DESCRIPTION
## Summary
- add shader flash uniform and imperative `flash` method to gradient background
- trigger background flash when crystal fracture animation begins

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b45adf84c48328aabb8a14ac34fb13