### PR TITLE
feat: add song view timeline to sequencer

### DIFF
--- a/src/sequencer/App.jsx
+++ b/src/sequencer/App.jsx
@@ -1,0 +1,255 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import SongView from './SongView';
+import TrackView from './TrackView';
+import './sequencer.css';
+
+const STEPS_PER_BAR = 16;
+
+const DEFAULT_TRACKS = [
+  {
+    id: 'kick',
+    name: 'Kick',
+    steps: [true, false, false, false, true, false, false, false, true, false, false, false, true, false, false, false]
+  },
+  {
+    id: 'snare',
+    name: 'Snare',
+    steps: [false, false, true, false, false, false, true, false, false, false, true, false, false, false, true, false]
+  },
+  {
+    id: 'hihat',
+    name: 'Hi-Hat',
+    steps: [true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, true]
+  },
+  {
+    id: 'bass',
+    name: 'Bass',
+    steps: [true, false, false, true, false, false, true, false, true, false, false, true, false, false, true, false]
+  }
+];
+
+const createSongSections = (trackCount, sectionCount = 4) =>
+  Array.from({ length: sectionCount }, () => Array(trackCount).fill(true));
+
+const clampSectionIndex = (sectionIndex, sectionCount) => {
+  if (sectionCount === 0) return 0;
+  return Math.min(sectionIndex, sectionCount - 1);
+};
+
+const SequencerApp = () => {
+  const [tracks, setTracks] = useState(DEFAULT_TRACKS);
+  const [viewMode, setViewMode] = useState('track');
+  const [songSections, setSongSections] = useState(() => createSongSections(DEFAULT_TRACKS.length, 4));
+  const [currentStep, setCurrentStep] = useState(0);
+  const [currentSection, setCurrentSection] = useState(0);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [bpm, setBpm] = useState(120);
+  const [activeTrackIds, setActiveTrackIds] = useState([]);
+
+  const trackCount = tracks.length;
+  const sectionCount = songSections.length;
+
+  useEffect(() => {
+    setSongSections((prevSections) => {
+      if (prevSections.length === 0) {
+        return createSongSections(trackCount, 1);
+      }
+
+      let didChange = false;
+      const nextSections = prevSections.map((section) => {
+        if (section.length === trackCount) return section;
+
+        didChange = true;
+        if (section.length < trackCount) {
+          return [...section, ...Array(trackCount - section.length).fill(true)];
+        }
+
+        return section.slice(0, trackCount);
+      });
+
+      return didChange ? nextSections : prevSections;
+    });
+  }, [trackCount]);
+
+  useEffect(() => {
+    setCurrentSection((prev) => clampSectionIndex(prev, sectionCount));
+  }, [sectionCount]);
+
+  const stepDuration = useMemo(() => {
+    return ((60 / bpm) / 4) * 1000;
+  }, [bpm]);
+
+  useEffect(() => {
+    if (!isPlaying) return undefined;
+
+    const totalSections = sectionCount || 1;
+    const interval = setInterval(() => {
+      setCurrentStep((prevStep) => {
+        const nextStep = (prevStep + 1) % STEPS_PER_BAR;
+        if (nextStep === 0) {
+          setCurrentSection((prevSection) => (prevSection + 1) % totalSections);
+        }
+        return nextStep;
+      });
+    }, stepDuration);
+
+    return () => clearInterval(interval);
+  }, [isPlaying, stepDuration, sectionCount]);
+
+  useEffect(() => {
+    if (!isPlaying) {
+      setActiveTrackIds([]);
+      return;
+    }
+
+    const section = songSections[currentSection];
+    if (!section) {
+      setActiveTrackIds([]);
+      return;
+    }
+
+    const triggeredTracks = [];
+
+    tracks.forEach((track, trackIndex) => {
+      const enabledInSection = section[trackIndex];
+      if (!enabledInSection) return;
+
+      const isStepActive = Boolean(track.steps?.[currentStep]);
+      if (isStepActive) {
+        triggeredTracks.push(track.id ?? trackIndex);
+      }
+    });
+
+    setActiveTrackIds(triggeredTracks);
+  }, [tracks, songSections, currentSection, currentStep, isPlaying]);
+
+  const togglePlay = useCallback(() => {
+    setIsPlaying((prev) => {
+      const next = !prev;
+      if (!prev) {
+        setCurrentStep(0);
+        setCurrentSection(0);
+      }
+      return next;
+    });
+  }, []);
+
+  const handleBpmChange = useCallback((event) => {
+    const value = Number(event.target.value);
+    if (Number.isFinite(value) && value > 0) {
+      setBpm(Math.max(40, Math.min(240, value)));
+    }
+  }, []);
+
+  const handleToggleStep = useCallback((trackIndex, stepIndex) => {
+    setTracks((prevTracks) =>
+      prevTracks.map((track, index) => {
+        if (index !== trackIndex) return track;
+        const steps = track.steps ?? Array(STEPS_PER_BAR).fill(false);
+        const nextSteps = steps.map((step, idx) => (idx === stepIndex ? !step : step));
+        return { ...track, steps: nextSteps };
+      })
+    );
+  }, []);
+
+  const handleToggleSongSection = useCallback((sectionIndex, trackIndex) => {
+    setSongSections((prevSections) =>
+      prevSections.map((section, idx) => {
+        if (idx !== sectionIndex) return section;
+        return section.map((value, trackIdx) =>
+          trackIdx === trackIndex ? !value : value
+        );
+      })
+    );
+  }, []);
+
+  const handleAddSection = useCallback(() => {
+    setSongSections((prevSections) => [
+      ...prevSections,
+      Array(trackCount).fill(true)
+    ]);
+  }, [trackCount]);
+
+  const handleSelectSection = useCallback((sectionIndex) => {
+    setCurrentSection(sectionIndex);
+    setCurrentStep(0);
+  }, []);
+
+  return (
+    <div className="sequencer-app">
+      <header className="sequencer-header">
+        <h1 className="sequencer-title">Sequencer Instrument</h1>
+        <div className="sequencer-controls">
+          <button
+            type="button"
+            className="sequencer-button"
+            onClick={togglePlay}
+          >
+            {isPlaying ? 'Stop' : 'Play'}
+          </button>
+
+          <label>
+            <span>BPM</span>
+            <input
+              type="number"
+              value={bpm}
+              min={40}
+              max={240}
+              onChange={handleBpmChange}
+            />
+          </label>
+
+          <div className="sequencer-status">
+            Section {currentSection + 1} / {Math.max(sectionCount, 1)}
+          </div>
+        </div>
+      </header>
+
+      <div className="sequencer-tabs" role="tablist" aria-label="View mode">
+        <button
+          type="button"
+          role="tab"
+          aria-selected={viewMode === 'track'}
+          className={`sequencer-tab ${viewMode === 'track' ? 'is-active' : ''}`}
+          onClick={() => setViewMode('track')}
+        >
+          Track View
+        </button>
+        <button
+          type="button"
+          role="tab"
+          aria-selected={viewMode === 'song'}
+          className={`sequencer-tab ${viewMode === 'song' ? 'is-active' : ''}`}
+          onClick={() => setViewMode('song')}
+        >
+          Song View
+        </button>
+      </div>
+
+      <main className="sequencer-content">
+        {viewMode === 'track' ? (
+          <TrackView
+            tracks={tracks}
+            currentStep={currentStep}
+            onToggleStep={handleToggleStep}
+            activeTrackIds={activeTrackIds}
+            isPlaying={isPlaying}
+            songSections={songSections}
+            currentSection={currentSection}
+          />
+        ) : (
+          <SongView
+            tracks={tracks}
+            songSections={songSections}
+            onToggleCell={handleToggleSongSection}
+            onAddSection={handleAddSection}
+            currentSection={currentSection}
+            onSelectSection={handleSelectSection}
+          />
+        )}
+      </main>
+    </div>
+  );
+};
+
+export default SequencerApp;

--- a/src/sequencer/SongView.jsx
+++ b/src/sequencer/SongView.jsx
@@ -1,0 +1,86 @@
+import React from 'react';
+
+const SongView = ({
+  tracks,
+  songSections,
+  onToggleCell,
+  onAddSection,
+  currentSection,
+  onSelectSection
+}) => {
+  const sectionCount = songSections.length;
+  const gridTemplateColumns = `160px repeat(${sectionCount}, minmax(0, 1fr))`;
+
+  return (
+    <div className="song-view">
+      <div className="song-view__header">
+        <h2 className="song-view__title">Song View</h2>
+        <button
+          type="button"
+          className="song-view__add-section"
+          onClick={onAddSection}
+        >
+          + Section
+        </button>
+      </div>
+
+      {sectionCount === 0 ? (
+        <div className="song-view__empty">
+          No sections yet. Add a section to start arranging your song.
+        </div>
+      ) : (
+        <div className="song-view__grid">
+          <div className="song-view__row song-view__row--header" style={{ gridTemplateColumns }}>
+            <div className="song-view__cell song-view__cell--label">Track</div>
+            {songSections.map((_, sectionIndex) => (
+              <button
+                key={`section-label-${sectionIndex}`}
+                type="button"
+                className={`song-view__cell song-view__cell--section ${
+                  sectionIndex === currentSection ? 'is-current' : ''
+                }`}
+                onClick={() => onSelectSection?.(sectionIndex)}
+              >
+                Section {sectionIndex + 1}
+              </button>
+            ))}
+          </div>
+
+          {tracks.map((track, trackIndex) => (
+            <div
+              key={track.id ?? trackIndex}
+              className="song-view__row"
+              style={{ gridTemplateColumns }}
+            >
+              <div className="song-view__cell song-view__cell--label">
+                {track.name ?? `Track ${trackIndex + 1}`}
+              </div>
+              {songSections.map((section, sectionIndex) => {
+                const isEnabled = Boolean(section?.[trackIndex]);
+                const isCurrent = sectionIndex === currentSection;
+                return (
+                  <button
+                    key={`section-${sectionIndex}-track-${trackIndex}`}
+                    type="button"
+                    className={`song-view__cell song-view__cell--toggle ${
+                      isEnabled ? 'is-active' : ''
+                    } ${isCurrent ? 'is-current' : ''}`}
+                    onClick={() => onToggleCell(sectionIndex, trackIndex)}
+                    aria-pressed={isEnabled}
+                    aria-label={`${track.name ?? `Track ${trackIndex + 1}`} ${
+                      isEnabled ? 'enabled' : 'muted'
+                    } in section ${sectionIndex + 1}`}
+                  >
+                    <span className="song-view__cell-indicator" />
+                  </button>
+                );
+              })}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SongView;

--- a/src/sequencer/TrackView.jsx
+++ b/src/sequencer/TrackView.jsx
@@ -1,0 +1,85 @@
+import React from 'react';
+
+const TrackView = ({
+  tracks,
+  currentStep,
+  onToggleStep,
+  activeTrackIds,
+  isPlaying,
+  songSections,
+  currentSection
+}) => {
+  const stepsPerTrack = tracks[0]?.steps?.length ?? 16;
+  const gridTemplateColumns = `160px repeat(${stepsPerTrack}, minmax(0, 1fr))`;
+
+  return (
+    <div className="track-view">
+      <div className="track-view__header">
+        <h2 className="track-view__title">Track View</h2>
+        <p className="track-view__subtitle">Toggle steps to program each pattern.</p>
+      </div>
+
+      <div className="track-view__grid">
+        <div className="track-view__row track-view__row--header" style={{ gridTemplateColumns }}>
+          <div className="track-view__cell track-view__cell--label">Track</div>
+          {Array.from({ length: stepsPerTrack }).map((_, stepIndex) => (
+            <div
+              key={`step-label-${stepIndex}`}
+              className={`track-view__cell track-view__cell--step-label ${
+                stepIndex === currentStep ? 'is-current' : ''
+              }`}
+            >
+              {stepIndex + 1}
+            </div>
+          ))}
+        </div>
+
+        {tracks.map((track, trackIndex) => {
+          const steps = track.steps ?? [];
+          const trackKey = track.id ?? trackIndex;
+          const trackName = track.name ?? `Track ${trackIndex + 1}`;
+          const isEnabledInSection = songSections[currentSection]?.[trackIndex] !== false;
+
+          return (
+            <div
+              key={trackKey}
+              className={`track-view__row ${!isEnabledInSection ? 'is-muted' : ''}`}
+              style={{ gridTemplateColumns }}
+            >
+              <div className="track-view__cell track-view__cell--label">{trackName}</div>
+              {steps.map((isActive, stepIndex) => {
+                const isCurrentStep = stepIndex === currentStep;
+                const isTriggering =
+                  isActive &&
+                  isCurrentStep &&
+                  isPlaying &&
+                  activeTrackIds.includes(trackKey);
+
+                return (
+                  <button
+                    key={`track-${trackIndex}-step-${stepIndex}`}
+                    type="button"
+                    className={`track-view__cell track-view__cell--step ${
+                      isActive ? 'is-active' : ''
+                    } ${isCurrentStep ? 'is-current' : ''} ${
+                      isTriggering ? 'is-triggered' : ''
+                    }`}
+                    onClick={() => onToggleStep(trackIndex, stepIndex)}
+                    aria-pressed={isActive}
+                    aria-label={`${trackName} step ${stepIndex + 1} ${
+                      isActive ? 'on' : 'off'
+                    }`}
+                  >
+                    <span className="track-view__cell-indicator" />
+                  </button>
+                );
+              })}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default TrackView;

--- a/src/sequencer/index.js
+++ b/src/sequencer/index.js
@@ -1,0 +1,3 @@
+export { default as SequencerApp } from './App.jsx';
+export { default as SongView } from './SongView.jsx';
+export { default as TrackView } from './TrackView.jsx';

--- a/src/sequencer/sequencer.css
+++ b/src/sequencer/sequencer.css
@@ -1,0 +1,313 @@
+.sequencer-app {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: linear-gradient(160deg, rgba(15, 23, 42, 0.9), rgba(15, 118, 110, 0.8));
+  color: #e2e8f0;
+  padding: 24px;
+  border-radius: 20px;
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.45);
+  max-width: 1080px;
+  margin: 40px auto;
+  backdrop-filter: blur(18px);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.sequencer-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.sequencer-title {
+  font-size: 28px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  margin: 0;
+}
+
+.sequencer-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
+}
+
+.sequencer-controls label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 14px;
+  background: rgba(15, 23, 42, 0.45);
+  padding: 8px 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.sequencer-controls input[type="number"] {
+  width: 70px;
+  padding: 6px 8px;
+  background: rgba(15, 23, 42, 0.75);
+  color: inherit;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  border-radius: 8px;
+  font-size: 14px;
+}
+
+.sequencer-button {
+  background: linear-gradient(135deg, #22d3ee, #6366f1);
+  border: none;
+  color: #0f172a;
+  font-weight: 600;
+  padding: 10px 18px;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  box-shadow: 0 12px 24px rgba(14, 165, 233, 0.35);
+}
+
+.sequencer-button:hover,
+.sequencer-button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 30px rgba(14, 165, 233, 0.45);
+}
+
+.sequencer-status {
+  font-size: 14px;
+  background: rgba(15, 23, 42, 0.45);
+  padding: 8px 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.sequencer-tabs {
+  display: inline-flex;
+  margin-top: 24px;
+  border-radius: 999px;
+  padding: 4px;
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.sequencer-tab {
+  position: relative;
+  background: transparent;
+  border: none;
+  color: rgba(226, 232, 240, 0.8);
+  font-weight: 600;
+  padding: 10px 22px;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: color 0.2s ease;
+}
+
+.sequencer-tab.is-active {
+  color: #0f172a;
+  background: linear-gradient(135deg, rgba(34, 197, 94, 0.85), rgba(20, 184, 166, 0.85));
+  box-shadow: 0 12px 24px rgba(20, 184, 166, 0.35);
+}
+
+.sequencer-tab:focus-visible {
+  outline: 2px solid rgba(226, 232, 240, 0.7);
+  outline-offset: 2px;
+}
+
+.sequencer-content {
+  margin-top: 28px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.song-view,
+.track-view {
+  background: rgba(15, 23, 42, 0.45);
+  border-radius: 18px;
+  padding: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.15);
+}
+
+.song-view__header,
+.track-view__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.song-view__title,
+.track-view__title {
+  margin: 0;
+  font-size: 20px;
+  font-weight: 700;
+}
+
+.track-view__subtitle {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.65);
+  font-size: 14px;
+}
+
+.song-view__add-section {
+  background: rgba(34, 197, 94, 0.18);
+  color: #bbf7d0;
+  border: 1px solid rgba(34, 197, 94, 0.35);
+  padding: 8px 14px;
+  border-radius: 10px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.song-view__add-section:hover,
+.song-view__add-section:focus-visible {
+  background: rgba(34, 197, 94, 0.32);
+  border-color: rgba(34, 197, 94, 0.55);
+}
+
+.song-view__grid,
+.track-view__grid {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.song-view__row,
+.track-view__row {
+  display: grid;
+  align-items: center;
+  gap: 8px;
+}
+
+.song-view__row--header,
+.track-view__row--header {
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  color: rgba(226, 232, 240, 0.6);
+}
+
+.song-view__cell,
+.track-view__cell {
+  background: rgba(15, 23, 42, 0.58);
+  border-radius: 12px;
+  padding: 10px 12px;
+  text-align: center;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  min-height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.song-view__cell--label,
+.track-view__cell--label {
+  justify-content: flex-start;
+  font-weight: 600;
+  color: rgba(226, 232, 240, 0.95);
+  background: transparent;
+  border: none;
+}
+
+.song-view__cell--section {
+  font-weight: 600;
+  background: transparent;
+  border: none;
+  color: rgba(226, 232, 240, 0.7);
+  cursor: pointer;
+  transition: color 0.2s ease;
+}
+
+.song-view__cell--section.is-current {
+  color: #38bdf8;
+}
+
+.song-view__cell--toggle,
+.track-view__cell--step {
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.song-view__cell--toggle.is-active,
+.track-view__cell--step.is-active {
+  background: rgba(34, 197, 94, 0.25);
+  border-color: rgba(34, 197, 94, 0.65);
+  box-shadow: inset 0 0 0 1px rgba(34, 197, 94, 0.4);
+}
+
+.song-view__cell--toggle.is-current,
+.track-view__cell--step.is-current {
+  box-shadow: inset 0 0 0 2px rgba(56, 189, 248, 0.9);
+}
+
+.track-view__row.is-muted .track-view__cell--step {
+  opacity: 0.35;
+}
+
+.track-view__cell--step.is-triggered {
+  animation: sequencerPulse 0.35s ease-out;
+  background: rgba(59, 130, 246, 0.45);
+  border-color: rgba(59, 130, 246, 0.75);
+}
+
+.song-view__cell-indicator,
+.track-view__cell-indicator {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: rgba(148, 163, 184, 0.35);
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.song-view__cell--toggle.is-active .song-view__cell-indicator,
+.track-view__cell--step.is-active .track-view__cell-indicator {
+  background: #34d399;
+  transform: scale(1.2);
+}
+
+.song-view__cell--toggle.is-current .song-view__cell-indicator,
+.track-view__cell--step.is-current .track-view__cell-indicator {
+  background: #38bdf8;
+}
+
+.song-view__empty {
+  font-size: 15px;
+  padding: 18px;
+  background: rgba(15, 23, 42, 0.6);
+  border-radius: 16px;
+  border: 1px dashed rgba(148, 163, 184, 0.4);
+  text-align: center;
+  color: rgba(226, 232, 240, 0.75);
+}
+
+.track-view__cell--step-label {
+  background: transparent;
+  border: none;
+  color: rgba(226, 232, 240, 0.5);
+}
+
+.track-view__cell--step-label.is-current {
+  color: #38bdf8;
+}
+
+@keyframes sequencerPulse {
+  0% {
+    transform: scale(0.9);
+  }
+  50% {
+    transform: scale(1.08);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+.song-view__cell--toggle:focus-visible,
+.track-view__cell--step:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.75);
+  outline-offset: 2px;
+}


### PR DESCRIPTION
## Summary
- add a sequencer app that tracks song sections, toggles view modes, and advances sections during playback
- implement a SongView grid for enabling tracks per section and appending new sections
- update track view and styling to reflect section activity and highlight triggered steps

## Testing
- npm run build -- --logLevel error

------
https://chatgpt.com/codex/tasks/task_e_68c871cecaf48328be1b212d916e75fa