### PR TITLE
Improve loader progress indicators and messaging

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -404,13 +404,17 @@ function App() {
   // UPDATED: Determine loader message and early return before app mounts
   let statusMessage = '';
   if (initProgress < 100) {
-    statusMessage = 'Initializing application...';
+    statusMessage = 'Initializing...';
   } else if (!performanceReady) {
-    statusMessage = testStatus || 'Testing performance...';
+    statusMessage = 'Optimizing for your device...';
   } else if (!assetsReady) {
-    statusMessage = currentAsset || 'Loading assets...';
+    if (currentAsset && /loaded|failed|timed out/i.test(currentAsset)) {
+      statusMessage = 'Loading assets...';
+    } else {
+      statusMessage = currentAsset || 'Loading assets...';
+    }
   } else {
-    statusMessage = 'Finalizing...';
+    statusMessage = 'Finishing up...';
   }
 
   if (!isAppReady && !exitLoader) {

--- a/src/hooks/useAssetLoaderV2.js
+++ b/src/hooks/useAssetLoaderV2.js
@@ -83,25 +83,29 @@ export const useAssetLoaderV2 = (performanceProfile) => {
   const handleProgress = useCallback((progressData) => {
     const { type, progress, currentAsset, loaded, total } = progressData;
 
-    // Calculate overall progress based on asset completion
+    const stats = assetLoaderRef.current?.getLoadingStats();
     let overallProgress = 0;
-    if (assetLoaderRef.current) {
-      const stats = assetLoaderRef.current.getLoadingStats();
-      overallProgress = stats.progress;
+
+    if (['gltf_download', 'texture_download', 'hdri_download'].includes(type) && stats) {
+      const completedCount = stats.loaded;
+      if (progressData.total) {
+        const fraction = progressData.loaded / progressData.total;
+        overallProgress = ((completedCount + fraction) / stats.total) * 100;
+      } else {
+        overallProgress = stats.progress || progress || 0;
+      }
     } else {
-      overallProgress = progress || 0;
+      overallProgress = stats?.progress || progress || 0;
     }
 
-    // Update state with real progress
     setLoadingState(prev => ({
       ...prev,
       progress: Math.round(overallProgress),
       currentAsset: currentAsset || prev.currentAsset,
-      loadedAssets: assetLoaderRef.current?.getLoadingStats().loaded || prev.loadedAssets,
+      loadedAssets: stats?.loaded || prev.loadedAssets,
       phase: overallProgress >= 100 ? 'ready' : 'loading'
     }));
 
-    // Update global HTML loader immediately
     window.updateImmediateLoader?.({
       assets: overallProgress,
       phase: 'Loading Assets',

--- a/src/ui/LoaderV2.tsx
+++ b/src/ui/LoaderV2.tsx
@@ -34,9 +34,9 @@ const LoaderV2: React.FC<LoaderProps> = ({
     size / 2 - (stroke * 5) / 2
   ];
 
-  const [outer, setOuter] = useState(0);
-  const [middle, setMiddle] = useState(0);
-  const [inner, setInner] = useState(0);
+  const [outer, setOuter] = useState(() => clamp(initProgress) * 100);
+  const [middle, setMiddle] = useState(() => clamp(assetProgress) * 100);
+  const [inner, setInner] = useState(() => clamp(testProgress) * 100);
 
   useEffect(() => {
     if (exiting) {
@@ -73,42 +73,44 @@ const LoaderV2: React.FC<LoaderProps> = ({
           className={styles.svg}
           viewBox={`-${size / 2} -${size / 2} ${size} ${size}`}
         >
-          {radii.map((r, i) => (
-            <circle
-              key={`track-${i}`}
-              className={styles.track}
-              cx={0}
-              cy={0}
-              r={r}
-              fill="none"
-              stroke="var(--ringTrack)"
-              strokeWidth={stroke}
-            />
-          ))}
-
-          {[
-            { r: radii[0], color: 'var(--ring1)', progress: outer },
-            { r: radii[1], color: 'var(--ring2)', progress: middle },
-            { r: radii[2], color: 'var(--ring3)', progress: inner }
-          ].map((ring, i) => {
-            const circumference = 2 * Math.PI * ring.r;
-            const offset = circumference * (1 - ring.progress / 100);
-            return (
+          <g transform="rotate(90 0 0)">
+            {radii.map((r, i) => (
               <circle
-                key={`progress-${i}`}
-                className={`${styles.progress} ${exiting ? styles.complete : ''}`}
+                key={`track-${i}`}
+                className={styles.track}
                 cx={0}
                 cy={0}
-                r={ring.r}
+                r={r}
                 fill="none"
-                stroke={ring.color}
+                stroke="var(--ringTrack)"
                 strokeWidth={stroke}
-                strokeDasharray={circumference}
-                strokeDashoffset={offset}
-                strokeLinecap="round"
               />
-            );
-          })}
+            ))}
+
+            {[
+              { r: radii[0], color: 'var(--ring1)', progress: outer },
+              { r: radii[1], color: 'var(--ring2)', progress: middle },
+              { r: radii[2], color: 'var(--ring3)', progress: inner }
+            ].map((ring, i) => {
+              const circumference = 2 * Math.PI * ring.r;
+              const offset = circumference * (1 - ring.progress / 100);
+              return (
+                <circle
+                  key={`progress-${i}`}
+                  className={`${styles.progress} ${exiting ? styles.complete : ''}`}
+                  cx={0}
+                  cy={0}
+                  r={ring.r}
+                  fill="none"
+                  stroke={ring.color}
+                  strokeWidth={stroke}
+                  strokeDasharray={circumference}
+                  strokeDashoffset={offset}
+                  strokeLinecap="round"
+                />
+              );
+            })}
+          </g>
 
           <g style={{ transform: 'scale(var(--diamond-scale,1))' }}>
             <image


### PR DESCRIPTION
## Summary
- Rotate loader rings so progress begins at the bottom and preserve progress on remount
- Track partial asset downloads for smooth 0–100% progress updates
- Clarify loader status messages with user-friendly text

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bb1628d1ac8328819e49aba916563e