### PR TITLE
Add Song view layout scaffold

### DIFF
--- a/src/components/song/SongView.jsx
+++ b/src/components/song/SongView.jsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import styles from './SongView.module.css';
+
+const SaveIcon = () => (
+  <svg viewBox="0 0 20 20" aria-hidden="true" focusable="false">
+    <path d="M4 2a2 2 0 0 0-2 2v12c0 1.1.9 2 2 2h12a2 2 0 0 0 2-2V6.83a2 2 0 0 0-.59-1.41l-2.83-2.83A2 2 0 0 0 13.17 2H4zm0 2h9v4H4V4zm0 6h12v6H4v-6zm3 2v2h6v-2H7z" />
+  </svg>
+);
+
+const MoreIcon = () => (
+  <svg viewBox="0 0 20 20" aria-hidden="true" focusable="false">
+    <path d="M4.5 10a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm7 0a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0zm5.5 1.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3z" />
+  </svg>
+);
+
+const PlayIcon = () => (
+  <svg viewBox="0 0 20 20" aria-hidden="true" focusable="false">
+    <path d="M6.5 4.5a1 1 0 0 1 1.52-.85l7 4.5a1 1 0 0 1 0 1.7l-7 4.5A1 1 0 0 1 6.5 14.5v-10z" />
+  </svg>
+);
+
+const PlusIcon = () => (
+  <svg viewBox="0 0 20 20" aria-hidden="true" focusable="false">
+    <path d="M10 3a1 1 0 0 1 1 1v5h5a1 1 0 1 1 0 2h-5v5a1 1 0 1 1-2 0v-5H4a1 1 0 0 1 0-2h5V4a1 1 0 0 1 1-1z" />
+  </svg>
+);
+
+const IconButton = ({ icon: Icon, label, className, children }) => (
+  <button
+    type="button"
+    className={`${styles.iconButton} ${className ?? ''}`.trim()}
+    aria-label={label}
+  >
+    {Icon ? <Icon /> : null}
+    {children}
+  </button>
+);
+
+const SongView = () => (
+  <div className={styles.songView}>
+    <div className={styles.topToolbar}>
+      <span className={styles.topToolbarTitle}>Timeline</span>
+      <div className={styles.topToolbarActions}>
+        <IconButton icon={SaveIcon} label="Save" />
+        <IconButton icon={MoreIcon} label="More options" />
+      </div>
+    </div>
+
+    <div className={styles.primaryContainer} />
+
+    <div className={`${styles.bottomToolbar} ${styles.controlsRow}`}>
+      <IconButton icon={PlayIcon} label="Play" className={styles.playButton} />
+      <div className={styles.bpmDropdown} role="button" tabIndex={0} aria-label="Tempo">
+        120 BPM
+      </div>
+      <IconButton
+        icon={PlusIcon}
+        label="Add Loop"
+        className={styles.iconButtonLabeled}
+      >
+        <span className={styles.plusButtonText}>+Loop</span>
+      </IconButton>
+      <IconButton
+        icon={PlusIcon}
+        label="Add Row"
+        className={styles.iconButtonLabeled}
+      >
+        <span className={styles.plusButtonText}>+Row</span>
+      </IconButton>
+      <IconButton
+        icon={PlusIcon}
+        label="Add Track"
+        className={styles.iconButtonLabeled}
+      >
+        <span className={styles.plusButtonText}>+Track</span>
+      </IconButton>
+    </div>
+
+    <div className={styles.instrumentControls}>Instrument Controls Area</div>
+  </div>
+);
+
+export default SongView;

--- a/src/components/song/SongView.module.css
+++ b/src/components/song/SongView.module.css
@@ -1,0 +1,175 @@
+.songView {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  width: 100%;
+  height: 100%;
+  color: #f0f3ff;
+  background: transparent;
+}
+
+.topToolbar,
+.bottomToolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: rgba(32, 39, 53, 0.95);
+  border-radius: 16px;
+  padding: 12px 16px;
+  min-height: 64px;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.25);
+}
+
+.topToolbar {
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.topToolbarTitle {
+  font-weight: 600;
+  font-size: 16px;
+}
+
+.topToolbarActions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.iconButton {
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: linear-gradient(180deg, #2f3a52 0%, #1d2333 100%);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  color: #f0f3ff;
+  cursor: pointer;
+  box-shadow: inset 0 1px 1px rgba(255, 255, 255, 0.08), inset 0 -2px 4px rgba(0, 0, 0, 0.35);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.iconButton:hover {
+  transform: translateY(-1px);
+  box-shadow: inset 0 1px 1px rgba(255, 255, 255, 0.12), inset 0 -2px 4px rgba(0, 0, 0, 0.4);
+}
+
+.iconButton:active {
+  transform: translateY(1px);
+}
+
+.iconButton svg {
+  width: 20px;
+  height: 20px;
+  fill: #f0f3ff;
+}
+
+.iconButton span {
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.iconButtonLabeled {
+  width: auto;
+  padding: 0 18px;
+  gap: 8px;
+  border-radius: 999px;
+}
+
+.primaryContainer {
+  flex: 1;
+  background: rgba(26, 32, 46, 0.95);
+  border-radius: 18px;
+  border: 1px solid rgba(118, 134, 181, 0.18);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+.bottomToolbar {
+  gap: 12px;
+  justify-content: flex-start;
+}
+
+.playButton {
+  background: linear-gradient(180deg, #34d1a5 0%, #1fa87f 100%);
+  color: #021d14;
+  width: 44px;
+  padding: 0;
+}
+
+.playButton svg {
+  fill: currentColor;
+}
+
+.bpmDropdown {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 18px;
+  height: 44px;
+  border-radius: 999px;
+  background: rgba(32, 39, 53, 0.95);
+  border: 1px solid rgba(118, 134, 181, 0.18);
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  color: #f0f3ff;
+  box-shadow: inset 0 1px 1px rgba(255, 255, 255, 0.06);
+}
+
+.bpmDropdown::after {
+  content: '';
+  margin-left: 10px;
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  border-top: 5px solid rgba(240, 243, 255, 0.8);
+}
+
+.plusButtonText {
+  font-size: 14px;
+  font-weight: 500;
+}
+
+.instrumentControls {
+  background: rgba(13, 17, 27, 0.95);
+  border-radius: 18px;
+  border: 1px dashed rgba(109, 127, 168, 0.35);
+  padding: 36px 20px;
+  text-align: center;
+  font-style: italic;
+  color: rgba(198, 208, 240, 0.7);
+}
+
+.controlsRow {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.controlsRow button,
+.controlsRow .bpmDropdown {
+  flex-shrink: 0;
+}
+
+@media (max-width: 768px) {
+  .songView {
+    padding: 12px;
+    gap: 10px;
+  }
+
+  .iconButton,
+  .bpmDropdown {
+    height: 40px;
+  }
+
+  .iconButton {
+    width: 40px;
+  }
+
+  .bpmDropdown {
+    padding: 0 14px;
+    font-size: 13px;
+  }
+}


### PR DESCRIPTION
## Summary
- add a SongView component that arranges the timeline, empty content area, playback toolbar, and instrument controls placeholder
- create module CSS to style the toolbars, buttons, dropdown, and placeholder container to match the provided mockup

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df0b6f8c088328ae7eca3b9b8d3c02