### PR TITLE
Guard HDRI debug logs

### DIFF
--- a/src/utils/AssetLoaderV2.js
+++ b/src/utils/AssetLoaderV2.js
@@ -258,7 +258,9 @@ export default class AssetLoaderV2 {
 
   // COMPLETELY REWRITTEN: Simple, reliable HDRI loading
   async loadHDRI(url, key) {
-    console.log(`🌍 Starting simple HDRI load: ${url}`);
+    if (import.meta.env.DEV) {
+      console.log(`🌍 Starting simple HDRI load: ${url}`);
+    }
     
     return new Promise((resolve, reject) => {
       // Use the THREE.js RGBELoader directly with its built-in loading
@@ -277,7 +279,9 @@ export default class AssetLoaderV2 {
         // Success callback
         (texture) => {
           clearTimeout(timeoutId);
-          console.log('🌍 HDRI loaded successfully');
+          if (import.meta.env.DEV) {
+            console.log('🌍 HDRI loaded successfully');
+          }
           
           // Configure texture
           texture.mapping = THREE.EquirectangularReflectionMapping;


### PR DESCRIPTION
## Summary
- wrap HDRI loader debug logs with `import.meta.env.DEV`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8dbe75e848328b1787fa366771cf3