### PR TITLE
Fix project label color syncing when hovering crystal facets

### DIFF
--- a/src/components/three/FacetLabels.jsx
+++ b/src/components/three/FacetLabels.jsx
@@ -4,6 +4,7 @@ import { useThree } from '@react-three/fiber';
 import Headline from '../ui/Headline';
 import { MQ_HOVER_CAPABLE } from '../../config/breakpoints';
 import { useLayoutConfig } from '../../hooks/useLayoutConfig';
+import { getProjectIdBySceneFacetKey } from '../../data/projects';
 import '../../styles/facet-label.css';
 
 const OptimizedLabel = React.memo(function OptimizedLabel({
@@ -355,8 +356,10 @@ const FacetLabels = React.memo(function FacetLabels({
         >
           {projects.map((project) => {
             const runtimeKey = project.facetKey || project.id;
+            const externallyHoveredRuntimeKey =
+              getProjectIdBySceneFacetKey(externallyHoveredFacetKey) || externallyHoveredFacetKey;
             const isActive =
-              externallyHoveredFacetKey === runtimeKey || labelHoveredFacetKey === runtimeKey;
+              externallyHoveredRuntimeKey === runtimeKey || labelHoveredFacetKey === runtimeKey;
             return (
             <OptimizedLabel
               key={runtimeKey}


### PR DESCRIPTION
### Motivation
- Ensure hovering a 3D project facet also activates the matching DOM project label color/transition so label and connector visuals remain consistent between label-hover and facet-hover interactions.

### Description
- Update `src/components/three/FacetLabels.jsx` to normalize an externally hovered scene facet key into the runtime project key using `getProjectIdBySceneFacetKey` and use that normalized key when evaluating `isTargetActive`, so facet-triggered hover state activates the corresponding label title color transition.

### Testing
- Ran `npm run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7dbd027288328b571e54ac502899a)