### PR TITLE
Delay facet labels until camera settles

### DIFF
--- a/src/components/three/FacetLabels.jsx
+++ b/src/components/three/FacetLabels.jsx
@@ -64,7 +64,8 @@ const FacetLabels = React.memo(function FacetLabels({
   const inActiveOverview =
     animationData?.currentZone === 'overview' &&
     animationData?.crystalForm === 'exploded' &&
-    animationData?.isTransitioning === false;
+    animationData?.isTransitioning === false &&
+    animationData?.cameraSettled === true;
 
   const calculateAndCacheAnchorPositions = useCallback(() => {
     const positions = {};

--- a/src/components/three/FacetLabels.jsx
+++ b/src/components/three/FacetLabels.jsx
@@ -78,20 +78,13 @@ const FacetLabels = React.memo(function FacetLabels({
     setAnchorScreenPositions(positions);
   }, [camera, size]);
 
-  // Fade labels as soon as we start moving away from the overview
+  // Fade labels the moment the camera leaves the overview state
   useEffect(() => {
-    if (
-      animationData?.currentZone === 'overview' &&
-      (animationData?.isTransitioning || animationData?.cameraSettled === false)
-    ) {
+    if (animationData?.cameraState !== 'overview') {
       setFadeDuration(0.2);
       setVisible(false);
     }
-  }, [
-    animationData?.currentZone,
-    animationData?.isTransitioning,
-    animationData?.cameraSettled,
-  ]);
+  }, [animationData?.cameraState]);
 
   // Handle DOM layer, activation, and cleanup based on overview state
   useEffect(() => {

--- a/src/components/three/FacetLabels.jsx
+++ b/src/components/three/FacetLabels.jsx
@@ -78,13 +78,31 @@ const FacetLabels = React.memo(function FacetLabels({
     setAnchorScreenPositions(positions);
   }, [camera, size]);
 
-  // Fade labels the moment the camera leaves the overview state
+  // Fade labels when the first project scrolls into view
   useEffect(() => {
-    if (animationData?.cameraState !== 'overview') {
-      setFadeDuration(0.2);
-      setVisible(false);
-    }
-  }, [animationData?.cameraState]);
+    const firstFacetKey = projects?.[0]?.facetKey;
+    if (!firstFacetKey || !inActiveOverview) return;
+
+    const section = document.getElementById(`project-${firstFacetKey}`);
+    if (!section) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.intersectionRatio >= 0.1) {
+          setFadeDuration(0.2);
+          setVisible(false);
+        } else if (inActiveOverview) {
+          setFadeDuration(0.8);
+          setVisible(true);
+        }
+      },
+      { threshold: 0.1 }
+    );
+
+    observer.observe(section);
+
+    return () => observer.disconnect();
+  }, [projects, inActiveOverview]);
 
   // Handle DOM layer, activation, and cleanup based on overview state
   useEffect(() => {

--- a/src/components/three/FacetLabels.jsx
+++ b/src/components/three/FacetLabels.jsx
@@ -78,6 +78,21 @@ const FacetLabels = React.memo(function FacetLabels({
     setAnchorScreenPositions(positions);
   }, [camera, size]);
 
+  // Fade labels as soon as we start moving away from the overview
+  useEffect(() => {
+    if (
+      animationData?.currentZone === 'overview' &&
+      (animationData?.isTransitioning || animationData?.cameraSettled === false)
+    ) {
+      setFadeDuration(0.2);
+      setVisible(false);
+    }
+  }, [
+    animationData?.currentZone,
+    animationData?.isTransitioning,
+    animationData?.cameraSettled,
+  ]);
+
   // Handle DOM layer, activation, and cleanup based on overview state
   useEffect(() => {
     if (!inActiveOverview) {


### PR DESCRIPTION
## Summary
- Require `cameraSettled` before showing facet labels to avoid premature display during zone transitions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint src/components/three/FacetLabels.jsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b5ce7d1c8c8328bac2102c3ea8ae2b