### PR TITLE
Ensure first project activates on entering projects zone

### DIFF
--- a/src/hooks/useUnifiedAnimationController.js
+++ b/src/hooks/useUnifiedAnimationController.js
@@ -420,8 +420,8 @@ export const useUnifiedAnimationController = (options = {}) => {
         }
       }
       
-      // Set initial project if none is set but we have an active project
-      if (!animationState.focusedFacet && activeProject.project && activeProject.progress > 0.05) {
+      // Set initial project immediately when entering projects zone
+      if (!animationState.focusedFacet && activeProject.project) {
         if (import.meta.env.DEV) {
           console.log(`🎯 Setting initial project: ${activeProject.project}`);
           console.log(`🎨 Background trigger: Initial project set to "${activeProject.project}"`);


### PR DESCRIPTION
## Summary
- Set first project focus immediately when entering projects zone
- Prevent skipping empathy when transitioning from overview

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b6592eb73883289a660555e38f2883