### PR TITLE
refactor: cache facet label positions

### DIFF
--- a/src/components/three/FacetLabels.jsx
+++ b/src/components/three/FacetLabels.jsx
@@ -61,44 +61,39 @@ const FacetLabels = React.memo(function FacetLabels({
   const layerRef = useRef(null);
   const rootRef = useRef(null);
   const [rootReady, setRootReady] = useState(false);
+  const zoneProgress = animationData?.zoneProgress ?? 1;
+  const inActiveOverview =
+    animationData?.currentZone === 'overview' &&
+    animationData?.crystalForm === 'exploded' &&
+    animationData?.isTransitioning === false &&
+    zoneProgress < 0.98;
 
-  // Create DOM layer
+  // Manage DOM layer creation and cleanup based on overview activation
   useEffect(() => {
-    const layer = document.createElement('div');
-    layer.style.cssText = 'position:fixed;top:0;left:0;width:100%;height:100%;pointer-events:none;z-index:20';
-    document.body.appendChild(layer);
-    layerRef.current = layer;
-    rootRef.current = createRoot(layer);
-    setRootReady(true);
-    return () => {
-      rootRef.current?.unmount();
-      document.body.removeChild(layer);
-    };
-  }, []);
-
-  // Fade out and clean up when leaving the overview or near zone boundaries
-  useEffect(() => {
-    const zoneProgress = animationData?.zoneProgress ?? 1;
-    if (
-      animationData?.isTransitioning ||
-      animationData?.crystalForm !== 'exploded' ||
-      animationData?.currentZone !== 'overview' ||
-      zoneProgress > 0.98
-    ) {
+    if (inActiveOverview && !rootReady) {
+      const layer = document.createElement('div');
+      layer.style.cssText =
+        'position:fixed;top:0;left:0;width:100%;height:100%;pointer-events:none;z-index:20';
+      document.body.appendChild(layer);
+      layerRef.current = layer;
+      rootRef.current = createRoot(layer);
+      setRootReady(true);
+    }
+    if (!inActiveOverview && rootReady) {
       setFadeDuration(0.2);
       setVisible(false);
       const timeout = setTimeout(() => {
         rootRef.current?.render(null);
+        rootRef.current?.unmount();
+        layerRef.current?.remove();
+        rootRef.current = null;
+        layerRef.current = null;
+        setRootReady(false);
         setAnchorScreenPositions({});
       }, 200);
       return () => clearTimeout(timeout);
     }
-  }, [
-    animationData?.isTransitioning,
-    animationData?.crystalForm,
-    animationData?.currentZone,
-    animationData?.zoneProgress,
-  ]);
+  }, [inActiveOverview, rootReady]);
 
   const calculateAndCacheAnchorPositions = useCallback(() => {
     const positions = {};
@@ -112,22 +107,12 @@ const FacetLabels = React.memo(function FacetLabels({
   }, [camera, size]);
 
   useEffect(() => {
-    const zoneProgress = animationData?.zoneProgress ?? 1;
-    if (
-      animationData?.currentZone === 'overview' &&
-      animationData?.isTransitioning === false &&
-      animationData?.crystalForm === 'exploded' &&
-      animationData?.cameraSettled === true &&
-      zoneProgress < 0.98
-    ) {
+    if (inActiveOverview && animationData?.cameraSettled === true) {
       calculateAndCacheAnchorPositions();
     }
   }, [
-    animationData?.currentZone,
-    animationData?.isTransitioning,
+    inActiveOverview,
     animationData?.cameraSettled,
-    animationData?.crystalForm,
-    animationData?.zoneProgress,
     calculateAndCacheAnchorPositions,
   ]);
 
@@ -157,8 +142,11 @@ const FacetLabels = React.memo(function FacetLabels({
 
   // Render labels using cached positions
   useEffect(() => {
-    if (!rootReady || !rootRef.current) return;
-    if (performanceProfile?.simplifiedAnimations || Object.keys(anchorScreenPositions).length === 0) {
+    if (!rootReady || !rootRef.current || !inActiveOverview) return;
+    if (
+      performanceProfile?.simplifiedAnimations ||
+      Object.keys(anchorScreenPositions).length === 0
+    ) {
       rootRef.current.render(null);
       return;
     }
@@ -200,6 +188,7 @@ const FacetLabels = React.memo(function FacetLabels({
     scrollToProgress,
     performanceProfile?.simplifiedAnimations,
     rootReady,
+    inActiveOverview,
   ]);
 
   return null;

--- a/src/components/three/FacetLabels.jsx
+++ b/src/components/three/FacetLabels.jsx
@@ -61,13 +61,10 @@ const FacetLabels = React.memo(function FacetLabels({
   const layerRef = useRef(null);
   const rootRef = useRef(null);
   const fadeTimeoutRef = useRef(null);
-  const zoneProgress = animationData?.zoneInfo?.progress ?? 0;
   const inActiveOverview =
     animationData?.currentZone === 'overview' &&
     animationData?.crystalForm === 'exploded' &&
-    animationData?.isTransitioning === false &&
-    zoneProgress > 0.02 &&
-    zoneProgress < 0.98;
+    animationData?.isTransitioning === false;
 
   const calculateAndCacheAnchorPositions = useCallback(() => {
     const positions = {};

--- a/src/components/three/FacetLabels.jsx
+++ b/src/components/three/FacetLabels.jsx
@@ -1,19 +1,15 @@
-// FIXED: src/components/three/FacetLabels.jsx
-// The issue is camera timing, not facet positions!
-
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { createRoot } from 'react-dom/client';
-import { useFrame, useThree } from '@react-three/fiber';
+import { useThree } from '@react-three/fiber';
 import { Vector3 } from 'three';
 import Headline from '../ui/Headline';
 import { ANIMATION_CONFIG } from '../../hooks/useUnifiedAnimationController';
-import projects from '../../data/projects';
 
-// Static anchor world positions (your original approach is correct!)
+// Predefined anchor positions in world space
 const ANCHOR_WORLD_POSITIONS = {
-  empathy: new Vector3(0.20, -2.37, -0.11),
-  narrative: new Vector3(0.09, -1.16, -1.00),
-  craft: new Vector3(1.39, 0.19, 0.70),
+  empathy: new Vector3(0.2, -2.37, -0.11),
+  narrative: new Vector3(0.09, -1.16, -1.0),
+  craft: new Vector3(1.39, 0.19, 0.7),
   system: new Vector3(-0.74, 0.19, -2.11),
   leadership: new Vector3(0.48, 2.01, 1.19),
   exploration: new Vector3(-0.83, 1.38, -0.07)
@@ -58,15 +54,18 @@ const FacetLabels = React.memo(function FacetLabels({
   animationData,
   performanceProfile,
 }) {
+  // Do nothing while the crystal is transitioning or not exploded
+  if (animationData?.isTransitioning || animationData?.crystalForm !== 'exploded') {
+    return null;
+  }
+
   const { camera, size } = useThree();
+  const [anchorScreenPositions, setAnchorScreenPositions] = useState({});
   const [visible, setVisible] = useState(false);
   const [fadeDuration, setFadeDuration] = useState(0.8);
-  const [rootReady, setRootReady] = useState(false);
-  const [screenPositions, setScreenPositions] = useState({});
-  
   const layerRef = useRef(null);
   const rootRef = useRef(null);
-  const lastCameraHash = useRef('');
+  const [rootReady, setRootReady] = useState(false);
 
   // Create DOM layer
   useEffect(() => {
@@ -82,108 +81,46 @@ const FacetLabels = React.memo(function FacetLabels({
     };
   }, []);
 
-  // Continuously track camera movement to keep label positions in sync
-  useFrame(() => {
-    if (!camera || Object.keys(ANCHOR_WORLD_POSITIONS).length === 0) return;
-
-    const isOverviewState =
-      animationData?.currentZone === 'overview' &&
-      animationData?.cameraState === 'overview' &&
-      animationData?.crystalForm === 'exploded' &&
-      !animationData?.isTransitioning;
-
-    if (!isOverviewState) {
-      if (lastCameraHash.current) {
-        lastCameraHash.current = '';
-        setScreenPositions({});
-      }
-      return;
-    }
-
-    const cameraHash = `${camera.position.x.toFixed(2)},${camera.position.y.toFixed(2)},${camera.position.z.toFixed(2)},${size.width}x${size.height}`;
-    const stateHash = `${animationData.currentZone}-${animationData.cameraState}-${animationData.crystalForm}-${animationData.cameraSettled}`;
-    const fullHash = `${cameraHash}-${stateHash}`;
-
-    if (fullHash === lastCameraHash.current) return;
-
-    const newScreenPositions = {};
-
+  const calculateAndCacheAnchorPositions = useCallback(() => {
+    const positions = {};
     Object.entries(ANCHOR_WORLD_POSITIONS).forEach(([facetKey, worldPos]) => {
-      const vec = worldPos.clone();
-      vec.applyMatrix4(camera.matrixWorldInverse);
-      vec.applyMatrix4(camera.projectionMatrix);
-
-      const screenX = (vec.x * 0.5 + 0.5) * size.width;
-      const screenY = (-vec.y * 0.5 + 0.5) * size.height;
-
-      newScreenPositions[facetKey] = [screenX, screenY];
+      const vec = worldPos.clone().project(camera);
+      const x = (vec.x * 0.5 + 0.5) * size.width;
+      const y = (-vec.y * 0.5 + 0.5) * size.height;
+      positions[facetKey] = { x, y };
     });
+    setAnchorScreenPositions(positions);
+  }, [camera, size]);
 
-    setScreenPositions(newScreenPositions);
-    lastCameraHash.current = fullHash;
-  });
+  useEffect(() => {
+    if (
+      animationData?.isTransitioning === false &&
+      animationData?.crystalForm === 'exploded' &&
+      animationData?.cameraSettled === true
+    ) {
+      calculateAndCacheAnchorPositions();
+    }
+  }, [animationData?.isTransitioning, animationData?.cameraSettled, animationData?.crystalForm, calculateAndCacheAnchorPositions]);
 
-  // Determine when labels should be visible
-  const shouldShow = useMemo(() => {
-    if (performanceProfile?.simplifiedAnimations) return false;
-    if (animationData?.isScrolling) return false;
-    if (animationData?.isTransitioning) return false;
-    if (animationData?.crystalForm !== 'exploded') return false;
-    if (animationData?.currentZone !== 'overview') return false;
-    if (animationData?.focusedProject) return false;
-    if (animationData?.cameraState !== 'overview') return false; // ADDED: Must be in overview camera mode
-    return true;
-  }, [
-    animationData?.crystalForm,
-    animationData?.currentZone,
-    animationData?.focusedProject,
-    animationData?.isScrolling,
-    animationData?.isTransitioning,
-    animationData?.cameraState, // ADDED: Camera state dependency
-    performanceProfile?.simplifiedAnimations,
-  ]);
-
-  // FIXED: Wait for both shouldShow AND stable screen positions
+  // Fade labels in once positions are calculated
   useEffect(() => {
     let timeout;
-    if (shouldShow && Object.keys(screenPositions).length > 0) {
-      // DEBUGGING: Log when we decide to show
-      if (import.meta.env.DEV) {
-        console.log('📍 Ready to show labels:', {
-          shouldShow,
-          hasPositions: Object.keys(screenPositions).length > 0,
-          screenPositions
-        });
-      }
-      
+    if (Object.keys(anchorScreenPositions).length > 0) {
       timeout = setTimeout(() => {
         setFadeDuration(0.8);
         setVisible(true);
-        if (import.meta.env.DEV) {
-          console.log('📍 Showing facet labels with stable positions');
-        }
-      }, 500); // REDUCED: Less delay since we're now ensuring camera stability first
+      }, 0);
     } else {
       setFadeDuration(0.2);
       setVisible(false);
-      if (import.meta.env.DEV && visible) {
-        console.log('📍 Hiding facet labels');
-      }
     }
     return () => clearTimeout(timeout);
-  }, [shouldShow, screenPositions, visible]);
+  }, [anchorScreenPositions]);
 
-  // Render labels
+  // Render labels using cached positions
   useEffect(() => {
-    if (!rootRef.current || !layerRef.current || !rootReady) return;
-    
-    if (performanceProfile?.simplifiedAnimations && !visible) {
-      rootRef.current.render(null);
-      return;
-    }
-
-    // Only render if we have screen positions calculated
-    if (Object.keys(screenPositions).length === 0) {
+    if (!rootReady || !rootRef.current) return;
+    if (performanceProfile?.simplifiedAnimations || Object.keys(anchorScreenPositions).length === 0) {
       rootRef.current.render(null);
       return;
     }
@@ -191,21 +128,15 @@ const FacetLabels = React.memo(function FacetLabels({
     rootRef.current.render(
       <>
         {projects.map((project) => {
-          const pos = screenPositions[project.facetKey];
-          if (!pos) {
-            if (import.meta.env.DEV) {
-              console.warn(`📍 No screen position calculated for project: ${project.facetKey}`);
-            }
-            return null;
-          }
-          
+          const pos = anchorScreenPositions[project.facetKey];
+          if (!pos) return null;
           return (
             <div
               key={project.facetKey}
               style={{
                 position: 'absolute',
-                left: `${pos[0]}px`,
-                top: `${pos[1]}px`,
+                left: `${pos.x}px`,
+                top: `${pos.y}px`,
                 transform: 'translate(-50%, -50%)',
                 opacity: visible ? 1 : 0,
                 transition: `opacity ${fadeDuration}s`,
@@ -223,8 +154,8 @@ const FacetLabels = React.memo(function FacetLabels({
       </>
     );
   }, [
+    anchorScreenPositions,
     projects,
-    screenPositions,
     visible,
     fadeDuration,
     onHoverChange,
@@ -237,3 +168,4 @@ const FacetLabels = React.memo(function FacetLabels({
 });
 
 export default FacetLabels;
+

--- a/src/components/three/FacetLabels.jsx
+++ b/src/components/three/FacetLabels.jsx
@@ -54,11 +54,6 @@ const FacetLabels = React.memo(function FacetLabels({
   animationData,
   performanceProfile,
 }) {
-  // Do nothing while the crystal is transitioning or not exploded
-  if (animationData?.isTransitioning || animationData?.crystalForm !== 'exploded') {
-    return null;
-  }
-
   const { camera, size } = useThree();
   const [anchorScreenPositions, setAnchorScreenPositions] = useState({});
   const [visible, setVisible] = useState(false);
@@ -80,6 +75,19 @@ const FacetLabels = React.memo(function FacetLabels({
       document.body.removeChild(layer);
     };
   }, []);
+
+  // Fade out and clean up when leaving the overview
+  useEffect(() => {
+    if (animationData?.isTransitioning || animationData?.crystalForm !== 'exploded') {
+      setFadeDuration(0.2);
+      setVisible(false);
+      const timeout = setTimeout(() => {
+        rootRef.current?.render(null);
+        setAnchorScreenPositions({});
+      }, 200);
+      return () => clearTimeout(timeout);
+    }
+  }, [animationData?.isTransitioning, animationData?.crystalForm]);
 
   const calculateAndCacheAnchorPositions = useCallback(() => {
     const positions = {};

--- a/src/components/three/FacetLabels.jsx
+++ b/src/components/three/FacetLabels.jsx
@@ -61,10 +61,13 @@ const FacetLabels = React.memo(function FacetLabels({
   const layerRef = useRef(null);
   const rootRef = useRef(null);
   const fadeTimeoutRef = useRef(null);
+  const zoneProgress = animationData?.zoneInfo?.progress ?? 0;
   const inActiveOverview =
     animationData?.currentZone === 'overview' &&
     animationData?.crystalForm === 'exploded' &&
-    animationData?.isTransitioning === false;
+    animationData?.isTransitioning === false &&
+    zoneProgress > 0.02 &&
+    zoneProgress < 0.98;
 
   const calculateAndCacheAnchorPositions = useCallback(() => {
     const positions = {};
@@ -77,21 +80,7 @@ const FacetLabels = React.memo(function FacetLabels({
     setAnchorScreenPositions(positions);
   }, [camera, size]);
 
-  // Create DOM layer once
-  useEffect(() => {
-    const layer = document.createElement('div');
-    layer.style.cssText =
-      'position:fixed;top:0;left:0;width:100%;height:100%;pointer-events:none;z-index:20';
-    document.body.appendChild(layer);
-    layerRef.current = layer;
-    rootRef.current = createRoot(layer);
-    return () => {
-      rootRef.current?.unmount();
-      layer.remove();
-    };
-  }, []);
-
-  // Handle activation and cleanup based on overview state
+  // Handle DOM layer, activation, and cleanup based on overview state
   useEffect(() => {
     if (!inActiveOverview) {
       setFadeDuration(0.2);
@@ -99,16 +88,34 @@ const FacetLabels = React.memo(function FacetLabels({
       clearTimeout(fadeTimeoutRef.current);
       fadeTimeoutRef.current = setTimeout(() => {
         rootRef.current?.render(null);
+        rootRef.current?.unmount();
+        layerRef.current?.remove();
+        rootRef.current = null;
+        layerRef.current = null;
         setAnchorScreenPositions({});
       }, 200);
       return;
     }
 
     clearTimeout(fadeTimeoutRef.current);
+
+    if (!rootRef.current) {
+      const layer = document.createElement('div');
+      layer.style.cssText =
+        'position:fixed;top:0;left:0;width:100%;height:100%;pointer-events:none;z-index:20';
+      document.body.appendChild(layer);
+      layerRef.current = layer;
+      rootRef.current = createRoot(layer);
+    }
+
     if (animationData?.cameraSettled === true) {
       calculateAndCacheAnchorPositions();
     }
-  }, [inActiveOverview, animationData?.cameraSettled, calculateAndCacheAnchorPositions]);
+  }, [
+    inActiveOverview,
+    animationData?.cameraSettled,
+    calculateAndCacheAnchorPositions,
+  ]);
 
   // Fade labels in once positions are calculated
   useEffect(() => {

--- a/src/components/three/FacetLabels.jsx
+++ b/src/components/three/FacetLabels.jsx
@@ -78,7 +78,11 @@ const FacetLabels = React.memo(function FacetLabels({
 
   // Fade out and clean up when leaving the overview
   useEffect(() => {
-    if (animationData?.isTransitioning || animationData?.crystalForm !== 'exploded') {
+    if (
+      animationData?.isTransitioning ||
+      animationData?.crystalForm !== 'exploded' ||
+      animationData?.currentZone !== 'overview'
+    ) {
       setFadeDuration(0.2);
       setVisible(false);
       const timeout = setTimeout(() => {
@@ -87,7 +91,7 @@ const FacetLabels = React.memo(function FacetLabels({
       }, 200);
       return () => clearTimeout(timeout);
     }
-  }, [animationData?.isTransitioning, animationData?.crystalForm]);
+  }, [animationData?.isTransitioning, animationData?.crystalForm, animationData?.currentZone]);
 
   const calculateAndCacheAnchorPositions = useCallback(() => {
     const positions = {};
@@ -102,27 +106,43 @@ const FacetLabels = React.memo(function FacetLabels({
 
   useEffect(() => {
     if (
+      animationData?.currentZone === 'overview' &&
       animationData?.isTransitioning === false &&
       animationData?.crystalForm === 'exploded' &&
       animationData?.cameraSettled === true
     ) {
       calculateAndCacheAnchorPositions();
     }
-  }, [animationData?.isTransitioning, animationData?.cameraSettled, animationData?.crystalForm, calculateAndCacheAnchorPositions]);
+  }, [
+    animationData?.currentZone,
+    animationData?.isTransitioning,
+    animationData?.cameraSettled,
+    animationData?.crystalForm,
+    calculateAndCacheAnchorPositions,
+  ]);
 
   // Fade labels in once positions are calculated
   useEffect(() => {
-    let timeout;
+    let frame1;
+    let frame2;
     if (Object.keys(anchorScreenPositions).length > 0) {
-      timeout = setTimeout(() => {
-        setFadeDuration(0.8);
-        setVisible(true);
-      }, 0);
+      // Render once with opacity 0, then fade up
+      setFadeDuration(0);
+      setVisible(false);
+      frame1 = requestAnimationFrame(() => {
+        frame2 = requestAnimationFrame(() => {
+          setFadeDuration(0.8);
+          setVisible(true);
+        });
+      });
     } else {
       setFadeDuration(0.2);
       setVisible(false);
     }
-    return () => clearTimeout(timeout);
+    return () => {
+      if (frame1) cancelAnimationFrame(frame1);
+      if (frame2) cancelAnimationFrame(frame2);
+    };
   }, [anchorScreenPositions]);
 
   // Render labels using cached positions

--- a/src/components/three/FacetLabels.jsx
+++ b/src/components/three/FacetLabels.jsx
@@ -60,40 +60,11 @@ const FacetLabels = React.memo(function FacetLabels({
   const [fadeDuration, setFadeDuration] = useState(0.8);
   const layerRef = useRef(null);
   const rootRef = useRef(null);
-  const [rootReady, setRootReady] = useState(false);
-  const zoneProgress = animationData?.zoneProgress ?? 1;
+  const fadeTimeoutRef = useRef(null);
   const inActiveOverview =
     animationData?.currentZone === 'overview' &&
     animationData?.crystalForm === 'exploded' &&
-    animationData?.isTransitioning === false &&
-    zoneProgress < 0.98;
-
-  // Manage DOM layer creation and cleanup based on overview activation
-  useEffect(() => {
-    if (inActiveOverview && !rootReady) {
-      const layer = document.createElement('div');
-      layer.style.cssText =
-        'position:fixed;top:0;left:0;width:100%;height:100%;pointer-events:none;z-index:20';
-      document.body.appendChild(layer);
-      layerRef.current = layer;
-      rootRef.current = createRoot(layer);
-      setRootReady(true);
-    }
-    if (!inActiveOverview && rootReady) {
-      setFadeDuration(0.2);
-      setVisible(false);
-      const timeout = setTimeout(() => {
-        rootRef.current?.render(null);
-        rootRef.current?.unmount();
-        layerRef.current?.remove();
-        rootRef.current = null;
-        layerRef.current = null;
-        setRootReady(false);
-        setAnchorScreenPositions({});
-      }, 200);
-      return () => clearTimeout(timeout);
-    }
-  }, [inActiveOverview, rootReady]);
+    animationData?.isTransitioning === false;
 
   const calculateAndCacheAnchorPositions = useCallback(() => {
     const positions = {};
@@ -106,15 +77,38 @@ const FacetLabels = React.memo(function FacetLabels({
     setAnchorScreenPositions(positions);
   }, [camera, size]);
 
+  // Create DOM layer once
   useEffect(() => {
-    if (inActiveOverview && animationData?.cameraSettled === true) {
+    const layer = document.createElement('div');
+    layer.style.cssText =
+      'position:fixed;top:0;left:0;width:100%;height:100%;pointer-events:none;z-index:20';
+    document.body.appendChild(layer);
+    layerRef.current = layer;
+    rootRef.current = createRoot(layer);
+    return () => {
+      rootRef.current?.unmount();
+      layer.remove();
+    };
+  }, []);
+
+  // Handle activation and cleanup based on overview state
+  useEffect(() => {
+    if (!inActiveOverview) {
+      setFadeDuration(0.2);
+      setVisible(false);
+      clearTimeout(fadeTimeoutRef.current);
+      fadeTimeoutRef.current = setTimeout(() => {
+        rootRef.current?.render(null);
+        setAnchorScreenPositions({});
+      }, 200);
+      return;
+    }
+
+    clearTimeout(fadeTimeoutRef.current);
+    if (animationData?.cameraSettled === true) {
       calculateAndCacheAnchorPositions();
     }
-  }, [
-    inActiveOverview,
-    animationData?.cameraSettled,
-    calculateAndCacheAnchorPositions,
-  ]);
+  }, [inActiveOverview, animationData?.cameraSettled, calculateAndCacheAnchorPositions]);
 
   // Fade labels in once positions are calculated
   useEffect(() => {
@@ -142,7 +136,7 @@ const FacetLabels = React.memo(function FacetLabels({
 
   // Render labels using cached positions
   useEffect(() => {
-    if (!rootReady || !rootRef.current || !inActiveOverview) return;
+    if (!rootRef.current || !inActiveOverview) return;
     if (
       performanceProfile?.simplifiedAnimations ||
       Object.keys(anchorScreenPositions).length === 0
@@ -187,7 +181,6 @@ const FacetLabels = React.memo(function FacetLabels({
     onHoverChange,
     scrollToProgress,
     performanceProfile?.simplifiedAnimations,
-    rootReady,
     inActiveOverview,
   ]);
 

--- a/src/components/three/FacetLabels.jsx
+++ b/src/components/three/FacetLabels.jsx
@@ -76,12 +76,14 @@ const FacetLabels = React.memo(function FacetLabels({
     };
   }, []);
 
-  // Fade out and clean up when leaving the overview
+  // Fade out and clean up when leaving the overview or near zone boundaries
   useEffect(() => {
+    const zoneProgress = animationData?.zoneProgress ?? 1;
     if (
       animationData?.isTransitioning ||
       animationData?.crystalForm !== 'exploded' ||
-      animationData?.currentZone !== 'overview'
+      animationData?.currentZone !== 'overview' ||
+      zoneProgress > 0.98
     ) {
       setFadeDuration(0.2);
       setVisible(false);
@@ -91,7 +93,12 @@ const FacetLabels = React.memo(function FacetLabels({
       }, 200);
       return () => clearTimeout(timeout);
     }
-  }, [animationData?.isTransitioning, animationData?.crystalForm, animationData?.currentZone]);
+  }, [
+    animationData?.isTransitioning,
+    animationData?.crystalForm,
+    animationData?.currentZone,
+    animationData?.zoneProgress,
+  ]);
 
   const calculateAndCacheAnchorPositions = useCallback(() => {
     const positions = {};
@@ -105,11 +112,13 @@ const FacetLabels = React.memo(function FacetLabels({
   }, [camera, size]);
 
   useEffect(() => {
+    const zoneProgress = animationData?.zoneProgress ?? 1;
     if (
       animationData?.currentZone === 'overview' &&
       animationData?.isTransitioning === false &&
       animationData?.crystalForm === 'exploded' &&
-      animationData?.cameraSettled === true
+      animationData?.cameraSettled === true &&
+      zoneProgress < 0.98
     ) {
       calculateAndCacheAnchorPositions();
     }
@@ -118,6 +127,7 @@ const FacetLabels = React.memo(function FacetLabels({
     animationData?.isTransitioning,
     animationData?.cameraSettled,
     animationData?.crystalForm,
+    animationData?.zoneProgress,
     calculateAndCacheAnchorPositions,
   ]);
 


### PR DESCRIPTION
## Summary
- avoid per-frame calculations for facet labels by caching anchor screen positions after the crystal settles
- render labels from cached coordinates, keeping component dormant during transitions

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b5a05be33c83288ddd3b6c93a8076b