### PR TITLE
Preload fracture textures and mount FX components at startup

### DIFF
--- a/src/components/three/FractureRingImage.jsx
+++ b/src/components/three/FractureRingImage.jsx
@@ -1,8 +1,8 @@
 import React, { useRef, useState, useEffect, useMemo } from 'react';
 import { useFrame } from '@react-three/fiber';
-import { useTexture } from '@react-three/drei';
 import * as THREE from 'three';
 import { BLENDING_MODES } from './GlowingSphereImage';
+import { getFractureRingTexture } from '../../loader/preloadFractureAssets';
 
 /**
  * Enhanced Fracture Ring Image with tweakable parameters
@@ -10,8 +10,6 @@ import { BLENDING_MODES } from './GlowingSphereImage';
  * Black in the texture becomes transparent via additive blending.
  */
 const FractureRingImage = ({
-  imagePath = '/assets/textures/fractureRing02.jpg',
-  
   // SCALE PARAMETERS - Easy to tweak!
   baseSize = 0.5,        // Starting size of the ring
   maxScale = 24,         // Maximum scale the ring reaches
@@ -44,22 +42,7 @@ const FractureRingImage = ({
   const [delayTimer, setDelayTimer] = useState(null);
   const lastForm = useRef('whole');
 
-  const texture = useTexture(imagePath);
-
-  // Configure texture
-  useEffect(() => {
-    if (texture) {
-      texture.minFilter = THREE.LinearFilter;
-      texture.magFilter = THREE.LinearFilter;
-      texture.anisotropy = Math.min(4, texture.renderer?.capabilities?.getMaxAnisotropy?.() || 1);
-      texture.generateMipmaps = false;
-      texture.colorSpace = THREE.SRGBColorSpace;
-      texture.wrapS = THREE.ClampToEdgeWrapping;
-      texture.wrapT = THREE.ClampToEdgeWrapping;
-      texture.flipY = false;
-      texture.needsUpdate = true;
-    }
-  }, [texture]);
+  const texture = getFractureRingTexture();
 
   const material = useMemo(() => new THREE.MeshBasicMaterial({
     map: texture,
@@ -204,7 +187,7 @@ const FractureRingImage = ({
     };
   }, [delayTimer]);
 
-  if (!visible || simplifiedAnimations) return null;
+  if (!visible || simplifiedAnimations || !texture) return null;
 
   return (
     <mesh

--- a/src/components/three/GlowingSphereImage.jsx
+++ b/src/components/three/GlowingSphereImage.jsx
@@ -3,8 +3,8 @@
 
 import React, { useRef, useState, useEffect, useMemo } from 'react';
 import { useFrame } from '@react-three/fiber';
-import { useTexture } from '@react-three/drei';
 import * as THREE from 'three';
+import { getGlowingSphereTexture } from '../../loader/preloadFractureAssets';
 
 /**
  * BLENDING MODE OPTIONS for Three.js materials
@@ -27,9 +27,6 @@ export const BLENDING_MODES = {
  * Enhanced Plane-Based Sphere with Anti-Banding Support
  */
 const GlowingSphereImage = ({
-  // Image path
-  imagePath = '/assets/textures/glowing-sphere06-noise.jpg',
-  
   // Size settings
   baseSize = 0.5,
   maxScale = 2.0,
@@ -68,9 +65,8 @@ const GlowingSphereImage = ({
   const [isExploding, setIsExploding] = useState(false);
   const [startTime, setStartTime] = useState(0);
   const lastCrystalForm = useRef('whole');
-  
-  // Load texture once with enhanced settings
-  const texture = useTexture(imagePath);
+
+  const texture = getGlowingSphereTexture();
   
   // ENHANCED: Configure texture with anti-banding settings
   useEffect(() => {
@@ -112,12 +108,11 @@ const GlowingSphereImage = ({
         if (import.meta.env.DEV) console.log('🌟 Enhanced sphere texture loaded:', {
           filtering: textureFiltering,
           anisotropy: texture.anisotropy,
-          colorSpace: texture.colorSpace,
-          imagePath
+          colorSpace: texture.colorSpace
         });
       }
     }
-  }, [texture, textureFiltering, imagePath, debugMode]);
+  }, [texture, textureFiltering, debugMode]);
   
   // Create geometry with higher tessellation for smoother appearance
   const geometry = useMemo(() => {
@@ -208,7 +203,7 @@ const GlowingSphereImage = ({
     }
   });
   
-  if (!visible || simplifiedAnimations) return null;
+  if (!visible || simplifiedAnimations || !texture) return null;
   
   return (
     <mesh

--- a/src/components/three/UnifiedCrystalScene.jsx
+++ b/src/components/three/UnifiedCrystalScene.jsx
@@ -988,35 +988,30 @@ const UnifiedCrystalScene = forwardRef(({
       />
 
       {/* Fracture expanding ring */}
-      {ringVisible && !simplifiedAnimations && (
-        <FractureRingImage
-          {...config.fracture.image}
-          visible={ringVisible}
-          animationData={animationData}
-          simplifiedAnimations={simplifiedAnimations}
-          debugMode={import.meta.env.DEV}
-        />
-      )}
+      <FractureRingImage
+        {...config.fracture.image}
+        visible={ringVisible}
+        animationData={animationData}
+        simplifiedAnimations={simplifiedAnimations}
+        debugMode={import.meta.env.DEV}
+      />
 
       {/* Enhanced Glowing Sphere */}
-      {sphereVisible && !simplifiedAnimations && (
-        <GlowingSphereImage
-          imagePath="/assets/textures/glowing-sphere06-noise.jpg"
-          blendingMode={BLENDING_MODES.ADDITIVE}
-          enableDithering={true}
-          enableAntialiasing={true}
-          textureFiltering="enhanced"
-          baseSize={0.2}
-          maxScale={1.0}
-          explosionDuration={0.05}
-          fadeInDuration={0.02}
-          position={[0, 0, 0]}
-          visible={sphereVisible}
-          animationData={animationData}
-          simplifiedAnimations={simplifiedAnimations}
-          debugMode={import.meta.env.DEV}
-        />
-      )}
+      <GlowingSphereImage
+        blendingMode={BLENDING_MODES.ADDITIVE}
+        enableDithering={true}
+        enableAntialiasing={true}
+        textureFiltering="enhanced"
+        baseSize={0.2}
+        maxScale={1.0}
+        explosionDuration={0.05}
+        fadeInDuration={0.02}
+        position={[0, 0, 0]}
+        visible={sphereVisible}
+        animationData={animationData}
+        simplifiedAnimations={simplifiedAnimations}
+        debugMode={import.meta.env.DEV}
+      />
 
       {!simplifiedAnimations && (
         <FractureBurstParticles

--- a/src/loader/preloadFractureAssets.js
+++ b/src/loader/preloadFractureAssets.js
@@ -1,0 +1,39 @@
+import * as THREE from 'three';
+
+let fractureRingTex = null;
+let glowSphereTex = null;
+
+const FRACTURE_RING_URL = '/assets/textures/fractureRing03.jpg';
+const GLOW_SPHERE_URL = '/assets/textures/glowing-sphere06-noise.jpg';
+
+export async function preloadFractureAssets() {
+  const loader = new THREE.TextureLoader();
+
+  const [ring, glow] = await Promise.all([
+    loader.loadAsync(FRACTURE_RING_URL),
+    loader.loadAsync(GLOW_SPHERE_URL)
+  ]);
+
+  [ring, glow].forEach((t) => {
+    // Match project texture settings
+    t.minFilter = THREE.LinearFilter;
+    t.magFilter = THREE.LinearFilter;
+    t.wrapS = THREE.ClampToEdgeWrapping;
+    t.wrapT = THREE.ClampToEdgeWrapping;
+    t.generateMipmaps = false;
+    t.colorSpace = THREE.SRGBColorSpace;
+    t.flipY = false;
+    t.needsUpdate = true;
+  });
+
+  fractureRingTex = ring;
+  glowSphereTex = glow;
+}
+
+export function getFractureRingTexture() {
+  return fractureRingTex;
+}
+
+export function getGlowingSphereTexture() {
+  return glowSphereTex;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,11 +2,21 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App.jsx';
+import { preloadFractureAssets } from './loader/preloadFractureAssets';
 
-const rootEl = document.getElementById('root');
+async function boot() {
+  try {
+    await preloadFractureAssets();
+  } catch (e) {
+    console.warn('Fracture assets preload failed:', e);
+  }
 
-createRoot(rootEl).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
-);
+  const rootEl = document.getElementById('root');
+  createRoot(rootEl).render(
+    <StrictMode>
+      <App />
+    </StrictMode>
+  );
+}
+
+boot();


### PR DESCRIPTION
## Summary
- preload fracture ring and glow sphere textures on boot and expose accessors
- inject cached textures into FractureRingImage and GlowingSphereImage
- always mount fracture visuals so first trigger is in sync

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68bb090f5eb4832886777e8b629789ab