### PR TITLE
fix: restore device-independent particle scaling

### DIFF
--- a/src/components/three/PersistentDustSystem.jsx
+++ b/src/components/three/PersistentDustSystem.jsx
@@ -53,7 +53,7 @@ const PersistentDustSystem = ({
   const timeRef = useRef(0);
 
   const { size } = useThree();
-  const { px, dpr } = usePxToWorld();
+  const { px } = usePxToWorld();
   
   // Load the particle texture
   const particleTexture = useTexture('/assets/textures/particle-dust05.png');
@@ -193,7 +193,7 @@ const PersistentDustSystem = ({
         uIridescenceVariation: { value: iridescenceVariation },
         uShimmerIntensity: { value: shimmerIntensity },
         uPx: { value: px(1) },
-        uScale: { value: (size.height * dpr) / 2 }
+        uScale: { value: size.height / 2 }
       },
       vertexShader: `
         attribute float size;
@@ -358,7 +358,6 @@ const PersistentDustSystem = ({
     enableFrustumCulling,
     maxDistance,
     px,
-    dpr,
     size.height
   ]);
 
@@ -369,7 +368,7 @@ const PersistentDustSystem = ({
     if (material.uniforms) {
       material.uniforms.uTime.value = timeRef.current;
       material.uniforms.uPx.value = px(1);
-      material.uniforms.uScale.value = (state.size.height * state.gl.getPixelRatio()) / 2;
+      material.uniforms.uScale.value = state.size.height / 2;
     }
     
     const positions = geometry.attributes.position.array;

--- a/src/hooks/usePxToWorld.js
+++ b/src/hooks/usePxToWorld.js
@@ -11,10 +11,13 @@ export function usePxToWorld() {
   const { size, viewport, gl } = useThree();
   const dpr = gl.getPixelRatio();
 
+  // Normalize height to CSS pixels so world-per-pixel is DPR-proof
+  const cssHeight = size.height / dpr;
+
   // world units per 1 CSS pixel at Z=0
   const worldPerPx = useMemo(
-    () => viewport.height / size.height,
-    [viewport.height, size.height]
+    () => viewport.height / cssHeight,
+    [viewport.height, cssHeight]
   );
 
   const px = (n) => n * worldPerPx;            // CSS px → world units


### PR DESCRIPTION
## Summary
- normalize pixel-to-world conversion against device pixel ratio
- use CSS-based height in dust shader for DPR-safe scaling

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `npx eslint .` *(fails: found 37 errors, 42 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bb72c5428483288aca6fba68de37e1