### PR TITLE
Introduce camera tuning payload, validation, and integration into camera/config flow

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -36,6 +36,8 @@ import PerformanceDebugPanel from './components/ui/PerformanceDebugPanel';
 
 // Configuration and utilities
 import * as defaultConfig from './crystalConfig';
+import cameraTuningJson from './config/tuning/cameraTuning.json';
+import { applyCameraTuningToConfig, deepFreeze } from './lib/tuning/cameraTuning';
 
 // Cinematic Movie Titles Effects
 import './styles/glow-70s.css';
@@ -43,6 +45,8 @@ import { isMobileDevice } from './utils/isMobileDevice.js';
 
 const projectKeys = ['empathy', 'narrative', 'craft', 'system', 'leadership', 'exploration'];
 const zoneKeys = ['intro', 'hero', 'overview', 'about'];
+const { config: baseTunedConfig, payload: baseTuningPayload } = applyCameraTuningToConfig(defaultConfig, cameraTuningJson);
+deepFreeze(baseTuningPayload);
 
 const toVecOrNull = (value) => (
   Array.isArray(value) && value.length === 3 && value.every((entry) => Number.isFinite(entry))
@@ -391,17 +395,17 @@ function App() {
   const [perfDebug, setPerfDebug] = useState(false);
   const [snapSpeed, setSnapSpeed] = useState('medium');
   const [config, setConfig] = useState({
-    ...defaultConfig,
+    ...baseTunedConfig,
     timing: {
-      ...defaultConfig.timing,
+      ...baseTunedConfig.timing,
       camera: {
-        ...defaultConfig.timing.camera,
+        ...baseTunedConfig.timing.camera,
         facetZoomDuration: 1000,
         facetReturnDuration: 1200
       }
     }
   });
-  const [animationConfig, setAnimationConfig] = useState(buildAnimationConfig(defaultConfig));
+  const [animationConfig, setAnimationConfig] = useState(buildAnimationConfig(baseTunedConfig));
   const [cameraRuntimeOverrides, setCameraRuntimeOverrides] = useState({});
   const [projectRuntimeOverrides, setProjectRuntimeOverrides] = useState({});
   const [sceneRestartToken, setSceneRestartToken] = useState(0);
@@ -591,8 +595,8 @@ function App() {
   const handleConfigUpdate = useCallback((newConfig) => {
     setConfig(newConfig);
     setAnimationConfig(buildAnimationConfig(newConfig));
-    setCameraRuntimeOverrides(getCameraRuntimeOverrides(defaultConfig, newConfig));
-    setProjectRuntimeOverrides(getProjectRuntimeOverrides(defaultConfig, newConfig));
+    setCameraRuntimeOverrides(getCameraRuntimeOverrides(baseTunedConfig, newConfig));
+    setProjectRuntimeOverrides(getProjectRuntimeOverrides(baseTunedConfig, newConfig));
   }, []);
 
 

--- a/src/components/three/UnifiedCameraController.jsx
+++ b/src/components/three/UnifiedCameraController.jsx
@@ -333,46 +333,34 @@ const UnifiedCameraController = ({
     if (!config?.cameraPositions) return null;
     const deviceKey = isMobile ? 'mobile' : 'desktop';
     const resolveProjectViewSettings = () => {
-      const selectedFallbackPosition = toVector3(config.cameraPositions?.projects?.[focusedFacet]);
-      const selectedFallbackTarget = toVector3(config.cameraTargets?.projects?.[focusedFacet]);
       const selectedFromConfig = config?.projectCameraSettings?.[focusedProjectId]?.[deviceKey]?.selected;
       const caseStudyFromConfig = config?.projectCameraSettings?.[focusedProjectId]?.[deviceKey]?.caseStudy;
 
-      const selectedPosition = toVector3(selectedFromConfig?.position || selectedFallbackPosition);
-      const selectedTarget = toVector3(selectedFromConfig?.target || selectedFallbackTarget);
-
-      const authoredCaseStudyPosition = caseStudyFromConfig?.position
-        ? toVector3(caseStudyFromConfig.position)
-        : null;
-      const authoredCaseStudyTarget = caseStudyFromConfig?.target
-        ? toVector3(caseStudyFromConfig.target)
-        : null;
-
-      // Temporary debug behavior: force caseStudy noticeably closer unless clearly authored.
-      const selectedDirection = new THREE.Vector3().subVectors(selectedPosition, selectedTarget);
-      const selectedDistance = Math.max(selectedDirection.length(), 0.0001);
-      const shouldForceCloserCaseStudy =
-        !authoredCaseStudyPosition ||
-        !authoredCaseStudyTarget;
-
-      let caseStudyPosition = authoredCaseStudyPosition;
-      let caseStudyTarget = authoredCaseStudyTarget;
-
-      if (shouldForceCloserCaseStudy) {
-        const closerDistance = Math.max(selectedDistance * 0.42, 0.55);
-        const direction = selectedDirection.normalize();
-        caseStudyTarget = selectedTarget.clone();
-        caseStudyPosition = selectedTarget.clone().add(direction.multiplyScalar(closerDistance));
+      if (
+        !selectedFromConfig?.position
+        || !selectedFromConfig?.target
+        || !caseStudyFromConfig?.position
+        || !caseStudyFromConfig?.target
+      ) {
+        if (import.meta.env.DEV) {
+          logger.error('Missing strict projectCameraSettings branch', {
+            focusedProjectId,
+            deviceKey,
+            selectedPresent: Boolean(selectedFromConfig),
+            caseStudyPresent: Boolean(caseStudyFromConfig)
+          });
+        }
+        return null;
       }
 
       return {
         selected: {
-          position: selectedPosition,
-          target: selectedTarget
+          position: toVector3(selectedFromConfig.position),
+          target: toVector3(selectedFromConfig.target)
         },
         caseStudy: {
-          position: caseStudyPosition || selectedPosition.clone(),
-          target: caseStudyTarget || selectedTarget.clone()
+          position: toVector3(caseStudyFromConfig.position),
+          target: toVector3(caseStudyFromConfig.target)
         }
       };
     };
@@ -415,6 +403,7 @@ const UnifiedCameraController = ({
 
     if (cameraState === 'project' && focusedFacet) {
       const projectViewSettings = resolveProjectViewSettings();
+      if (!projectViewSettings) return null;
 
       return {
         position: projectViewSettings.selected.position,
@@ -426,6 +415,7 @@ const UnifiedCameraController = ({
 
     if (cameraState === 'caseStudy' && focusedFacet) {
       const projectViewSettings = resolveProjectViewSettings();
+      if (!projectViewSettings) return null;
 
       return {
         position: projectViewSettings.caseStudy.position,
@@ -681,7 +671,6 @@ const UnifiedCameraController = ({
         const deviceMode = isMobile ? 'mobile' : 'desktop';
         const selectedConfigPosition =
           config?.projectCameraSettings?.[focusedProject]?.[deviceMode]?.selected?.position
-          || config?.cameraPositions?.projects?.[resolvedFocusedFacet]
           || null;
         const caseStudyConfigPosition =
           config?.projectCameraSettings?.[focusedProject]?.[deviceMode]?.caseStudy?.position

--- a/src/components/three/UnifiedCrystalScene.jsx
+++ b/src/components/three/UnifiedCrystalScene.jsx
@@ -114,8 +114,6 @@ const UnifiedCrystalScene = forwardRef(({
   const hoverCapable = useHoverCapable();
   useCursor(Boolean(hoverCapable && hoveredFacet));
   const overviewWorldAnchors = layout?.anchors?.overviewWorld;
-  const layoutCamera = layout?.camera;
-  const layoutProjects = layout?.projects;
   const resolvedConnectorPairs = useMemo(() => {
     const pairs = projects
       .map((project) => {
@@ -129,93 +127,7 @@ const UnifiedCrystalScene = forwardRef(({
     return pairs;
   }, []);
 
-  const mergedConfig = useMemo(() => {
-    const nextConfig = { ...config };
-
-    if (layoutCamera?.positions) {
-      nextConfig.cameraPositions = {
-        ...(nextConfig.cameraPositions || {}),
-        ...layoutCamera.positions,
-        projects: {
-          ...(nextConfig.cameraPositions?.projects || {}),
-          ...(layoutCamera.positions.projects || {}),
-        },
-      };
-    }
-
-    if (layoutCamera?.targets) {
-      nextConfig.cameraTargets = {
-        ...(nextConfig.cameraTargets || {}),
-        ...layoutCamera.targets,
-        projects: {
-          ...(nextConfig.cameraTargets?.projects || {}),
-          ...(layoutCamera.targets.projects || {}),
-        },
-      };
-    }
-
-    if (layoutCamera?.offsets) {
-      nextConfig.cameraOffsets = {
-        ...(nextConfig.cameraOffsets || {}),
-        ...layoutCamera.offsets,
-        global: {
-          ...(nextConfig.cameraOffsets?.global || {}),
-          ...(layoutCamera.offsets.global || {}),
-        },
-        zones: {
-          ...(nextConfig.cameraOffsets?.zones || {}),
-          ...(layoutCamera.offsets.zones || {}),
-        },
-        projects: {
-          ...(nextConfig.cameraOffsets?.projects || {}),
-          ...(layoutCamera.offsets.projects || {}),
-        },
-      };
-    }
-
-    if (layoutProjects?.explodedPositions) {
-      nextConfig.explodedPositions = {
-        ...Object.fromEntries(
-          Object.entries(layoutProjects.explodedPositions).map(([key, value]) => [key, value.toArray()]),
-        ),
-        ...(nextConfig.explodedPositions || {}),
-        ...(projectRuntimeOverrides?.explodedPositions || {}),
-      };
-    } else if (projectRuntimeOverrides?.explodedPositions) {
-      nextConfig.explodedPositions = {
-        ...(nextConfig.explodedPositions || {}),
-        ...projectRuntimeOverrides.explodedPositions,
-      };
-    }
-
-    if (layoutProjects?.facetRotationsEulerDeg) {
-      nextConfig.facetRotationsEulerDeg = {
-        ...(nextConfig.facetRotationsEulerDeg || {}),
-        ...layoutProjects.facetRotationsEulerDeg,
-        ...(projectRuntimeOverrides?.facetRotationsEulerDeg || {}),
-      };
-    } else if (projectRuntimeOverrides?.facetRotationsEulerDeg) {
-      nextConfig.facetRotationsEulerDeg = {
-        ...(nextConfig.facetRotationsEulerDeg || {}),
-        ...projectRuntimeOverrides.facetRotationsEulerDeg,
-      };
-    }
-
-    if (layoutProjects?.selectedFacetRotationsEulerDeg) {
-      nextConfig.selectedFacetRotationsEulerDeg = {
-        ...(nextConfig.selectedFacetRotationsEulerDeg || {}),
-        ...layoutProjects.selectedFacetRotationsEulerDeg,
-        ...(projectRuntimeOverrides?.selectedFacetRotationsEulerDeg || {}),
-      };
-    } else if (projectRuntimeOverrides?.selectedFacetRotationsEulerDeg) {
-      nextConfig.selectedFacetRotationsEulerDeg = {
-        ...(nextConfig.selectedFacetRotationsEulerDeg || {}),
-        ...projectRuntimeOverrides.selectedFacetRotationsEulerDeg,
-      };
-    }
-
-    return nextConfig;
-  }, [config, layoutCamera, layoutProjects, projectRuntimeOverrides]);
+  const mergedConfig = useMemo(() => config, [config]);
 
   useEffect(() => {
     if (!import.meta.env.DEV) return;
@@ -224,53 +136,7 @@ const UnifiedCrystalScene = forwardRef(({
     logger.debug('📷 Effective layout camera positions', { hero, overview });
   }, [mergedConfig?.cameraPositions?.hero, mergedConfig?.cameraPositions?.overview]);
 
-  const crystalConfig = useMemo(() => {
-    const baseCrystalConfig = animationData?.crystalConfig;
-    if (!baseCrystalConfig) return baseCrystalConfig;
-
-    const nextCrystalConfig = { ...baseCrystalConfig };
-
-    if (layoutProjects?.explodedPositions) {
-      nextCrystalConfig.explodedPositions = {
-        ...layoutProjects.explodedPositions,
-        ...(baseCrystalConfig.explodedPositions || {}),
-        ...(projectRuntimeOverrides?.explodedPositions || {}),
-      };
-    } else if (projectRuntimeOverrides?.explodedPositions) {
-      nextCrystalConfig.explodedPositions = {
-        ...(baseCrystalConfig.explodedPositions || {}),
-        ...projectRuntimeOverrides.explodedPositions,
-      };
-    }
-
-    if (layoutProjects?.facetRotationsEulerDeg) {
-      nextCrystalConfig.facetRotationsEulerDeg = {
-        ...(baseCrystalConfig.facetRotationsEulerDeg || {}),
-        ...layoutProjects.facetRotationsEulerDeg,
-        ...(projectRuntimeOverrides?.facetRotationsEulerDeg || {}),
-      };
-    } else if (projectRuntimeOverrides?.facetRotationsEulerDeg) {
-      nextCrystalConfig.facetRotationsEulerDeg = {
-        ...(baseCrystalConfig.facetRotationsEulerDeg || {}),
-        ...projectRuntimeOverrides.facetRotationsEulerDeg,
-      };
-    }
-
-    if (layoutProjects?.selectedFacetRotationsEulerDeg) {
-      nextCrystalConfig.selectedFacetRotationsEulerDeg = {
-        ...(baseCrystalConfig.selectedFacetRotationsEulerDeg || {}),
-        ...layoutProjects.selectedFacetRotationsEulerDeg,
-        ...(projectRuntimeOverrides?.selectedFacetRotationsEulerDeg || {}),
-      };
-    } else if (projectRuntimeOverrides?.selectedFacetRotationsEulerDeg) {
-      nextCrystalConfig.selectedFacetRotationsEulerDeg = {
-        ...(baseCrystalConfig.selectedFacetRotationsEulerDeg || {}),
-        ...projectRuntimeOverrides.selectedFacetRotationsEulerDeg,
-      };
-    }
-
-    return nextCrystalConfig;
-  }, [animationData?.crystalConfig, layoutProjects, projectRuntimeOverrides]);
+  const crystalConfig = useMemo(() => animationData?.crystalConfig, [animationData?.crystalConfig]);
 
   // Facet configuration
   const facetKeys = canonicalFacetKeys;

--- a/src/components/ui/CrystalControls.jsx
+++ b/src/components/ui/CrystalControls.jsx
@@ -4,6 +4,11 @@ import * as THREE from 'three';
 import * as crystalConfig from '../../crystalConfig';
 import { isMobileDevice } from '../../utils/isMobileDevice';
 import { getProjectIdBySceneFacetKey, getSceneFacetKeyByProjectId } from '../../data/projects';
+import {
+  applyCameraTuningToConfig,
+  buildCameraTuningPayloadFromConfig,
+  stringifyCameraTuningPayload
+} from '../../lib/tuning/cameraTuning';
 
 const RAD2DEG = 180 / Math.PI;
 const DEG2RAD = Math.PI / 180;
@@ -318,174 +323,6 @@ const CrystalControls = ({ config, onUpdate, onRestartScene = null }) => {
   };
 
   const cloneConfig = () => normalizeCrystalConfig(config ?? crystalConfig);
-
-  const sanitizeNumber = (value, fallback = 0) => {
-    if (value === null || value === undefined) return fallback;
-    const parsed = typeof value === 'number' ? value : Number(value);
-    return Number.isFinite(parsed) ? parsed : fallback;
-  };
-
-  const clampNumber = (value, min, max) => Math.min(Math.max(value, min), max);
-
-  const sanitizeVec3 = (value, options = {}) => {
-    if (!Array.isArray(value) || value.length !== 3) return null;
-    const numbers = value.map((entry) => sanitizeNumber(entry, 0));
-    if (options.clamp) {
-      return numbers.map((entry) => clampNumber(entry, options.clamp[0], options.clamp[1]));
-    }
-    return numbers;
-  };
-
-  const buildTuningPayload = (baseConfig) => {
-    const payload = {
-      version: 1,
-      tuning: {
-        cameraPositions: baseConfig.cameraPositions,
-        cameraTargets: baseConfig.cameraTargets,
-        cameraOffsets: baseConfig.cameraOffsets,
-        explodedPositions: baseConfig.explodedPositions,
-        facetRotationsEulerDeg: baseConfig.facetRotationsEulerDeg,
-        selectedFacetRotationsEulerDeg: baseConfig.selectedFacetRotationsEulerDeg,
-        projectCameraSettings: baseConfig.projectCameraSettings
-      }
-    };
-
-    if (baseConfig.timing?.camera) {
-      payload.tuning.timing = {
-        camera: baseConfig.timing.camera
-      };
-    }
-
-    return payload;
-  };
-
-  const applyTuningToConfig = (currentConfig, tuningPayload) => {
-    const base = currentConfig ?? crystalConfig;
-    const updatedConfig = JSON.parse(JSON.stringify(base));
-    const tuning = tuningPayload?.tuning ?? tuningPayload ?? {};
-
-    const updateCameraPositions = (positions) => {
-      if (!positions) return;
-      zoneKeys.forEach((zone) => {
-        const vec = sanitizeVec3(positions[zone]);
-        if (vec) updatedConfig.cameraPositions[zone] = vec;
-      });
-      if (positions.projects) {
-        projectKeys.forEach((project) => {
-          const vec = sanitizeVec3(positions.projects?.[project]);
-          if (vec) updatedConfig.cameraPositions.projects[project] = vec;
-        });
-      }
-    };
-
-    const updateCameraTargets = (targets) => {
-      if (!targets) return;
-      zoneKeys.forEach((zone) => {
-        const vec = sanitizeVec3(targets[zone]);
-        if (vec) updatedConfig.cameraTargets[zone] = vec;
-      });
-      if (targets.projects) {
-        projectKeys.forEach((project) => {
-          const vec = sanitizeVec3(targets.projects?.[project]);
-          if (vec) updatedConfig.cameraTargets.projects[project] = vec;
-        });
-      }
-    };
-
-    const updateCameraOffsets = (offsets) => {
-      if (!offsets) return;
-      const clamp = [-2, 2];
-      if (offsets.global) {
-        const position = sanitizeVec3(offsets.global.position, { clamp });
-        const target = sanitizeVec3(offsets.global.target, { clamp });
-        if (position) updatedConfig.cameraOffsets.global.position = position;
-        if (target) updatedConfig.cameraOffsets.global.target = target;
-      }
-      if (offsets.zones) {
-        zoneKeys.forEach((zone) => {
-          const zoneOffsets = offsets.zones?.[zone];
-          if (!zoneOffsets) return;
-          const position = sanitizeVec3(zoneOffsets.position, { clamp });
-          const target = sanitizeVec3(zoneOffsets.target, { clamp });
-          if (position) updatedConfig.cameraOffsets.zones[zone].position = position;
-          if (target) updatedConfig.cameraOffsets.zones[zone].target = target;
-        });
-      }
-      if (offsets.projects) {
-        projectKeys.forEach((project) => {
-          const projectOffsets = offsets.projects?.[project];
-          if (!projectOffsets) return;
-          const position = sanitizeVec3(projectOffsets.position, { clamp });
-          const target = sanitizeVec3(projectOffsets.target, { clamp });
-          if (position) updatedConfig.cameraOffsets.projects[project].position = position;
-          if (target) updatedConfig.cameraOffsets.projects[project].target = target;
-        });
-      }
-    };
-
-    const updateExplodedPositions = (positions) => {
-      if (!positions) return;
-      projectKeys.forEach((project) => {
-        const vec = sanitizeVec3(positions?.[project]);
-        if (vec) updatedConfig.explodedPositions[project] = vec;
-      });
-    };
-
-    const updateFacetRotations = (rotations) => {
-      if (!rotations) return;
-      projectKeys.forEach((project) => {
-        const vec = sanitizeVec3(rotations?.[project]);
-        if (vec) updatedConfig.facetRotationsEulerDeg[project] = vec;
-      });
-    };
-
-    const updateSelectedFacetRotations = (rotations) => {
-      if (!rotations) return;
-      projectKeys.forEach((project) => {
-        const vec = sanitizeVec3(rotations?.[project]);
-        if (vec) updatedConfig.selectedFacetRotationsEulerDeg[project] = vec;
-      });
-    };
-
-    const updateProjectCameraSettings = (settings) => {
-      if (!settings) return;
-      projectCameraKeys.forEach((project) => {
-        ['desktop', 'mobile'].forEach((device) => {
-          const selectedPosition = sanitizeVec3(settings?.[project]?.[device]?.selected?.position);
-          const selectedTarget = sanitizeVec3(settings?.[project]?.[device]?.selected?.target);
-          const caseStudyPosition = sanitizeVec3(settings?.[project]?.[device]?.caseStudy?.position);
-          const caseStudyTarget = sanitizeVec3(settings?.[project]?.[device]?.caseStudy?.target);
-          const caseStudyFacetRotation = sanitizeVec3(settings?.[project]?.[device]?.caseStudy?.facetRotation);
-
-          if (selectedPosition) updatedConfig.projectCameraSettings[project][device].selected.position = selectedPosition;
-          if (selectedTarget) updatedConfig.projectCameraSettings[project][device].selected.target = selectedTarget;
-          if (caseStudyPosition) updatedConfig.projectCameraSettings[project][device].caseStudy.position = caseStudyPosition;
-          if (caseStudyTarget) updatedConfig.projectCameraSettings[project][device].caseStudy.target = caseStudyTarget;
-          if (caseStudyFacetRotation) updatedConfig.projectCameraSettings[project][device].caseStudy.facetRotation = caseStudyFacetRotation;
-        });
-      });
-    };
-
-    const updateTiming = (timing) => {
-      if (!timing?.camera) return;
-      Object.entries(timing.camera).forEach(([key, value]) => {
-        const numericValue = sanitizeNumber(value, null);
-        if (numericValue === null) return;
-        updatedConfig.timing.camera[key] = numericValue;
-      });
-    };
-
-    updateCameraPositions(tuning.cameraPositions);
-    updateCameraTargets(tuning.cameraTargets);
-    updateCameraOffsets(tuning.cameraOffsets);
-    updateExplodedPositions(tuning.explodedPositions);
-    updateFacetRotations(tuning.facetRotationsEulerDeg);
-    updateSelectedFacetRotations(tuning.selectedFacetRotationsEulerDeg);
-    updateProjectCameraSettings(tuning.projectCameraSettings);
-    updateTiming(tuning.timing);
-
-    return updatedConfig;
-  };
 
   const syncStateFromConfig = (updatedConfig) => {
     setTimingValues({
@@ -978,8 +815,8 @@ const CrystalControls = ({ config, onUpdate, onRestartScene = null }) => {
 
   const getTuningPayload = () => {
     const base = config ?? crystalConfig;
-    const payload = buildTuningPayload(base);
-    return JSON.stringify(payload, null, 2);
+    const payload = buildCameraTuningPayloadFromConfig(base);
+    return stringifyCameraTuningPayload(payload);
   };
 
   const setExportMessage = (message) => {
@@ -1050,40 +887,10 @@ const CrystalControls = ({ config, onUpdate, onRestartScene = null }) => {
     try {
       const text = await file.text();
       const rawPayload = JSON.parse(text);
-      const normalized = normalizeCrystalConfig(rawPayload);
-      console.log('[LOAD JSON] normalized colors:', {
-        color: normalized.materials?.crystal?.color?.isColor,
-        emissive: normalized.materials?.crystal?.emissive?.isColor,
-        attenuationColor: normalized.materials?.crystal?.attenuationColor?.isColor,
-        specularColor: normalized.materials?.crystal?.specularColor?.isColor
-      });
-      const tuningData = rawPayload?.tuning ?? rawPayload;
-      const hasKnownKeys =
-        tuningData &&
-        (tuningData.cameraPositions ||
-          tuningData.cameraTargets ||
-          tuningData.cameraOffsets ||
-          tuningData.explodedPositions ||
-          tuningData.facetRotationsEulerDeg ||
-          tuningData.selectedFacetRotationsEulerDeg ||
-          tuningData.timing);
-
-      if (!hasKnownKeys) {
-        throw new Error('Missing tuning data');
-      }
-
-      const isTuningPayload = Boolean(rawPayload?.tuning) || !rawPayload?.materials;
-
-      if (isTuningPayload) {
-        const normalizedPayload = rawPayload?.tuning ? rawPayload : { version: 1, tuning: tuningData };
-        const updatedConfig = applyTuningToConfig(config ?? crystalConfig, normalizedPayload);
-        const normalizedConfig = normalizeCrystalConfig(updatedConfig);
-        syncStateFromConfig(normalizedConfig);
-        onUpdate(normalizedConfig);
-      } else {
-        syncStateFromConfig(normalized);
-        onUpdate(normalized);
-      }
+      const { config: updatedConfig } = applyCameraTuningToConfig(config ?? crystalConfig, rawPayload);
+      const normalizedConfig = normalizeCrystalConfig(updatedConfig);
+      syncStateFromConfig(normalizedConfig);
+      onUpdate(normalizedConfig);
       setExportMessage('Loaded preset ✅');
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown error';

--- a/src/config/tuning/cameraTuning.json
+++ b/src/config/tuning/cameraTuning.json
@@ -1,0 +1,145 @@
+{
+  "version": 1,
+  "tuning": {
+    "cameraPositions": {
+      "intro": [0.16359952088021784, -2.0376618037026195, 1.1719674768510127],
+      "hero": [0.55, 0.92, 3.94],
+      "overview": [0.23, 0.53, 6.57],
+      "about": [1.74, 1.34, 1.87],
+      "projects": {
+        "empathy": [0.16, -1.85, 1.79],
+        "narrative": [-0.66, -1.37, 1.1],
+        "craft": [-0.88, -0.85, 2.53],
+        "system": [-1.28, -0.23, 1.58],
+        "leadership": [-0.09, 0.38, 2.87],
+        "exploration": [-0.05, 0.28, 3.94]
+      }
+    },
+    "cameraTargets": {
+      "intro": [0.6, -2.9, 0],
+      "hero": [0, 0.5, 0],
+      "overview": [0, 0.3, 0],
+      "about": [0, 0.2, 0],
+      "projects": {
+        "empathy": [0.3, -0.7, -0.2],
+        "narrative": [0.3, -0.1, -0.7],
+        "craft": [1.3, 0.8, 0.5],
+        "system": [-0.5, 0.2, -1.8],
+        "leadership": [0.4, 1.2, 0.9],
+        "exploration": [-0.6, 0.7, 0]
+      }
+    },
+    "cameraOffsets": {
+      "global": {
+        "position": [0, 0, 0],
+        "target": [0, 0, 0]
+      },
+      "zones": {
+        "intro": { "position": [0, 0, 0], "target": [0, 0, 0] },
+        "hero": { "position": [0, 0, 0], "target": [0, 0, 0] },
+        "overview": { "position": [0, 0, 0], "target": [0, 0, 0] },
+        "about": { "position": [0, 0, 0], "target": [0, 0, 0] }
+      },
+      "projects": {
+        "empathy": { "position": [0, 0, 0], "target": [0, 0, 0] },
+        "narrative": { "position": [0, 0, 0], "target": [0, 0, 0] },
+        "craft": { "position": [0, 0, 0], "target": [0, 0, 0] },
+        "system": { "position": [0, 0, 0], "target": [0, 0, 0] },
+        "leadership": { "position": [0, 0, 0], "target": [0, 0, 0] },
+        "exploration": { "position": [0, 0, 0], "target": [0, 0, 0] }
+      }
+    },
+    "explodedPositions": {
+      "empathy": [0.3, -0.7, -0.2],
+      "narrative": [0.3, -0.1, -0.7],
+      "craft": [1.3, 0.8, 0.5],
+      "system": [-0.5, 0.2, -1.8],
+      "leadership": [0.4, 1.2, 0.9],
+      "exploration": [-0.6, 0.7, 0]
+    },
+    "facetRotationsEulerDeg": {
+      "empathy": [0, 0, 0],
+      "narrative": [0, 0, 0],
+      "craft": [0, 0, 0],
+      "system": [0, 0, 0],
+      "leadership": [0, 0, 0],
+      "exploration": [0, 0, 0]
+    },
+    "selectedFacetRotationsEulerDeg": {
+      "empathy": [25, 121, 13],
+      "narrative": [10, -16, 0],
+      "craft": [-2, 65, 45],
+      "system": [-25, -19, 1],
+      "leadership": [18, 112, 4],
+      "exploration": [-15, -13, -17]
+    },
+    "projectCameraSettings": {
+      "project01": {
+        "desktop": {
+          "selected": { "position": [-0.09, 0.38, 2.87], "target": [0.4, 1.2, 0.9] },
+          "caseStudy": { "position": [-0.09, 0.38, 2.87], "target": [0.4, 1.2, 0.9], "facetRotation": [18, 112, 4] }
+        },
+        "mobile": {
+          "selected": { "position": [-0.09, 0.38, 2.87], "target": [0.4, 1.2, 0.9] },
+          "caseStudy": { "position": [-0.09, 0.38, 2.87], "target": [0.4, 1.2, 0.9], "facetRotation": [18, 112, 4] }
+        }
+      },
+      "project02": {
+        "desktop": {
+          "selected": { "position": [-0.05, 0.28, 3.94], "target": [-0.6, 0.7, 0] },
+          "caseStudy": { "position": [-0.05, 0.28, 3.94], "target": [-0.6, 0.7, 0], "facetRotation": [-15, -13, -17] }
+        },
+        "mobile": {
+          "selected": { "position": [-0.05, 0.28, 3.94], "target": [-0.6, 0.7, 0] },
+          "caseStudy": { "position": [-0.05, 0.28, 3.94], "target": [-0.6, 0.7, 0], "facetRotation": [-15, -13, -17] }
+        }
+      },
+      "project03": {
+        "desktop": {
+          "selected": { "position": [-0.88, -0.85, 2.53], "target": [1.3, 0.8, 0.5] },
+          "caseStudy": { "position": [-0.88, -0.85, 2.53], "target": [1.3, 0.8, 0.5], "facetRotation": [-2, 65, 45] }
+        },
+        "mobile": {
+          "selected": { "position": [-0.88, -0.85, 2.53], "target": [1.3, 0.8, 0.5] },
+          "caseStudy": { "position": [-0.88, -0.85, 2.53], "target": [1.3, 0.8, 0.5], "facetRotation": [-2, 65, 45] }
+        }
+      },
+      "project04": {
+        "desktop": {
+          "selected": { "position": [-1.28, -0.23, 1.58], "target": [-0.5, 0.2, -1.8] },
+          "caseStudy": { "position": [-1.28, -0.23, 1.58], "target": [-0.5, 0.2, -1.8], "facetRotation": [-25, -19, 1] }
+        },
+        "mobile": {
+          "selected": { "position": [-1.28, -0.23, 1.58], "target": [-0.5, 0.2, -1.8] },
+          "caseStudy": { "position": [-1.28, -0.23, 1.58], "target": [-0.5, 0.2, -1.8], "facetRotation": [-25, -19, 1] }
+        }
+      },
+      "project05": {
+        "desktop": {
+          "selected": { "position": [-0.66, -1.37, 1.1], "target": [0.3, -0.1, -0.7] },
+          "caseStudy": { "position": [-0.66, -1.37, 1.1], "target": [0.3, -0.1, -0.7], "facetRotation": [10, -16, 0] }
+        },
+        "mobile": {
+          "selected": { "position": [-0.66, -1.37, 1.1], "target": [0.3, -0.1, -0.7] },
+          "caseStudy": { "position": [-0.66, -1.37, 1.1], "target": [0.3, -0.1, -0.7], "facetRotation": [10, -16, 0] }
+        }
+      },
+      "project06": {
+        "desktop": {
+          "selected": { "position": [0.16, -1.85, 1.79], "target": [0.3, -0.7, -0.2] },
+          "caseStudy": { "position": [0.16, -1.85, 1.79], "target": [0.3, -0.7, -0.2], "facetRotation": [25, 121, 13] }
+        },
+        "mobile": {
+          "selected": { "position": [0.16, -1.85, 1.79], "target": [0.3, -0.7, -0.2] },
+          "caseStudy": { "position": [0.16, -1.85, 1.79], "target": [0.3, -0.7, -0.2], "facetRotation": [25, 121, 13] }
+        }
+      }
+    },
+    "timing": {
+      "camera": {
+        "explodeDuration": 1600,
+        "reformDuration": 900
+      }
+    }
+  }
+}

--- a/src/lib/tuning/cameraTuning.js
+++ b/src/lib/tuning/cameraTuning.js
@@ -1,0 +1,286 @@
+const ZONE_KEYS = ['intro', 'hero', 'overview', 'about'];
+const PROJECT_KEYS = ['empathy', 'narrative', 'craft', 'system', 'leadership', 'exploration'];
+const PROJECT_CAMERA_KEYS = ['project01', 'project02', 'project03', 'project04', 'project05', 'project06'];
+const DEVICE_KEYS = ['desktop', 'mobile'];
+const MODE_KEYS = ['selected', 'caseStudy'];
+
+const ensureObject = (value, path) => {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${path} must be an object`);
+  }
+};
+
+const ensureExactKeys = (value, expectedKeys, path) => {
+  ensureObject(value, path);
+  const actualKeys = Object.keys(value);
+  const extras = actualKeys.filter((key) => !expectedKeys.includes(key));
+  if (extras.length > 0) {
+    throw new Error(`${path} has unsupported keys: ${extras.join(', ')}`);
+  }
+
+  const missing = expectedKeys.filter((key) => !actualKeys.includes(key));
+  if (missing.length > 0) {
+    throw new Error(`${path} is missing required keys: ${missing.join(', ')}`);
+  }
+};
+
+const ensureVec3 = (value, path) => {
+  if (
+    !Array.isArray(value)
+    || value.length !== 3
+    || value.some((entry) => typeof entry !== 'number' || Number.isNaN(entry))
+  ) {
+    throw new Error(`${path} must be a numeric [x, y, z] array`);
+  }
+};
+
+const cloneVec3 = (value) => [...value];
+
+const cloneOffsetsMap = (source) => Object.fromEntries(
+  Object.entries(source).map(([key, value]) => [key, {
+    position: cloneVec3(value.position),
+    target: cloneVec3(value.target)
+  }])
+);
+
+const cloneProjectCameraSettings = (source) => Object.fromEntries(
+  PROJECT_CAMERA_KEYS.map((projectKey) => [projectKey, {
+    desktop: {
+      selected: {
+        position: cloneVec3(source[projectKey].desktop.selected.position),
+        target: cloneVec3(source[projectKey].desktop.selected.target)
+      },
+      caseStudy: {
+        position: cloneVec3(source[projectKey].desktop.caseStudy.position),
+        target: cloneVec3(source[projectKey].desktop.caseStudy.target),
+        facetRotation: cloneVec3(source[projectKey].desktop.caseStudy.facetRotation)
+      }
+    },
+    mobile: {
+      selected: {
+        position: cloneVec3(source[projectKey].mobile.selected.position),
+        target: cloneVec3(source[projectKey].mobile.selected.target)
+      },
+      caseStudy: {
+        position: cloneVec3(source[projectKey].mobile.caseStudy.position),
+        target: cloneVec3(source[projectKey].mobile.caseStudy.target),
+        facetRotation: cloneVec3(source[projectKey].mobile.caseStudy.facetRotation)
+      }
+    }
+  }])
+);
+
+const validateProjectCameraMode = (modeValue, path, requireFacetRotation) => {
+  const keys = requireFacetRotation ? ['position', 'target', 'facetRotation'] : ['position', 'target'];
+  ensureExactKeys(modeValue, keys, path);
+  ensureVec3(modeValue.position, `${path}.position`);
+  ensureVec3(modeValue.target, `${path}.target`);
+  if (requireFacetRotation) {
+    ensureVec3(modeValue.facetRotation, `${path}.facetRotation`);
+  }
+};
+
+export const validateCameraTuningPayload = (payload) => {
+  ensureExactKeys(payload, ['version', 'tuning'], 'root');
+  if (payload.version !== 1) {
+    throw new Error(`root.version must be 1, received ${payload.version}`);
+  }
+
+  const { tuning } = payload;
+  ensureExactKeys(
+    tuning,
+    [
+      'cameraPositions',
+      'cameraTargets',
+      'cameraOffsets',
+      'explodedPositions',
+      'facetRotationsEulerDeg',
+      'selectedFacetRotationsEulerDeg',
+      'projectCameraSettings',
+      'timing'
+    ],
+    'root.tuning'
+  );
+
+  ensureExactKeys(tuning.cameraPositions, [...ZONE_KEYS, 'projects'], 'root.tuning.cameraPositions');
+  ZONE_KEYS.forEach((zone) => ensureVec3(tuning.cameraPositions[zone], `root.tuning.cameraPositions.${zone}`));
+  ensureExactKeys(tuning.cameraPositions.projects, PROJECT_KEYS, 'root.tuning.cameraPositions.projects');
+  PROJECT_KEYS.forEach((project) => ensureVec3(tuning.cameraPositions.projects[project], `root.tuning.cameraPositions.projects.${project}`));
+
+  ensureExactKeys(tuning.cameraTargets, [...ZONE_KEYS, 'projects'], 'root.tuning.cameraTargets');
+  ZONE_KEYS.forEach((zone) => ensureVec3(tuning.cameraTargets[zone], `root.tuning.cameraTargets.${zone}`));
+  ensureExactKeys(tuning.cameraTargets.projects, PROJECT_KEYS, 'root.tuning.cameraTargets.projects');
+  PROJECT_KEYS.forEach((project) => ensureVec3(tuning.cameraTargets.projects[project], `root.tuning.cameraTargets.projects.${project}`));
+
+  ensureExactKeys(tuning.cameraOffsets, ['global', 'zones', 'projects'], 'root.tuning.cameraOffsets');
+  ensureExactKeys(tuning.cameraOffsets.global, ['position', 'target'], 'root.tuning.cameraOffsets.global');
+  ensureVec3(tuning.cameraOffsets.global.position, 'root.tuning.cameraOffsets.global.position');
+  ensureVec3(tuning.cameraOffsets.global.target, 'root.tuning.cameraOffsets.global.target');
+
+  ensureExactKeys(tuning.cameraOffsets.zones, ZONE_KEYS, 'root.tuning.cameraOffsets.zones');
+  ZONE_KEYS.forEach((zone) => {
+    ensureExactKeys(tuning.cameraOffsets.zones[zone], ['position', 'target'], `root.tuning.cameraOffsets.zones.${zone}`);
+    ensureVec3(tuning.cameraOffsets.zones[zone].position, `root.tuning.cameraOffsets.zones.${zone}.position`);
+    ensureVec3(tuning.cameraOffsets.zones[zone].target, `root.tuning.cameraOffsets.zones.${zone}.target`);
+  });
+
+  ensureExactKeys(tuning.cameraOffsets.projects, PROJECT_KEYS, 'root.tuning.cameraOffsets.projects');
+  PROJECT_KEYS.forEach((project) => {
+    ensureExactKeys(tuning.cameraOffsets.projects[project], ['position', 'target'], `root.tuning.cameraOffsets.projects.${project}`);
+    ensureVec3(tuning.cameraOffsets.projects[project].position, `root.tuning.cameraOffsets.projects.${project}.position`);
+    ensureVec3(tuning.cameraOffsets.projects[project].target, `root.tuning.cameraOffsets.projects.${project}.target`);
+  });
+
+  ensureExactKeys(tuning.explodedPositions, PROJECT_KEYS, 'root.tuning.explodedPositions');
+  PROJECT_KEYS.forEach((project) => ensureVec3(tuning.explodedPositions[project], `root.tuning.explodedPositions.${project}`));
+
+  ensureExactKeys(tuning.facetRotationsEulerDeg, PROJECT_KEYS, 'root.tuning.facetRotationsEulerDeg');
+  PROJECT_KEYS.forEach((project) => ensureVec3(tuning.facetRotationsEulerDeg[project], `root.tuning.facetRotationsEulerDeg.${project}`));
+
+  ensureExactKeys(tuning.selectedFacetRotationsEulerDeg, PROJECT_KEYS, 'root.tuning.selectedFacetRotationsEulerDeg');
+  PROJECT_KEYS.forEach((project) => ensureVec3(tuning.selectedFacetRotationsEulerDeg[project], `root.tuning.selectedFacetRotationsEulerDeg.${project}`));
+
+  ensureExactKeys(tuning.projectCameraSettings, PROJECT_CAMERA_KEYS, 'root.tuning.projectCameraSettings');
+  PROJECT_CAMERA_KEYS.forEach((projectCameraKey) => {
+    ensureExactKeys(tuning.projectCameraSettings[projectCameraKey], DEVICE_KEYS, `root.tuning.projectCameraSettings.${projectCameraKey}`);
+    DEVICE_KEYS.forEach((deviceKey) => {
+      ensureExactKeys(tuning.projectCameraSettings[projectCameraKey][deviceKey], MODE_KEYS, `root.tuning.projectCameraSettings.${projectCameraKey}.${deviceKey}`);
+      validateProjectCameraMode(tuning.projectCameraSettings[projectCameraKey][deviceKey].selected, `root.tuning.projectCameraSettings.${projectCameraKey}.${deviceKey}.selected`, false);
+      validateProjectCameraMode(tuning.projectCameraSettings[projectCameraKey][deviceKey].caseStudy, `root.tuning.projectCameraSettings.${projectCameraKey}.${deviceKey}.caseStudy`, true);
+    });
+  });
+
+  ensureExactKeys(tuning.timing, ['camera'], 'root.tuning.timing');
+  ensureExactKeys(tuning.timing.camera, ['explodeDuration', 'reformDuration'], 'root.tuning.timing.camera');
+  if (typeof tuning.timing.camera.explodeDuration !== 'number' || Number.isNaN(tuning.timing.camera.explodeDuration)) {
+    throw new Error('root.tuning.timing.camera.explodeDuration must be numeric');
+  }
+  if (typeof tuning.timing.camera.reformDuration !== 'number' || Number.isNaN(tuning.timing.camera.reformDuration)) {
+    throw new Error('root.tuning.timing.camera.reformDuration must be numeric');
+  }
+};
+
+export const cloneCameraTuningPayload = (payload) => {
+  validateCameraTuningPayload(payload);
+
+  return {
+    version: 1,
+    tuning: {
+      cameraPositions: {
+        intro: cloneVec3(payload.tuning.cameraPositions.intro),
+        hero: cloneVec3(payload.tuning.cameraPositions.hero),
+        overview: cloneVec3(payload.tuning.cameraPositions.overview),
+        about: cloneVec3(payload.tuning.cameraPositions.about),
+        projects: Object.fromEntries(
+          PROJECT_KEYS.map((project) => [project, cloneVec3(payload.tuning.cameraPositions.projects[project])])
+        )
+      },
+      cameraTargets: {
+        intro: cloneVec3(payload.tuning.cameraTargets.intro),
+        hero: cloneVec3(payload.tuning.cameraTargets.hero),
+        overview: cloneVec3(payload.tuning.cameraTargets.overview),
+        about: cloneVec3(payload.tuning.cameraTargets.about),
+        projects: Object.fromEntries(
+          PROJECT_KEYS.map((project) => [project, cloneVec3(payload.tuning.cameraTargets.projects[project])])
+        )
+      },
+      cameraOffsets: {
+        global: {
+          position: cloneVec3(payload.tuning.cameraOffsets.global.position),
+          target: cloneVec3(payload.tuning.cameraOffsets.global.target)
+        },
+        zones: cloneOffsetsMap(payload.tuning.cameraOffsets.zones),
+        projects: cloneOffsetsMap(payload.tuning.cameraOffsets.projects)
+      },
+      explodedPositions: Object.fromEntries(
+        PROJECT_KEYS.map((project) => [project, cloneVec3(payload.tuning.explodedPositions[project])])
+      ),
+      facetRotationsEulerDeg: Object.fromEntries(
+        PROJECT_KEYS.map((project) => [project, cloneVec3(payload.tuning.facetRotationsEulerDeg[project])])
+      ),
+      selectedFacetRotationsEulerDeg: Object.fromEntries(
+        PROJECT_KEYS.map((project) => [project, cloneVec3(payload.tuning.selectedFacetRotationsEulerDeg[project])])
+      ),
+      projectCameraSettings: cloneProjectCameraSettings(payload.tuning.projectCameraSettings),
+      timing: {
+        camera: {
+          explodeDuration: payload.tuning.timing.camera.explodeDuration,
+          reformDuration: payload.tuning.timing.camera.reformDuration
+        }
+      }
+    }
+  };
+};
+
+export const deepFreeze = (value) => {
+  if (!value || typeof value !== 'object' || Object.isFrozen(value)) return value;
+  Object.freeze(value);
+  Object.values(value).forEach((entry) => deepFreeze(entry));
+  return value;
+};
+
+export const applyCameraTuningToConfig = (baseConfig, payload) => {
+  const nextPayload = cloneCameraTuningPayload(payload);
+
+  const nextConfig = {
+    ...baseConfig,
+    cameraPositions: nextPayload.tuning.cameraPositions,
+    cameraTargets: nextPayload.tuning.cameraTargets,
+    cameraOffsets: nextPayload.tuning.cameraOffsets,
+    explodedPositions: nextPayload.tuning.explodedPositions,
+    facetRotationsEulerDeg: nextPayload.tuning.facetRotationsEulerDeg,
+    selectedFacetRotationsEulerDeg: nextPayload.tuning.selectedFacetRotationsEulerDeg,
+    projectCameraSettings: nextPayload.tuning.projectCameraSettings,
+    timing: {
+      ...baseConfig.timing,
+      camera: {
+        ...baseConfig.timing?.camera,
+        explodeDuration: nextPayload.tuning.timing.camera.explodeDuration,
+        reformDuration: nextPayload.tuning.timing.camera.reformDuration
+      }
+    }
+  };
+
+  deepFreeze(nextPayload);
+  deepFreeze(nextConfig.cameraPositions);
+  deepFreeze(nextConfig.cameraTargets);
+  deepFreeze(nextConfig.cameraOffsets);
+  deepFreeze(nextConfig.explodedPositions);
+  deepFreeze(nextConfig.facetRotationsEulerDeg);
+  deepFreeze(nextConfig.selectedFacetRotationsEulerDeg);
+  deepFreeze(nextConfig.projectCameraSettings);
+
+  return {
+    config: nextConfig,
+    payload: nextPayload
+  };
+};
+
+export const buildCameraTuningPayloadFromConfig = (config) => cloneCameraTuningPayload({
+  version: 1,
+  tuning: {
+    cameraPositions: config.cameraPositions,
+    cameraTargets: config.cameraTargets,
+    cameraOffsets: config.cameraOffsets,
+    explodedPositions: config.explodedPositions,
+    facetRotationsEulerDeg: config.facetRotationsEulerDeg,
+    selectedFacetRotationsEulerDeg: config.selectedFacetRotationsEulerDeg,
+    projectCameraSettings: config.projectCameraSettings,
+    timing: {
+      camera: {
+        explodeDuration: config.timing.camera.explodeDuration,
+        reformDuration: config.timing.camera.reformDuration
+      }
+    }
+  }
+});
+
+export const stringifyCameraTuningPayload = (payload) => `${JSON.stringify(cloneCameraTuningPayload(payload), null, 2)}\n`;
+
+export const PROJECT_CAMERA_TUNING_KEYS = {
+  ZONE_KEYS,
+  PROJECT_KEYS,
+  PROJECT_CAMERA_KEYS,
+  DEVICE_KEYS,
+  MODE_KEYS
+};


### PR DESCRIPTION
### Motivation

- Provide a first-class, versioned camera tuning payload that can be validated, cloned, and applied to the runtime crystal configuration.  
- Integrate external tuning into app startup and UI controls so tuning can be authored/loaded safely and used as the canonical base configuration.

### Description

- Add a new tuning payload implementation with validation, cloning, freeze utilities, and helpers in `src/lib/tuning/cameraTuning.js` that expose `validateCameraTuningPayload`, `cloneCameraTuningPayload`, `applyCameraTuningToConfig`, `buildCameraTuningPayloadFromConfig`, `stringifyCameraTuningPayload`, and `deepFreeze`.  
- Add a sample tuning file `src/config/tuning/cameraTuning.json` and apply it at app initialization by importing it in `src/App.jsx` and calling `applyCameraTuningToConfig`; the tuned config is used as the initial `config` and for building the animation config and runtime override comparisons.  
- Update `src/components/ui/CrystalControls.jsx` to use the new tuning helpers for exporting and importing tuning payloads via `buildCameraTuningPayloadFromConfig`, `stringifyCameraTuningPayload`, and `applyCameraTuningToConfig`, replacing scattered/manual tuning logic.  
- Harden camera resolution logic in `src/components/three/UnifiedCameraController.jsx` to require strict `projectCameraSettings` branches and return `null` (with DEV logging) when required branches are missing, removing previous fallbacks and ad-hoc case-study distance forcing.  
- Simplify `src/components/three/UnifiedCrystalScene.jsx` by removing complex runtime merging with layout/project overrides and using the canonical `config`/`animationData.crystalConfig` directly for `mergedConfig` and `crystalConfig`.

### Testing

- No automated tests were added or executed as part of this change; existing test coverage was not modified by this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0239466d083289b0e996e8d84e5f7)