### PR TITLE
Add DEV-only camera write guard warning mode

### DIFF
--- a/docs/camera-suppression-matrix.md
+++ b/docs/camera-suppression-matrix.md
@@ -1,0 +1,18 @@
+# Camera Suppression Matrix (planning only)
+
+> Status: analysis-only. No suppression is implemented in runtime.
+
+This document captures observed writer conflicts from the DEV camera write guard and proposes future ownership/suppression decisions for a later PR.
+
+| known conflict pair | category affected | likely transition/flow | current risk | suggested future owner | writer likely to suppress later | writer that should remain authoritative later | notes |
+|---|---|---|---|---|---|---|---|
+| `AUTHORITATIVE_HERO <> heroOrbit` | position, orientation, filmOffset | plain hero orbit update lane | Medium (duplicate writes can hide ownership intent) | `AUTHORITATIVE_HERO` lane | `heroOrbit` alias/duplicate instrumentation lane | `AUTHORITATIVE_HERO` | Likely a naming overlap where both entries represent the same effective hero owner path. Resolve as ownership normalization, not behavior change. |
+| `FORCED_OVERVIEW_TO_HERO <> authoritativeOverviewToHero` | position, orientation, filmOffset, currentTarget | forced Overview → Hero authoritative transition | Medium (dual labels on same transition ownership) | `FORCED_OVERVIEW_TO_HERO` transition lane | `authoritativeOverviewToHero` duplicate lane label | `FORCED_OVERVIEW_TO_HERO` | Keep runtime as-is for now; future cleanup should unify writer identity for this path. |
+| `FORCED_HERO_TO_OVERVIEW <> authoritativeHeroToOverview` (expected potential) | position, orientation, filmOffset, currentTarget | forced Hero → Overview authoritative transition | Medium | `FORCED_HERO_TO_OVERVIEW` transition lane | `authoritativeHeroToOverview` duplicate lane label | `FORCED_HERO_TO_OVERVIEW` | Track in warning mode; suppress only after final owner map signoff. |
+| `about path writer <> fallback/currentTarget smoothing` (expected potential) | filmOffset, currentTarget, possibly position/orientation | About navigation and return/hand-off paths | High (known About bugs remain) | About-specific authoritative lane per flow | fallback smoother where it overlaps About authoritative writes | About authoritative writer per resolved owner map | Do not fix About behavior in this phase; document conflict surface only. |
+| `project/caseStudy writer <> fallback/currentTarget smoothing` (expected potential) | currentTarget, position/orientation | project focus / case study hand-offs | Medium | project/caseStudy authoritative writer | generic fallback smoother while project owner is active | project/caseStudy lane | Requires later suppression matrix rollout once guard data is stable over multiple sessions. |
+
+## Notes
+- This matrix is intentionally forward-looking and does **not** alter current runtime behavior.
+- Known bugs (Hero→Overview blip and About-path issues) remain out of scope in this phase.
+- Any future suppression PR should reference this matrix and the guard detail output before changing ownership.

--- a/docs/camera-suppression-matrix.md
+++ b/docs/camera-suppression-matrix.md
@@ -16,3 +16,8 @@ This document captures observed writer conflicts from the DEV camera write guard
 - This matrix is intentionally forward-looking and does **not** alter current runtime behavior.
 - Known bugs (Hero→Overview blip and About-path issues) remain out of scope in this phase.
 - Any future suppression PR should reference this matrix and the guard detail output before changing ownership.
+
+
+## Highest-priority clusters
+1. `AUTHORITATIVE_HERO <> heroOrbit`
+2. `FORCED_OVERVIEW_TO_HERO <> authoritativeOverviewToHero`

--- a/docs/camera-write-guard.md
+++ b/docs/camera-write-guard.md
@@ -69,3 +69,8 @@ This creates ownership visibility needed for a later suppression matrix rollout,
 - `transitionOrPhase`
 - `firstSeenAt`
 - `count`
+- `conflictId`
+- `firstSeenFrame`
+- `lastSeenFrame`
+
+If the renderer frame counter is unavailable, the guard uses a stable fallback key (`frame-seq-N`) so rows never show an undefined frame identifier.

--- a/docs/camera-write-guard.md
+++ b/docs/camera-write-guard.md
@@ -27,11 +27,13 @@ Bounded by design:
 - No mandatory per-frame spam.
 - One-time deduped conflict warnings per `writerPair + category + phase/reason` key when verbose mode is enabled.
 - Manual summary output.
+- Manual conflict detail output.
 
 ## Manual helpers
 Available in DEV:
 - `globalThis.__printCameraWriteGuardSummary()`
 - `globalThis.__clearCameraWriteGuardSummary()`
+- `globalThis.__printCameraWriteGuardConflictDetails()`
 - Optional verbose mode: `globalThis.__CAMERA_WRITE_GUARD_VERBOSE__ = true`
 
 ## Summary fields
@@ -49,3 +51,21 @@ Available in DEV:
 
 ## Why this exists
 This creates ownership visibility needed for a later suppression matrix rollout, without changing current camera execution behavior.
+
+
+## Conflict details table
+`__printCameraWriteGuardConflictDetails()` prints a compact `console.table` with:
+- `frameId`
+- `state`
+- `cameraState`
+- `viewMode`
+- `selectedProject`
+- `phase`
+- `category`
+- `writerA`
+- `writerB`
+- `writerAReason`
+- `writerBReason`
+- `transitionOrPhase`
+- `firstSeenAt`
+- `count`

--- a/docs/camera-write-guard.md
+++ b/docs/camera-write-guard.md
@@ -1,0 +1,51 @@
+# Camera Write Guard (DEV warning mode)
+
+This PR adds a **DEV-only** camera write guard that inventories camera write ownership and reports potential multi-writer conflicts.
+
+## Scope
+- Warning mode only.
+- No write suppression.
+- No runtime camera behavior changes.
+- No transition logic changes.
+
+## What it tracks
+Per frame, the guard records writer activity for these categories:
+- `position`
+- `lookAt/quaternion/rotation` (normalized as `orientation`)
+- `fov`
+- `filmOffset`
+- `currentTarget`
+
+## Conflict definition
+A conflict is recorded when, in the same frame, more than one distinct `writerId` writes the same category.
+
+## Instrumented lanes
+Primary instrumentation is attached at UnifiedCameraController writer boundaries (intro, hero orbit, authoritative transition lanes, fracture/transition lanes, fallback-like transition writes, and project/about branches where logged).
+
+## Console behavior
+Bounded by design:
+- No mandatory per-frame spam.
+- One-time deduped conflict warnings per `writerPair + category + phase/reason` key when verbose mode is enabled.
+- Manual summary output.
+
+## Manual helpers
+Available in DEV:
+- `globalThis.__printCameraWriteGuardSummary()`
+- `globalThis.__clearCameraWriteGuardSummary()`
+- Optional verbose mode: `globalThis.__CAMERA_WRITE_GUARD_VERBOSE__ = true`
+
+## Summary fields
+`__printCameraWriteGuardSummary()` includes:
+- `totalFramesObserved`
+- `totalWritesRecorded`
+- `conflictCount`
+- `conflictCategories`
+- `conflictPairs`
+- `conflictsByState`
+- `conflictsByCameraState`
+- `conflictsByTransitionOrPhase`
+- `topWriterIds`
+- `highRiskFlowsObserved`
+
+## Why this exists
+This creates ownership visibility needed for a later suppression matrix rollout, without changing current camera execution behavior.

--- a/src/camera/cameraWriteGuard.js
+++ b/src/camera/cameraWriteGuard.js
@@ -2,93 +2,175 @@ const DEV = typeof import.meta !== 'undefined' ? Boolean(import.meta.env?.DEV) :
 
 const CATEGORIES = ['position', 'orientation', 'fov', 'filmOffset', 'currentTarget'];
 
-const state = DEV
-  ? {
-      activeFrame: null,
-      totalFramesObserved: 0,
-      totalWritesRecorded: 0,
-      conflictCount: 0,
-      conflictCategories: {},
-      conflictPairs: {},
-      conflictsByState: {},
-      conflictsByCameraState: {},
-      conflictsByTransitionOrPhase: {},
-      topWriterIds: {},
-      highRiskFlowsObserved: {},
-      warned: new Set(),
-    }
-  : null;
+const buildInitialState = () => ({
+  activeFrame: null,
+  totalFramesObserved: 0,
+  totalWritesRecorded: 0,
+  conflictCount: 0,
+  conflictCategories: {},
+  conflictPairs: {},
+  conflictsByState: {},
+  conflictsByCameraState: {},
+  conflictsByTransitionOrPhase: {},
+  topWriterIds: {},
+  highRiskFlowsObserved: {},
+  conflictDetails: new Map(),
+  warned: new Set(),
+});
+
+const state = DEV ? buildInitialState() : null;
 
 const noop = () => {};
-const bump = (obj, key) => { obj[key] = (obj[key] || 0) + 1; };
-const normalizeWrites = (writes = []) => writes.includes('lookAt') || writes.includes('quaternion') || writes.includes('rotation') ? [...new Set([...writes.filter((w) => !['lookAt','quaternion','rotation'].includes(w)), 'orientation'])] : writes;
+const bump = (obj, key) => {
+  obj[key] = (obj[key] || 0) + 1;
+};
 
-export const beginCameraFrame = DEV ? (frameId, context = {}) => {
-  if (state.activeFrame) endCameraFrame(state.activeFrame.frameId);
-  state.activeFrame = { frameId, context, writesByCategory: new Map() };
-  state.totalFramesObserved += 1;
-} : noop;
+const normalizeWrites = (writes = []) => {
+  const includesOrientationWrite =
+    writes.includes('lookAt') || writes.includes('quaternion') || writes.includes('rotation');
 
-export const recordCameraWrite = DEV ? ({ writerId, writes = [], phase, state: animState, cameraState, reason }) => {
-  if (!state.activeFrame) return;
-  state.totalWritesRecorded += 1;
-  bump(state.topWriterIds, writerId || 'unknown');
-  const categories = normalizeWrites(writes);
-  categories.forEach((category) => {
-    if (!CATEGORIES.includes(category)) return;
-    const categorySet = state.activeFrame.writesByCategory.get(category) || new Set();
-    categorySet.add(writerId || 'unknown');
-    state.activeFrame.writesByCategory.set(category, categorySet);
-    if (categorySet.size > 1) {
-      const writers = [...categorySet].sort();
-      const pair = `${writers[0]} <> ${writers[1]}`;
-      const transitionKey = phase || reason || 'unknown';
-      const dedupeKey = `${pair}|${category}|${transitionKey}`;
-      if (!state.warned.has(dedupeKey)) {
-        state.warned.add(dedupeKey);
-        state.conflictCount += 1;
-        bump(state.conflictCategories, category);
-        bump(state.conflictPairs, `${pair}|${category}`);
-        bump(state.conflictsByState, animState || 'unknown');
-        bump(state.conflictsByCameraState, cameraState || 'unknown');
-        bump(state.conflictsByTransitionOrPhase, transitionKey);
-        bump(state.highRiskFlowsObserved, `${transitionKey}:${category}`);
-        if (globalThis.__CAMERA_WRITE_GUARD_VERBOSE__) {
-          console.warn('[CAMERA_WRITE_GUARD] conflict', { pair, category, transitionKey, animState, cameraState });
-        }
-      }
+  if (!includesOrientationWrite) return writes;
+
+  return [
+    ...new Set([...writes.filter((w) => !['lookAt', 'quaternion', 'rotation'].includes(w)), 'orientation']),
+  ];
+};
+
+const toSummaryConflictDetails = () => {
+  const details = [...state.conflictDetails.values()]
+    .map((row) => ({ ...row }))
+    .sort((a, b) => b.count - a.count || a.firstSeenAt - b.firstSeenAt);
+  return details;
+};
+
+export const beginCameraFrame = DEV
+  ? (frameId, context = {}) => {
+      if (state.activeFrame) endCameraFrame(state.activeFrame.frameId);
+      state.activeFrame = { frameId, context, writesByCategory: new Map() };
+      state.totalFramesObserved += 1;
     }
-  });
-} : noop;
+  : noop;
 
-export const endCameraFrame = DEV ? (frameId) => {
-  if (!state.activeFrame) return;
-  if (frameId !== undefined && state.activeFrame.frameId !== frameId) return;
-  state.activeFrame = null;
-} : noop;
+export const recordCameraWrite = DEV
+  ? ({ writerId, writes = [], phase, state: animState, cameraState, reason, viewMode, selectedProject }) => {
+      if (!state.activeFrame) return;
+      const normalizedWriterId = writerId || 'unknown';
+      const normalizedReason = reason || 'unknown';
+      const transitionKey = phase || normalizedReason || 'unknown';
 
-export const getCameraWriteGuardSummary = DEV ? () => ({
-  totalFramesObserved: state.totalFramesObserved,
-  totalWritesRecorded: state.totalWritesRecorded,
-  conflictCount: state.conflictCount,
-  conflictCategories: { ...state.conflictCategories },
-  conflictPairs: { ...state.conflictPairs },
-  conflictsByState: { ...state.conflictsByState },
-  conflictsByCameraState: { ...state.conflictsByCameraState },
-  conflictsByTransitionOrPhase: { ...state.conflictsByTransitionOrPhase },
-  topWriterIds: { ...state.topWriterIds },
-  highRiskFlowsObserved: { ...state.highRiskFlowsObserved },
-}) : () => ({ devOnly: true });
+      state.totalWritesRecorded += 1;
+      bump(state.topWriterIds, normalizedWriterId);
 
-export const printCameraWriteGuardSummary = DEV ? () => {
-  console.log('[CAMERA_WRITE_GUARD] summary', getCameraWriteGuardSummary());
-} : noop;
+      const categories = normalizeWrites(writes);
+      categories.forEach((category) => {
+        if (!CATEGORIES.includes(category)) return;
 
-export const clearCameraWriteGuardSummary = DEV ? () => {
-  Object.assign(state, { activeFrame: null, totalFramesObserved: 0, totalWritesRecorded: 0, conflictCount: 0, conflictCategories: {}, conflictPairs: {}, conflictsByState: {}, conflictsByCameraState: {}, conflictsByTransitionOrPhase: {}, topWriterIds: {}, highRiskFlowsObserved: {}, warned: new Set() });
-} : noop;
+        const categoryMap = state.activeFrame.writesByCategory.get(category) || new Map();
+        categoryMap.set(normalizedWriterId, normalizedReason);
+        state.activeFrame.writesByCategory.set(category, categoryMap);
+
+        if (categoryMap.size > 1) {
+          const sortedWriters = [...categoryMap.keys()].sort();
+          const writerA = sortedWriters[0];
+          const writerB = sortedWriters[1];
+          const pair = `${writerA} <> ${writerB}`;
+          const dedupeKey = `${pair}|${category}|${transitionKey}`;
+          const detailKey = `${dedupeKey}|${animState || 'unknown'}|${cameraState || 'unknown'}|${viewMode || 'unknown'}|${selectedProject || 'none'}`;
+
+          if (!state.warned.has(dedupeKey)) {
+            state.warned.add(dedupeKey);
+            state.conflictCount += 1;
+            bump(state.conflictCategories, category);
+            bump(state.conflictPairs, `${pair}|${category}`);
+            bump(state.conflictsByState, animState || 'unknown');
+            bump(state.conflictsByCameraState, cameraState || 'unknown');
+            bump(state.conflictsByTransitionOrPhase, transitionKey);
+            bump(state.highRiskFlowsObserved, `${transitionKey}:${category}`);
+            if (globalThis.__CAMERA_WRITE_GUARD_VERBOSE__) {
+              console.warn('[CAMERA_WRITE_GUARD] conflict', {
+                pair,
+                category,
+                transitionKey,
+                animState,
+                cameraState,
+              });
+            }
+          }
+
+          const existingDetail = state.conflictDetails.get(detailKey);
+          if (existingDetail) {
+            existingDetail.count += 1;
+          } else {
+            state.conflictDetails.set(detailKey, {
+              frameId: state.activeFrame.frameId,
+              state: animState || 'unknown',
+              cameraState: cameraState || 'unknown',
+              viewMode: viewMode || 'unknown',
+              selectedProject: selectedProject || 'none',
+              phase: phase || 'unknown',
+              category,
+              writerA,
+              writerB,
+              writerAReason: categoryMap.get(writerA) || 'unknown',
+              writerBReason: categoryMap.get(writerB) || 'unknown',
+              transitionOrPhase: transitionKey,
+              firstSeenAt: state.totalFramesObserved,
+              count: 1,
+            });
+          }
+        }
+      });
+    }
+  : noop;
+
+export const endCameraFrame = DEV
+  ? (frameId) => {
+      if (!state.activeFrame) return;
+      if (frameId !== undefined && state.activeFrame.frameId !== frameId) return;
+      state.activeFrame = null;
+    }
+  : noop;
+
+export const getCameraWriteGuardSummary = DEV
+  ? () => ({
+      totalFramesObserved: state.totalFramesObserved,
+      totalWritesRecorded: state.totalWritesRecorded,
+      conflictCount: state.conflictCount,
+      conflictCategories: { ...state.conflictCategories },
+      conflictPairs: { ...state.conflictPairs },
+      conflictsByState: { ...state.conflictsByState },
+      conflictsByCameraState: { ...state.conflictsByCameraState },
+      conflictsByTransitionOrPhase: { ...state.conflictsByTransitionOrPhase },
+      topWriterIds: { ...state.topWriterIds },
+      highRiskFlowsObserved: { ...state.highRiskFlowsObserved },
+    })
+  : () => ({ devOnly: true });
+
+export const printCameraWriteGuardSummary = DEV
+  ? () => {
+      console.log('[CAMERA_WRITE_GUARD] summary', getCameraWriteGuardSummary());
+    }
+  : noop;
+
+export const printCameraWriteGuardConflictDetails = DEV
+  ? () => {
+      const details = toSummaryConflictDetails();
+      if (!details.length) {
+        console.log('[CAMERA_WRITE_GUARD] conflict details: none recorded');
+        return;
+      }
+      console.table(details);
+    }
+  : noop;
+
+export const clearCameraWriteGuardSummary = DEV
+  ? () => {
+      Object.assign(state, buildInitialState());
+    }
+  : noop;
 
 if (DEV) {
   globalThis.__printCameraWriteGuardSummary = printCameraWriteGuardSummary;
+  globalThis.__printCameraWriteGuardConflictDetails = printCameraWriteGuardConflictDetails;
   globalThis.__clearCameraWriteGuardSummary = clearCameraWriteGuardSummary;
 }

--- a/src/camera/cameraWriteGuard.js
+++ b/src/camera/cameraWriteGuard.js
@@ -1,0 +1,94 @@
+const DEV = typeof import.meta !== 'undefined' ? Boolean(import.meta.env?.DEV) : false;
+
+const CATEGORIES = ['position', 'orientation', 'fov', 'filmOffset', 'currentTarget'];
+
+const state = DEV
+  ? {
+      activeFrame: null,
+      totalFramesObserved: 0,
+      totalWritesRecorded: 0,
+      conflictCount: 0,
+      conflictCategories: {},
+      conflictPairs: {},
+      conflictsByState: {},
+      conflictsByCameraState: {},
+      conflictsByTransitionOrPhase: {},
+      topWriterIds: {},
+      highRiskFlowsObserved: {},
+      warned: new Set(),
+    }
+  : null;
+
+const noop = () => {};
+const bump = (obj, key) => { obj[key] = (obj[key] || 0) + 1; };
+const normalizeWrites = (writes = []) => writes.includes('lookAt') || writes.includes('quaternion') || writes.includes('rotation') ? [...new Set([...writes.filter((w) => !['lookAt','quaternion','rotation'].includes(w)), 'orientation'])] : writes;
+
+export const beginCameraFrame = DEV ? (frameId, context = {}) => {
+  if (state.activeFrame) endCameraFrame(state.activeFrame.frameId);
+  state.activeFrame = { frameId, context, writesByCategory: new Map() };
+  state.totalFramesObserved += 1;
+} : noop;
+
+export const recordCameraWrite = DEV ? ({ writerId, writes = [], phase, state: animState, cameraState, reason }) => {
+  if (!state.activeFrame) return;
+  state.totalWritesRecorded += 1;
+  bump(state.topWriterIds, writerId || 'unknown');
+  const categories = normalizeWrites(writes);
+  categories.forEach((category) => {
+    if (!CATEGORIES.includes(category)) return;
+    const categorySet = state.activeFrame.writesByCategory.get(category) || new Set();
+    categorySet.add(writerId || 'unknown');
+    state.activeFrame.writesByCategory.set(category, categorySet);
+    if (categorySet.size > 1) {
+      const writers = [...categorySet].sort();
+      const pair = `${writers[0]} <> ${writers[1]}`;
+      const transitionKey = phase || reason || 'unknown';
+      const dedupeKey = `${pair}|${category}|${transitionKey}`;
+      if (!state.warned.has(dedupeKey)) {
+        state.warned.add(dedupeKey);
+        state.conflictCount += 1;
+        bump(state.conflictCategories, category);
+        bump(state.conflictPairs, `${pair}|${category}`);
+        bump(state.conflictsByState, animState || 'unknown');
+        bump(state.conflictsByCameraState, cameraState || 'unknown');
+        bump(state.conflictsByTransitionOrPhase, transitionKey);
+        bump(state.highRiskFlowsObserved, `${transitionKey}:${category}`);
+        if (globalThis.__CAMERA_WRITE_GUARD_VERBOSE__) {
+          console.warn('[CAMERA_WRITE_GUARD] conflict', { pair, category, transitionKey, animState, cameraState });
+        }
+      }
+    }
+  });
+} : noop;
+
+export const endCameraFrame = DEV ? (frameId) => {
+  if (!state.activeFrame) return;
+  if (frameId !== undefined && state.activeFrame.frameId !== frameId) return;
+  state.activeFrame = null;
+} : noop;
+
+export const getCameraWriteGuardSummary = DEV ? () => ({
+  totalFramesObserved: state.totalFramesObserved,
+  totalWritesRecorded: state.totalWritesRecorded,
+  conflictCount: state.conflictCount,
+  conflictCategories: { ...state.conflictCategories },
+  conflictPairs: { ...state.conflictPairs },
+  conflictsByState: { ...state.conflictsByState },
+  conflictsByCameraState: { ...state.conflictsByCameraState },
+  conflictsByTransitionOrPhase: { ...state.conflictsByTransitionOrPhase },
+  topWriterIds: { ...state.topWriterIds },
+  highRiskFlowsObserved: { ...state.highRiskFlowsObserved },
+}) : () => ({ devOnly: true });
+
+export const printCameraWriteGuardSummary = DEV ? () => {
+  console.log('[CAMERA_WRITE_GUARD] summary', getCameraWriteGuardSummary());
+} : noop;
+
+export const clearCameraWriteGuardSummary = DEV ? () => {
+  Object.assign(state, { activeFrame: null, totalFramesObserved: 0, totalWritesRecorded: 0, conflictCount: 0, conflictCategories: {}, conflictPairs: {}, conflictsByState: {}, conflictsByCameraState: {}, conflictsByTransitionOrPhase: {}, topWriterIds: {}, highRiskFlowsObserved: {}, warned: new Set() });
+} : noop;
+
+if (DEV) {
+  globalThis.__printCameraWriteGuardSummary = printCameraWriteGuardSummary;
+  globalThis.__clearCameraWriteGuardSummary = clearCameraWriteGuardSummary;
+}

--- a/src/camera/cameraWriteGuard.js
+++ b/src/camera/cameraWriteGuard.js
@@ -15,6 +15,8 @@ const buildInitialState = () => ({
   topWriterIds: {},
   highRiskFlowsObserved: {},
   conflictDetails: new Map(),
+  nextConflictId: 1,
+  frameSequence: 0,
   warned: new Set(),
 });
 
@@ -46,8 +48,16 @@ const toSummaryConflictDetails = () => {
 export const beginCameraFrame = DEV
   ? (frameId, context = {}) => {
       if (state.activeFrame) endCameraFrame(state.activeFrame.frameId);
-      state.activeFrame = { frameId, context, writesByCategory: new Map() };
       state.totalFramesObserved += 1;
+      state.frameSequence += 1;
+      const resolvedFrameId = frameId ?? `frame-seq-${state.frameSequence}`;
+      state.activeFrame = {
+        frameId: resolvedFrameId,
+        rawFrameId: frameId ?? null,
+        frameSequence: state.frameSequence,
+        context,
+        writesByCategory: new Map(),
+      };
     }
   : noop;
 
@@ -100,8 +110,10 @@ export const recordCameraWrite = DEV
           const existingDetail = state.conflictDetails.get(detailKey);
           if (existingDetail) {
             existingDetail.count += 1;
+            existingDetail.lastSeenFrame = state.activeFrame.frameId;
           } else {
             state.conflictDetails.set(detailKey, {
+              conflictId: state.nextConflictId++,
               frameId: state.activeFrame.frameId,
               state: animState || 'unknown',
               cameraState: cameraState || 'unknown',
@@ -115,6 +127,8 @@ export const recordCameraWrite = DEV
               writerBReason: categoryMap.get(writerB) || 'unknown',
               transitionOrPhase: transitionKey,
               firstSeenAt: state.totalFramesObserved,
+              firstSeenFrame: state.activeFrame.frameId,
+              lastSeenFrame: state.activeFrame.frameId,
               count: 1,
             });
           }

--- a/src/components/three/UnifiedCameraController.jsx
+++ b/src/components/three/UnifiedCameraController.jsx
@@ -6,6 +6,7 @@ import { useThree, useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
 import { facetKeys as canonicalFacetKeys, getSceneFacetKeyByProjectId } from '../../data/projects';
 import { createLogger } from '../../utils/logger';
+import { beginCameraFrame, recordCameraWrite } from '../../camera/cameraWriteGuard';
 
 const logger = createLogger('unified-camera-controller');
 
@@ -1406,7 +1407,32 @@ const UnifiedCameraController = ({
   ]);
 
 
+  const guardRecord = (writerId, writes, phase, reason) => {
+    recordCameraWrite({
+      writerId,
+      ownerGroup: 'UnifiedCameraController',
+      writes,
+      phase,
+      reason,
+      state: animationData?.state ?? null,
+      cameraState: animationData?.cameraState ?? null,
+      viewMode: animationData?.state ?? null,
+      selectedProject: animationData?.focusedProject ?? null,
+    });
+  };
+
   const logCameraWrite = (state, branch, reason, lookAtTarget = null, projectionUpdated = false, returns = false) => {
+    const writesByBranch = {
+      AUTHORITATIVE_HERO: ["position", "lookAt", "filmOffset"],
+      FORCED_HERO_TO_OVERVIEW: ["position", "lookAt", "filmOffset", "currentTarget"],
+      FORCED_OVERVIEW_TO_HERO: ["position", "lookAt", "filmOffset", "currentTarget"],
+      TRANSITION: ["position", "lookAt", "filmOffset", "currentTarget"],
+      INTRO: ["position", "lookAt", "fov", "currentTarget"],
+      PROJECT: ["position", "lookAt", "fov", "filmOffset", "currentTarget"],
+      ABOUT: ["position", "lookAt", "fov", "filmOffset", "currentTarget"],
+      FALLBACK: ["position", "lookAt", "fov", "currentTarget"],
+    };
+    guardRecord(branch, writesByBranch[branch] || ["position", "lookAt"], animationData?.cameraState || animationData?.state || "unknown", reason);
     const forcedHeroToOverviewActive = authoritativeHeroToOverviewTransitionRef.current.active;
     const forcedOverviewToHeroActive = authoritativeOverviewToHeroTransitionRef.current.active;
     if ((forcedHeroToOverviewActive || forcedOverviewToHeroActive) &&
@@ -1519,6 +1545,7 @@ const UnifiedCameraController = ({
 
   useFrame((state, delta) => {
     syncFractureTiltState(state.clock.elapsedTime);
+    beginCameraFrame(state.clock.frame, { elapsed: state.clock.elapsedTime, phase: animationData?.cameraState ?? null });
 
     const debugSecond = Math.floor(state.clock.elapsedTime);
 
@@ -1875,6 +1902,7 @@ const UnifiedCameraController = ({
       camera.lookAt(forcedLookAt);
       camera.filmOffset = THREE.MathUtils.lerp(transition.from.filmOffsetX, transition.to.filmOffsetX, filmOffsetProgress);
       camera.updateProjectionMatrix();
+      guardRecord("authoritativeOverviewToHero", ["position", "lookAt", "filmOffset", "currentTarget"], "overview->hero", "forced-overview-to-hero-frame");
       logCameraWrite(state, "FORCED_OVERVIEW_TO_HERO", "forced-overview-to-hero-frame", forcedLookAt, true, true);
       if (!transition.divergenceWarned && Math.abs(accumulatedProgress - elapsedProgress) > 0.05) {
         transition.divergenceWarned = true;
@@ -1965,6 +1993,7 @@ const UnifiedCameraController = ({
       camera.lookAt(introLookAt);
       camera.filmOffset = destination.filmOffsetX;
       camera.updateProjectionMatrix();
+      guardRecord("introPlayback", ["position", "lookAt", "filmOffset", "fov", "currentTarget"], "intro", "intro-playback");
 
       const completedThisFrame = progress >= 1;
       if (completedThisFrame) {
@@ -2005,6 +2034,7 @@ const UnifiedCameraController = ({
         tuning: { ...tuning },
         center: center.clone(),
       };
+      guardRecord("heroOrbit", ["position", "lookAt", "filmOffset"], "hero", "authoritative-hero-update");
       logCameraWrite(state, "AUTHORITATIVE_HERO", "authoritative-hero-update", snapshot.lookAtTarget, true, true);
       if (shouldLogBranch) {
         console.log('[UCC AUTHORITATIVE HERO]', {
@@ -2053,6 +2083,7 @@ const UnifiedCameraController = ({
         camera.lookAt(forcedLookAt);
         camera.filmOffset = transition.from.filmOffsetX;
         camera.updateProjectionMatrix();
+        guardRecord("authoritativeHeroToOverview", ["position", "lookAt", "filmOffset", "currentTarget"], "hero->overview", "forced-hero-to-overview-frame");
         if (shouldLogBranch) {
           console.log('[UCC HERO TO OVERVIEW CAMERA LOCK TEST]', {
             progress: round4(accumulatedProgress),


### PR DESCRIPTION
### Motivation
- Provide DEV-only instrumentation to surface camera writer ownership and multi-writer conflicts without modifying runtime or transition behavior. 
- Give maintainers a bounded, deduped summary and manual helpers to inform a later suppression matrix while preserving known bugs and behavior.

### Description
- Add `src/camera/cameraWriteGuard.js` which exports `beginCameraFrame`, `recordCameraWrite`, `endCameraFrame`, `getCameraWriteGuardSummary`, `printCameraWriteGuardSummary`, and `clearCameraWriteGuardSummary`, and is a no-op in production builds. 
- Instrument `UnifiedCameraController` to `beginCameraFrame` each frame and call a small `guardRecord` helper at known writer boundaries (intro playback, authoritative hero orbit, authoritative hero→overview and overview→hero forced transitions, and fracture/transition branches) without changing writer order, early returns, or suppression. 
- Track the categories `position`, normalized `orientation` (from `lookAt`/`quaternion`/`rotation`), `fov`, `filmOffset`, and `currentTarget`, and record deduped conflict counts per writer-pair/category/phase with optional verbose warnings via `globalThis.__CAMERA_WRITE_GUARD_VERBOSE__`. 
- Add `docs/camera-write-guard.md` documenting what is tracked, how to enable verbose mode, how to print/clear summaries, and an explicit statement that this is warning-only.

### Testing
- Ran `npm run build` and the Vite production build completed successfully. 
- No automated unit tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0dc279824c8328b4e794af0a7c00ec)