### PR TITLE
Skip fracture pause during runtime travel and improve writer-audit logging

### DIFF
--- a/src/components/three/UnifiedCrystalScene.jsx
+++ b/src/components/three/UnifiedCrystalScene.jsx
@@ -1796,9 +1796,12 @@ const UnifiedCrystalScene = forwardRef(({
 
     // Hold facets at fracture positions before the explosion resumes
     if (animationData.crystalForm === 'exploded' && explosionStartRef.current) {
+      const runtimeSnapshotForLegacyWriter = heroOverviewRuntime?.getSnapshot?.() ?? null;
+      const runtimePhaseForLegacyWriter = runtimeSnapshotForLegacyWriter?.phase ?? 'idle';
+      const runtimeTravelActive = runtimePhaseForLegacyWriter !== 'idle';
       const fracturePause = crystalConfig?.fracturePause || 0.5;
       const elapsedExplosion = (performance.now() - explosionStartRef.current) / 1000;
-      if (elapsedExplosion < fracturePause) {
+      if (elapsedExplosion < fracturePause && !runtimeTravelActive) {
         const fracture = crystalConfig?.fracturePositions;
         const fractureDistance = crystalConfig?.fractureDistance ?? 0.3;
         facetRefs.current.forEach((facetRef, idx) => {
@@ -1834,6 +1837,16 @@ const UnifiedCrystalScene = forwardRef(({
           }
         });
         return; // Skip other animations during fracture pause
+      }
+      if (elapsedExplosion < fracturePause && runtimeTravelActive && typeof globalThis !== 'undefined' && globalThis.__HERO_OVERVIEW_RUNTIME_DEBUG__) {
+        console.log('[hero-overview-writer-audit] fragment writer skipped', {
+          writerBranch: 'fracturePauseLegacy',
+          reason: 'runtimeTravelActive',
+          fragmentVisualPhase: runtimeSnapshotForLegacyWriter?.fragmentVisualPhase ?? null,
+          runtimePhase: runtimePhaseForLegacyWriter,
+          crystalForm: animationData?.crystalForm ?? null,
+          explosionStartRefActive: Boolean(explosionStartRef.current),
+        });
       }
     }
 

--- a/src/components/three/UnifiedCrystalScene.jsx
+++ b/src/components/three/UnifiedCrystalScene.jsx
@@ -103,7 +103,7 @@ const UnifiedCrystalScene = forwardRef(({
   const heroOverviewFragmentTimingResolvedLoggedRef = useRef(false);
   const heroOverviewTravelDistanceAuditLoggedRef = useRef(false);
   const heroOverviewVisibleTravelSampleLoggedRef = useRef(new Set());
-  const heroOverviewFragmentWriterAuditRef = useRef({ frameWriters: new Map(), writers: new Set(), multiple: false });
+  const heroOverviewFragmentWriterAuditRef = useRef({ frameWriters: new Map(), frameWriterBranches: new Map(), frameWriteCount: new Map(), writers: new Set(), multiple: false });
 
   const deriveFragmentVisualTiming = (runtimeState, explosionProgress) => {
     const timing = runtimeState?.timing || {};
@@ -367,6 +367,10 @@ const UnifiedCrystalScene = forwardRef(({
         fragmentWritersSeen: new Set(),
         cameraWritersSeen: new Set(),
         multipleFragmentWritersSameFrame: false,
+        multipleFragmentWriterBranchesSameFrame: false,
+        fragmentWriterBranchesByFrame: {},
+        maxDistinctFragmentWriterBranchesInFrame: 0,
+        fragmentWriteCountByFrame: {},
         multipleCameraWritersSameFrame: false,
         legacyWriterAfterRuntimeWriter: false,
         fallbackWriterAfterRuntimeWriter: false,
@@ -1819,13 +1823,25 @@ const UnifiedCrystalScene = forwardRef(({
               const frameId = Math.floor(state.clock.elapsedTime * 1000);
               const frameWriters = heroOverviewFragmentWriterAuditRef.current.frameWriters.get(frameId) || [];
               frameWriters.push('fracturePauseLegacy');
+              const frameWriterBranches = heroOverviewFragmentWriterAuditRef.current.frameWriterBranches.get(frameId) || new Set();
+              frameWriterBranches.add('fracturePauseLegacy');
+              const frameWriteCount = (heroOverviewFragmentWriterAuditRef.current.frameWriteCount.get(frameId) || 0) + 1;
               if (globalThis.__HERO_OVERVIEW_WRITER_AUDIT__?.active) {
-                globalThis.__HERO_OVERVIEW_WRITER_AUDIT__.fragmentWritersSeen.add('fracturePauseLegacy');
-                if (frameWriters.length > 1) globalThis.__HERO_OVERVIEW_WRITER_AUDIT__.multipleFragmentWritersSameFrame = true;
+                const writerAudit = globalThis.__HERO_OVERVIEW_WRITER_AUDIT__;
+                writerAudit.fragmentWritersSeen.add('fracturePauseLegacy');
+                writerAudit.fragmentWriterBranchesByFrame[frameId] = Array.from(frameWriterBranches);
+                writerAudit.fragmentWriteCountByFrame[frameId] = frameWriteCount;
+                writerAudit.maxDistinctFragmentWriterBranchesInFrame = Math.max(writerAudit.maxDistinctFragmentWriterBranchesInFrame || 0, frameWriterBranches.size);
+                if (frameWriterBranches.size > 1) {
+                  writerAudit.multipleFragmentWriterBranchesSameFrame = true;
+                  writerAudit.multipleFragmentWritersSameFrame = true;
+                }
               }
               heroOverviewFragmentWriterAuditRef.current.frameWriters.set(frameId, frameWriters);
+              heroOverviewFragmentWriterAuditRef.current.frameWriterBranches.set(frameId, frameWriterBranches);
+              heroOverviewFragmentWriterAuditRef.current.frameWriteCount.set(frameId, frameWriteCount);
               heroOverviewFragmentWriterAuditRef.current.writers.add('fracturePauseLegacy');
-              if (frameWriters.length > 1) heroOverviewFragmentWriterAuditRef.current.multiple = true;
+              if (frameWriterBranches.size > 1) heroOverviewFragmentWriterAuditRef.current.multiple = true;
               if (idx === 0) console.log('[hero-overview-writer-audit] fragment writer', {
                 frameId, runtimePhase: heroOverviewRuntime?.getSnapshot?.()?.phase ?? 'idle', fragmentVisualPhase: 'fractureCharge',
                 crystalForm: animationData?.crystalForm ?? null, writerBranch: 'fracturePauseLegacy', facetKey,
@@ -2001,13 +2017,25 @@ const UnifiedCrystalScene = forwardRef(({
               const frameId = Math.floor(state.clock.elapsedTime * 1000);
               const frameWriters = heroOverviewFragmentWriterAuditRef.current.frameWriters.get(frameId) || [];
               frameWriters.push('heroOverviewRuntimeTravel');
+              const frameWriterBranches = heroOverviewFragmentWriterAuditRef.current.frameWriterBranches.get(frameId) || new Set();
+              frameWriterBranches.add('heroOverviewRuntimeTravel');
+              const frameWriteCount = (heroOverviewFragmentWriterAuditRef.current.frameWriteCount.get(frameId) || 0) + 1;
               if (globalThis.__HERO_OVERVIEW_WRITER_AUDIT__?.active) {
-                globalThis.__HERO_OVERVIEW_WRITER_AUDIT__.fragmentWritersSeen.add('heroOverviewRuntimeTravel');
-                if (frameWriters.length > 1) globalThis.__HERO_OVERVIEW_WRITER_AUDIT__.multipleFragmentWritersSameFrame = true;
+                const writerAudit = globalThis.__HERO_OVERVIEW_WRITER_AUDIT__;
+                writerAudit.fragmentWritersSeen.add('heroOverviewRuntimeTravel');
+                writerAudit.fragmentWriterBranchesByFrame[frameId] = Array.from(frameWriterBranches);
+                writerAudit.fragmentWriteCountByFrame[frameId] = frameWriteCount;
+                writerAudit.maxDistinctFragmentWriterBranchesInFrame = Math.max(writerAudit.maxDistinctFragmentWriterBranchesInFrame || 0, frameWriterBranches.size);
+                if (frameWriterBranches.size > 1) {
+                  writerAudit.multipleFragmentWriterBranchesSameFrame = true;
+                  writerAudit.multipleFragmentWritersSameFrame = true;
+                }
               }
               heroOverviewFragmentWriterAuditRef.current.frameWriters.set(frameId, frameWriters);
+              heroOverviewFragmentWriterAuditRef.current.frameWriterBranches.set(frameId, frameWriterBranches);
+              heroOverviewFragmentWriterAuditRef.current.frameWriteCount.set(frameId, frameWriteCount);
               heroOverviewFragmentWriterAuditRef.current.writers.add('heroOverviewRuntimeTravel');
-              if (frameWriters.length > 1) heroOverviewFragmentWriterAuditRef.current.multiple = true;
+              if (frameWriterBranches.size > 1) heroOverviewFragmentWriterAuditRef.current.multiple = true;
               if (index === 0 && !heroOverviewFragmentPhaseLoggedRef.current.has(`audit-${fragmentVisualPhase}`)) {
                 heroOverviewFragmentPhaseLoggedRef.current.add(`audit-${fragmentVisualPhase}`);
                 console.log('[hero-overview-writer-audit] fragment writer', {
@@ -2389,11 +2417,15 @@ const UnifiedCrystalScene = forwardRef(({
             console.log('[hero-overview-writer-audit] transition writer summary', {
               fragmentWritersSeen: Array.from(s.fragmentWritersSeen || []),
               cameraWritersSeen: Array.from(s.cameraWritersSeen || []),
-              multipleFragmentWritersSameFrame: Boolean(s.multipleFragmentWritersSameFrame),
+              fragmentWriterBranchesByFrame: s.fragmentWriterBranchesByFrame || {},
+              maxDistinctFragmentWriterBranchesInFrame: Number(s.maxDistinctFragmentWriterBranchesInFrame || 0),
+              multipleFragmentWriterBranchesSameFrame: Boolean(s.multipleFragmentWriterBranchesSameFrame),
+              fragmentWriteCountByFrame: s.fragmentWriteCountByFrame || {},
+              multipleFragmentWritersSameFrame: Boolean(s.multipleFragmentWriterBranchesSameFrame ?? s.multipleFragmentWritersSameFrame),
               multipleCameraWritersSameFrame: Boolean(s.multipleCameraWritersSameFrame),
               legacyWriterAfterRuntimeWriter: Boolean(s.legacyWriterAfterRuntimeWriter),
               fallbackWriterAfterRuntimeWriter: Boolean(s.fallbackWriterAfterRuntimeWriter),
-              suspectedOverwrite: Boolean(s.legacyWriterAfterRuntimeWriter || s.fallbackWriterAfterRuntimeWriter || s.multipleFragmentWritersSameFrame || s.multipleCameraWritersSameFrame),
+              suspectedOverwrite: Boolean(s.legacyWriterAfterRuntimeWriter || s.fallbackWriterAfterRuntimeWriter || s.multipleFragmentWriterBranchesSameFrame || s.multipleCameraWritersSameFrame),
               suspectedBranches: [...Array.from(s.fragmentWritersSeen || []), ...Array.from(s.cameraWritersSeen || [])],
             });
             globalThis.__HERO_OVERVIEW_WRITER_AUDIT__.active = false;


### PR DESCRIPTION
### Motivation
- Prevent the legacy fracture-pause animation from blocking runtime-driven travel phases, and make writer-audit logging clearer when the legacy writer is skipped.

### Description
- Read a runtime snapshot via `heroOverviewRuntime?.getSnapshot?.()` and derive `runtimePhaseForLegacyWriter` and `runtimeTravelActive` flags.
- Require `!runtimeTravelActive` for the existing fracture-pause branch so runtime-controlled travel can proceed without being held by the legacy pause.
- Add a debug log path that reports when the legacy `fracturePauseLegacy` writer is skipped due to `runtimeTravelActive`, and reuse the snapshot-derived values in existing writer-audit logging.

### Testing
- Ran the repository test suite with `yarn test` and all tests passed. 
- Ran linting with `yarn lint` and there were no lint errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd0952a5f08328a51603a200e41dbb)