### PR TITLE
Add crystal ember preset for dust system

### DIFF
--- a/src/components/layout/Fixed3DCanvas.jsx
+++ b/src/components/layout/Fixed3DCanvas.jsx
@@ -11,7 +11,7 @@ import * as THREE from 'three';
 // FIXED: Import enhanced camera controller from correct path
 import UnifiedCameraController from '../three/UnifiedCameraController';
 import UnifiedCrystalScene from '../three/UnifiedCrystalScene';
-import PersistentDustSystem from '../three/PersistentDustSystem';
+import PersistentDustSystem, { CRYSTAL_EMBER_PRESET } from '../three/PersistentDustSystem';
 import { FPSCounter } from '../ui/FpsDisplay';
 
 // ADDED: Import the debug panels component
@@ -215,7 +215,11 @@ const Fixed3DCanvas = forwardRef(({
 
           {/* Persistent Dust System */}
           {dustEnabled && (
-            <PersistentDustSystem count={particleCount} enabled={dustEnabled} />
+            <PersistentDustSystem
+              enabled={dustEnabled}
+              {...CRYSTAL_EMBER_PRESET}
+              count={particleCount ?? CRYSTAL_EMBER_PRESET.count}
+            />
           )}
           
           {/* UPDATED: Enhanced lighting setup with bottom directional light */}

--- a/src/components/three/PersistentDustSystem.jsx
+++ b/src/components/three/PersistentDustSystem.jsx
@@ -5,6 +5,45 @@ import { useTexture } from '@react-three/drei';
 import * as THREE from 'three';
 import { usePxToWorld } from '../../hooks/usePxToWorld';
 
+export const CRYSTAL_EMBER_PRESET = {
+  // Emission - start below crystal base
+  emissionHeight: -1.5,
+  emissionRadius: 1.2,
+  emissionInnerRadius: 0.3,
+
+  // Movement - rise around crystal over 3-5 seconds  
+  riseHeight: 3.5,
+  baseRiseSpeed: 0.7,
+
+  // Vortex motion
+  spiralStrength: 0.8,
+  spiralRadius: 0.8,
+  spiralSpeed: 0.004,
+
+  // Turbulence for ember-like movement
+  turbulenceStrength: 0.3,
+  turbulenceSpeed: 0.6,
+
+  // Particle lifecycle
+  minLifetime: 3.0,
+  maxLifetime: 5.0,
+  fadeStart: 0.6,
+  fadeEnd: 1.0,
+
+  // Size appropriate for crystal scale
+  baseSize: 8,
+  sizeVariation: 3.0,
+
+  // Never cull - always visible
+  maxDistance: 50,
+  enableFrustumCulling: false,
+
+  // Ember appearance
+  color: '#ff6b35',
+  emissiveIntensity: 1.2,
+  count: 12
+};
+
 /**
  * Enhanced Ember System with iridescent shimmer, spiral vortex motion, and directional rotation
  * FIXED: Ring/donut emission pattern and static iridescence


### PR DESCRIPTION
## Summary
- add CRYSTAL_EMBER_PRESET tuned for crystal scene scale
- apply crystal preset to PersistentDustSystem in Fixed3DCanvas

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc708e637083289faccaed5865b4bc