### PR TITLE
Adjust dust particle size scaling

### DIFF
--- a/src/components/three/PersistentDustSystem.jsx
+++ b/src/components/three/PersistentDustSystem.jsx
@@ -23,8 +23,10 @@ const PersistentDustSystem = ({
   driftSpeed = 0.5,
   fadeStart = 0.3,
   fadeEnd = 1.8,
-  baseSize = 0.2,
-  sizeVariation = 8.0,
+  // Increased default base size to restore ~6px particle rendering
+  baseSize = 0.4,
+  // Reduced variation to compensate for larger base size
+  sizeVariation = 3.5,
   color = '#ff6b35',
   emissiveIntensity = 1.0,
   blending = THREE.AdditiveBlending,


### PR DESCRIPTION
## Summary
- Double PersistentDustSystem particle base size and reduce variation to restore ~6px rendering

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bb32047c9c832898754934f92ddd3c