### PR TITLE
Add focus texture overlay fade to crystal facets

### DIFF
--- a/src/components/three/UnifiedCrystalScene.jsx
+++ b/src/components/three/UnifiedCrystalScene.jsx
@@ -17,6 +17,8 @@ import { getProjectColorByFacetKey } from '../../data/projects'
 import FacetLabels from './FacetLabels'
 import projects from '../../data/projects'
 import { effects } from '../../crystalConfig'
+import { useBlendTexture, setBlend } from '../../three/useBlendTexture'
+import { loadFacetOverlayTexture } from '../../three/loadFacetOverlayTexture'
 
 const UnifiedCrystalScene = forwardRef(({ 
   animationData,
@@ -107,6 +109,7 @@ const UnifiedCrystalScene = forwardRef(({
   const [modelsLoaded, setModelsLoaded] = useState(false);
   // Store precomputed anchor offsets for label placement
   const [anchorOffsets, setAnchorOffsets] = useState({});
+  const [overlayTexture, setOverlayTexture] = useState(null);
 
   const handleMaterialReady = useCallback(() => {
     setMaterialVersion(v => v + 1);
@@ -118,6 +121,19 @@ const UnifiedCrystalScene = forwardRef(({
       facetRefs.current = facetKeys.map(() => React.createRef());
     }
   }, [facetKeys]);
+
+  // Load overlay texture once
+  useEffect(() => {
+    let mounted = true;
+    loadFacetOverlayTexture()
+      .then((texture) => {
+        if (mounted) setOverlayTexture(texture);
+      })
+      .catch((error) => {
+        console.warn('Failed to load overlay texture:', error);
+      });
+    return () => { mounted = false; };
+  }, []);
 
   
   useImperativeHandle(ref, () => ({
@@ -483,7 +499,10 @@ const UnifiedCrystalScene = forwardRef(({
         baseEmissiveIntensity:
           mat.userData?.baseEmissiveIntensity ?? mat.emissiveIntensity,
         baseEmissiveColor:
-          mat.userData?.baseEmissiveColor?.clone?.() || mat.emissive.clone()
+          mat.userData?.baseEmissiveColor?.clone?.() || mat.emissive.clone(),
+        // Add blend tracking
+        blendTarget: 0,
+        blendCurrent: 0
       };
 
       const model = facetModels[idx];
@@ -541,6 +560,13 @@ const UnifiedCrystalScene = forwardRef(({
     animationData?.crystalConfig?.explodeDuration,
     config?.effects?.fracture?.initialGlow
   ]);
+
+  // Apply blending to each material if texture is loaded
+  if (overlayTexture) {
+    facetMaterialsRef.current.forEach((material) => {
+      useBlendTexture(material, overlayTexture, { initialBlend: 0 });
+    });
+  }
 
   // Debug anchor positions when facets are loaded
   useEffect(() => {
@@ -670,8 +696,24 @@ const UnifiedCrystalScene = forwardRef(({
       activeFacetRef.current = currentFacet;
     }, 50);
 
+    // NEW: Handle texture blending for project focus
+    if (facetMaterialsRef.current.length && overlayTexture) {
+      facetMaterialsRef.current.forEach((mat, idx) => {
+        const key = facetKeys[idx];
+        const shouldShowTexture = currentFacet === key;
+
+        if (mat.userData.blendTarget !== (shouldShowTexture ? 1 : 0)) {
+          mat.userData.blendTarget = shouldShowTexture ? 1 : 0;
+
+          if (import.meta.env.DEV) {
+            console.log(`🎨 Texture blend ${key}: ${shouldShowTexture ? 'fade in' : 'fade out'}`);
+          }
+        }
+      });
+    }
+
     return () => clearTimeout(focusUpdateTimeoutRef.current);
-  }, [animationData?.focusedFacet, materialVersion, facetKeys, projectColors]);
+  }, [animationData?.focusedFacet, materialVersion, facetKeys, projectColors, overlayTexture]);
   
   // Crystal form change detection
   useEffect(() => {
@@ -962,6 +1004,23 @@ const UnifiedCrystalScene = forwardRef(({
         setShowFacets(false);
         setShowWholeCrystal(true);
       }
+    }
+
+    // NEW: Animate texture blending
+    if (overlayTexture) {
+      facetMaterialsRef.current.forEach((mat) => {
+        if (mat.userData?.blendTarget !== undefined) {
+          const current = mat.userData.blendCurrent || 0;
+          const target = mat.userData.blendTarget || 0;
+
+          if (Math.abs(current - target) > 0.01) {
+            const blendSpeed = 2.0; // Adjust fade speed here
+            const newBlend = THREE.MathUtils.lerp(current, target, blendSpeed * deltaTime);
+            mat.userData.blendCurrent = newBlend;
+            setBlend(mat, newBlend);
+          }
+        }
+      });
     }
 
     // Smooth color transitions for facet materials

--- a/src/three/loadFacetOverlayTexture.js
+++ b/src/three/loadFacetOverlayTexture.js
@@ -1,0 +1,27 @@
+import * as THREE from "three";
+
+let cachedTexture = null;
+
+export async function loadFacetOverlayTexture() {
+  if (cachedTexture) return cachedTexture;
+  
+  return new Promise((resolve, reject) => {
+    const loader = new THREE.TextureLoader();
+    loader.load(
+      "/assets/textures/checker01.jpg",
+      (texture) => {
+        texture.colorSpace = THREE.SRGBColorSpace;
+        texture.magFilter = THREE.NearestFilter;
+        texture.minFilter = THREE.NearestMipmapNearestFilter;
+        texture.anisotropy = 8;
+        texture.wrapS = texture.wrapT = THREE.ClampToEdgeWrapping;
+        texture.needsUpdate = true;
+        
+        cachedTexture = texture;
+        resolve(texture);
+      },
+      undefined,
+      reject
+    );
+  });
+}

--- a/src/three/useBlendTexture.js
+++ b/src/three/useBlendTexture.js
@@ -1,0 +1,62 @@
+import * as THREE from "three";
+import { useEffect, useRef } from "react";
+
+export function useBlendTexture(material, texture, { initialBlend = 0 } = {}) {
+  const patchedRef = useRef(false);
+  
+  useEffect(() => {
+    if (!material || !texture || patchedRef.current) return;
+
+    const originalOnBeforeCompile = material.onBeforeCompile;
+    
+    material.onBeforeCompile = (shader) => {
+      if (originalOnBeforeCompile) {
+        originalOnBeforeCompile(shader);
+      }
+      
+      if (!shader.uniforms.uBlend) {
+        shader.uniforms.uBlend = { value: initialBlend };
+        material.userData._blendUniform = shader.uniforms.uBlend;
+      }
+
+      if (!shader.fragmentShader.includes('// TEXTURE_BLEND_PATCH')) {
+        shader.fragmentShader = shader.fragmentShader.replace(
+          "#include <map_fragment>",
+          `
+          // TEXTURE_BLEND_PATCH
+          #ifdef USE_MAP
+            vec4 sampledDiffuseColor = texture2D( map, vMapUv );
+            #ifdef DECODE_VIDEO_TEXTURE
+              sampledDiffuseColor = vec4( mix( vec3(0.0), sampledDiffuseColor.rgb, saturate( sampledDiffuseColor.a ) ), 1.0 );
+            #endif
+            sampledDiffuseColor = mapTexelToLinear( sampledDiffuseColor );
+
+            vec3 baseCol = diffuseColor.rgb;
+            vec3 mappedCol = baseCol * sampledDiffuseColor.rgb;
+            diffuseColor.rgb = mix( baseCol, mappedCol, uBlend );
+          #endif
+          `
+        );
+      }
+    };
+
+    material.map = texture;
+    material.needsUpdate = true;
+    patchedRef.current = true;
+
+    return () => {
+      material.onBeforeCompile = originalOnBeforeCompile;
+      material.map = null;
+      delete material.userData._blendUniform;
+      material.needsUpdate = true;
+      patchedRef.current = false;
+    };
+  }, [material, texture, initialBlend]);
+}
+
+export function setBlend(material, value) {
+  const uniform = material?.userData?._blendUniform;
+  if (uniform) {
+    uniform.value = Math.max(0, Math.min(1, value));
+  }
+}


### PR DESCRIPTION
## Summary
- add hook to blend facet textures and expose setBlend helper
- load checkerboard overlay texture once and cache it
- integrate texture fade-in when a facet gains focus and animate blending per frame

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c187ec29548328b929e6344b85651b