### PR TITLE
feat: define facet overlay images in project data

### DIFF
--- a/src/data/projects.js
+++ b/src/data/projects.js
@@ -19,7 +19,7 @@ export const projects = [
     technologies: ["React", "D3.js", "Figma", "User Research"],
     color: "#64ffda", // Match the facet color
     headlineColor: "#64ffda", // NEW: Color for 1970s glow headlines
-    overlayTexture: "/assets/textures/checker01.jpg",
+    overlayImage: "/assets/textures/checker01.jpg",
     imageUrl: "/assets/projects/user-dashboard.jpg",
     demoUrl: "https://demo-url.com/dashboard",
     githubUrl: "https://github.com/yourusername/user-dashboard",
@@ -40,7 +40,7 @@ export const projects = [
     technologies: ["Three.js", "GSAP", "React", "Storyboarding"],
     color: "#bb86fc", // Match the facet color
     headlineColor: "#bb86fc", // NEW: Color for 1970s glow headlines
-    overlayTexture: "/assets/textures/checker01.jpg",
+    overlayImage: "/assets/textures/checker01.jpg",
     imageUrl: "/assets/projects/storytelling-platform.jpg",
     demoUrl: "https://demo-url.com/storytelling",
     githubUrl: "https://github.com/yourusername/storytelling-platform",
@@ -61,7 +61,7 @@ export const projects = [
     technologies: ["Styled Components", "Storybook", "Figma", "Design Tokens"],
     color: "#03dac6", // Match the facet color
     headlineColor: "#03dac6", // NEW: Color for 1970s glow headlines
-    overlayTexture: "/assets/textures/checker01.jpg",
+    overlayImage: "/assets/textures/checker01.jpg",
     imageUrl: "/assets/projects/design-system.jpg",
     demoUrl: "https://demo-url.com/design-system",
     githubUrl: "https://github.com/yourusername/design-system",
@@ -82,7 +82,7 @@ export const projects = [
     technologies: ["React", "TypeScript", "Monorepo", "CI/CD"],
     color: "#cf6679", // Match the facet color
     headlineColor: "#cf6679", // NEW: Color for 1970s glow headlines
-    overlayTexture: "/assets/textures/checker01.jpg",
+    overlayImage: "/assets/textures/checker01.jpg",
     imageUrl: "/assets/projects/component-architecture.jpg",
     demoUrl: "https://demo-url.com/components",
     githubUrl: "https://github.com/yourusername/component-architecture",
@@ -103,7 +103,7 @@ export const projects = [
     technologies: ["Next.js", "Firebase", "Tailwind CSS", "User Testing"],
     color: "#ffd600", // Match the facet color
     headlineColor: "#ffd600", // NEW: Color for 1970s glow headlines
-    overlayTexture: "/assets/textures/checker01.jpg",
+    overlayImage: "/assets/textures/checker01.jpg",
     imageUrl: "/assets/projects/collaboration-platform.jpg",
     demoUrl: "https://demo-url.com/collaboration",
     githubUrl: "https://github.com/yourusername/collaboration-platform",
@@ -124,7 +124,7 @@ export const projects = [
     technologies: ["WebGL", "React Three Fiber", "Shaders", "Motion Design"],
     color: "#ff7043", // Match the facet color
     headlineColor: "#ff7043", // NEW: Color for 1970s glow headlines
-    overlayTexture: "/assets/textures/checker01.jpg",
+    overlayImage: "/assets/textures/checker01.jpg",
     imageUrl: "/assets/projects/experimental-interactions.jpg",
     demoUrl: "https://demo-url.com/experiments",
     githubUrl: "https://github.com/yourusername/experimental-interactions",
@@ -154,13 +154,13 @@ export const getProjectColorByFacetKey = (facetKey) => {
 };
 
 /**
- * Get overlay texture path by facet key
+ * Get overlay image path by facet key
  * @param {string} facetKey - The facet key to lookup
- * @returns {string|null} Overlay texture path or null if not found
- */
-export const getOverlayTextureByFacetKey = (facetKey) => {
+ * @returns {string|null} Overlay image path or null if not found
+*/
+export const getOverlayImageByFacetKey = (facetKey) => {
   const project = getProjectByFacetKey(facetKey);
-  return project?.overlayTexture || null;
+  return project?.overlayImage || null;
 };
 
 export default projects;

--- a/src/hooks/useFacetOverlayGeometry.js
+++ b/src/hooks/useFacetOverlayGeometry.js
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import * as THREE from 'three';
-import { getOverlayTextureByFacetKey } from '../data/projects';
+import { getOverlayImageByFacetKey } from '../data/projects';
 
 export const useFacetOverlayGeometry = (facetKeys) => {
   const [overlayTextures, setOverlayTextures] = useState(new Map());
@@ -8,7 +8,7 @@ export const useFacetOverlayGeometry = (facetKeys) => {
   const overlayMeshesRef = useRef(new Map());
   const texturesLoadedRef = useRef(false);
 
-  // Load all overlay textures
+  // Load all overlay images
   useEffect(() => {
     if (texturesLoadedRef.current) return;
     texturesLoadedRef.current = true;
@@ -18,10 +18,10 @@ export const useFacetOverlayGeometry = (facetKeys) => {
       const textureMap = new Map();
 
       for (const facetKey of facetKeys) {
-        const texturePath = getOverlayTextureByFacetKey(facetKey);
-        if (texturePath) {
+        const imagePath = getOverlayImageByFacetKey(facetKey);
+        if (imagePath) {
           try {
-            const texture = await loader.loadAsync(texturePath);
+            const texture = await loader.loadAsync(imagePath);
 
             // Configure texture
             texture.wrapS = THREE.RepeatWrapping;
@@ -33,9 +33,9 @@ export const useFacetOverlayGeometry = (facetKeys) => {
             texture.needsUpdate = true;
 
             textureMap.set(facetKey, texture);
-            console.log(`✅ Loaded overlay texture for ${facetKey}`);
+            console.log(`✅ Loaded overlay image for ${facetKey}`);
           } catch (error) {
-            console.warn(`❌ Failed to load overlay texture for ${facetKey}:`, error);
+            console.warn(`❌ Failed to load overlay image for ${facetKey}:`, error);
           }
         }
       }


### PR DESCRIPTION
## Summary
- add `overlayImage` placeholder to each project entry
- load facet overlay textures from project data

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c308c777a883289a5e0088778603b4