### PR TITLE
Fix sticky project facet highlight after returning to overview

### DIFF
--- a/src/components/three/UnifiedCrystalScene.jsx
+++ b/src/components/three/UnifiedCrystalScene.jsx
@@ -813,6 +813,9 @@ const UnifiedCrystalScene = forwardRef(({
 
   useEffect(() => {
     if (inActiveOverview) return;
+    hoverSourcesRef.current = {};
+    hoveredFacetRef.current = null;
+    setHoveredFacet(null);
     setAlwaysOnDomAnchorsByRuntimeKey({});
     setLabelsReady(false);
     facetsSettledRef.current = false;


### PR DESCRIPTION
### Motivation
- Returning to the overview could leave a previously-hovered project facet/label in an active state because hover tracking state was not cleared when exiting overview mode. This causes a stale selection to appear until the label is hovered again.

### Description
- Clear hover tracking when leaving overview by resetting `hoverSourcesRef.current = {}`, `hoveredFacetRef.current = null`, and `setHoveredFacet(null)` in `src/components/three/UnifiedCrystalScene.jsx` so hover state does not persist across zone changes.

### Testing
- Built the app with `npm run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e903aea7e88328a9ace6f58afc0f55)