### PR TITLE
Add DEV-only shadow instrumentation for Overview→Project camera timing/composition

### DIFF
--- a/docs/camera-overview-project-shadow-instrumentation.md
+++ b/docs/camera-overview-project-shadow-instrumentation.md
@@ -1,0 +1,55 @@
+# Camera Overview → Project Shadow Instrumentation (PR-9)
+
+## Scope
+This instrumentation is **DEV-only, shadow-only, and read-only**. It observes existing Overview → Project behavior and does not drive camera movement, suppress writers, or enable CameraDirector pilot behavior.
+
+## What is sampled
+During Overview → Project transitions, samples capture:
+- Timing/state: `cameraMoveProgress`, `state`, `cameraState`, `viewMode`, `focusedProject`, `selectedProject` (if present), frame number, and frame delta.
+- Transition lifecycle: inferred start, inferred completion, approximate duration in seconds and frames.
+- Composition/live camera: live camera position, derived live lookAt (forward vector), `fov`, and `filmOffset`.
+- Current target: `currentTarget.position`, `currentTarget.lookAt`, `currentTarget.fov`.
+- Resolved destinations: resolved overview pose and resolved project pose via `resolveCameraDestination` when available.
+- Delta checks:
+  - Live vs resolved overview deltas at transition start.
+  - Live vs resolved project deltas at completion.
+  - Per-sample live vs resolved project positional/look deltas.
+- Facet coupling snapshot (if available from scene): focused facet key/project id, focus rotation progress, approximate facet rotation progress, and cameraMoveProgress.
+
+## Manual helper commands
+In DEV console:
+- `globalThis.__printOverviewProjectTimingSummary()`
+  - Prints current/last transition summary including start/completion and duration.
+- `globalThis.__printOverviewProjectTimingSamples()`
+  - Prints bounded sample buffer.
+- `globalThis.__clearOverviewProjectTimingSamples()`
+  - Clears buffered samples.
+
+## Bounded diagnostics behavior
+- Default behavior is silent except explicit helper calls.
+- Samples are bounded (ring-style truncation) to avoid console flooding.
+
+## How to test
+1. Run app in DEV.
+2. Navigate to overview.
+3. Select a project to trigger overview → project.
+4. Wait for camera settle.
+5. Call helper commands above and capture outputs.
+6. Repeat across several projects/devices/layouts for parity evidence.
+
+## Values needed before retrying pilot
+Collect and compare:
+- Start contamination deltas (live vs resolved overview).
+- Completion deltas (live vs resolved project).
+- Real transition duration distribution (frames + seconds).
+- `cameraMoveProgress` curve shape over time.
+- Whether facet rotation progression tracks `cameraMoveProgress` and whether camera settles before facet progression completes.
+
+## Explicit non-goals
+This PR does **not**:
+- Change runtime camera behavior.
+- Change camera writes or writer ownership.
+- Enable CameraDirector pilot.
+- Migrate/suppress any camera paths.
+- Touch Hero ↔ Overview behavior or About bugs.
+- Tune fragments/particles/glow/ring/project facet behavior.

--- a/src/components/three/UnifiedCameraController.jsx
+++ b/src/components/three/UnifiedCameraController.jsx
@@ -1573,6 +1573,11 @@ const UnifiedCameraController = ({
   const quaternionToPlain = (q) => ({ x: round4(q?.x), y: round4(q?.y), z: round4(q?.z), w: round4(q?.w) });
   const safeDistance = (a, b) => (a && b ? round4(a.distanceTo(b)) : null);
   const quaternionAngleDelta = (q1, q2) => (q1 && q2 ? round4(q1.angleTo(q2)) : null);
+  const getCameraLookAtFromTransform = (distance = 10) => {
+    const forward = new THREE.Vector3();
+    camera.getWorldDirection(forward);
+    return camera.position.clone().addScaledVector(forward, distance);
+  };
   const getOverviewProjectResolvedPose = (destination, projectId = null) => {
     const resolved = resolveCameraDestination({ destination, projectId, mode: 'selected', config, animationData, isMobile });
     if (!resolved || resolved?.meta?.unresolved) return null;
@@ -1613,8 +1618,20 @@ const UnifiedCameraController = ({
     globalThis.__overviewProjectShadowHelpersInstalled = true;
   };
 
-  const sampleOverviewProjectShadow = ({ state, delta, transitionActive, transitionKey, focusedProject, settled }) => {
+  const sampleOverviewProjectShadow = ({ state, delta, transitionActive, transitionKey, focusedProject, settled, prevCameraState, nextCameraState, nextState, viewMode }) => {
     if (!import.meta.env.DEV) return;
+    const isFreshOverviewToProject =
+      prevCameraState === 'overview' &&
+      nextCameraState === 'project' &&
+      Boolean(focusedProject) &&
+      viewMode !== 'caseStudy';
+    const isActiveObservedOverviewToProject =
+      overviewProjectShadowRef.current.active &&
+      nextCameraState === 'project' &&
+      nextState !== 'about' &&
+      viewMode !== 'caseStudy';
+    if (!isFreshOverviewToProject && !isActiveObservedOverviewToProject) return;
+
     installOverviewProjectShadowHelpers();
     const shadow = overviewProjectShadowRef.current;
     const now = state.clock.elapsedTime;
@@ -3517,6 +3534,10 @@ const UnifiedCameraController = ({
       transitionKey,
       focusedProject: animationData?.focusedProject ?? null,
       settled: cameraSettledRef.current,
+      prevCameraState,
+      nextCameraState,
+      nextState,
+      viewMode: animationData?.viewMode ?? null,
     });
 
     // FIXED: Enhanced orbit initiation with additional delay and stricter conditions

--- a/src/components/three/UnifiedCameraController.jsx
+++ b/src/components/three/UnifiedCameraController.jsx
@@ -1674,6 +1674,7 @@ const UnifiedCameraController = ({
       const transitionElapsedSeconds = shadow.startedAt != null ? round4(now - shadow.startedAt) : null;
       shadow.samples.push({
         sampleType,
+        transitionId: shadow.transitionId ?? transitionKey,
         frameId: frame,
         elapsedSeconds: round4(now),
         transitionElapsedSeconds,
@@ -1693,8 +1694,6 @@ const UnifiedCameraController = ({
         currentTargetFilmOffset: null,
         deltaToResolvedProjectPosition: safeDistance(camera.position, resolvedProject?.position),
         deltaToResolvedProjectLookAt: safeDistance(liveLookAt, resolvedProject?.lookAt),
-        deltaToResolvedOverviewPosition: safeDistance(camera.position, resolvedOverview?.position),
-        deltaToResolvedOverviewLookAt: safeDistance(liveLookAt, resolvedOverview?.lookAt),
         facet: facetDebug,
       });
       if (shadow.samples.length > shadow.maxSamples) shadow.samples.shift();
@@ -1721,9 +1720,6 @@ const UnifiedCameraController = ({
       return;
     }
 
-    if (shadow.active) {
-      pushRow('active');
-    }
 
     if (shadow.active && settled && animationData?.cameraState === 'project') {
       shadow.completionSample = {

--- a/src/components/three/UnifiedCameraController.jsx
+++ b/src/components/three/UnifiedCameraController.jsx
@@ -1639,36 +1639,67 @@ const UnifiedCameraController = ({
 
   const sampleOverviewProjectShadow = ({ state, delta, transitionActive, transitionKey, focusedProject, settled, prevCameraState, nextCameraState, nextState, viewMode }) => {
     if (!import.meta.env.DEV) return;
+    const shadow = getOverviewProjectShadowStore();
     const isFreshOverviewToProject =
       prevCameraState === 'overview' &&
       nextCameraState === 'project' &&
       Boolean(focusedProject) &&
       viewMode !== 'caseStudy';
-    const isActiveObservedOverviewToProject =
-      getOverviewProjectShadowStore().active &&
+    const isProjectContext =
       nextCameraState === 'project' &&
       nextState !== 'about' &&
       viewMode !== 'caseStudy';
-    if (!isFreshOverviewToProject && !isActiveObservedOverviewToProject) {
-      getOverviewProjectShadowStore().lastSkipReason = {
+    const shouldObserve = isFreshOverviewToProject || (shadow.active && isProjectContext) || (transitionActive && isProjectContext);
+    if (!shouldObserve) {
+      shadow.lastSkipReason = {
         prevCameraState,
         nextCameraState,
         nextState,
         viewMode,
         focusedProject: focusedProject ?? null,
-        reason: "outside-overview-to-project",
+        reason: 'outside-overview-to-project',
       };
       return;
     }
 
     installOverviewProjectShadowHelpers();
-    const shadow = getOverviewProjectShadowStore();
     const now = state.clock.elapsedTime;
     const frame = state.clock.frame;
     const liveLookAt = getCameraLookAtFromTransform();
     const resolvedOverview = getOverviewProjectResolvedPose('overview');
     const resolvedProject = focusedProject ? getOverviewProjectResolvedPose('project', focusedProject) : null;
     const facetDebug = globalThis?.__overviewProjectFacetDebug ?? null;
+
+    const pushRow = (sampleType) => {
+      const transitionElapsedSeconds = shadow.startedAt != null ? round4(now - shadow.startedAt) : null;
+      shadow.samples.push({
+        sampleType,
+        frameId: frame,
+        elapsedSeconds: round4(now),
+        transitionElapsedSeconds,
+        deltaSeconds: round4(delta),
+        cameraMoveProgress: round4(cameraMoveProgressRef.current),
+        state: animationData?.state ?? null,
+        cameraState: animationData?.cameraState ?? null,
+        viewMode: animationData?.viewMode ?? null,
+        focusedProject: animationData?.focusedProject ?? null,
+        selectedProject: animationData?.selectedProject ?? null,
+        livePosition: vectorToPlain(camera.position),
+        liveLookAt: vectorToPlain(liveLookAt),
+        liveFov: round4(camera.fov),
+        liveFilmOffset: round4(camera.filmOffset),
+        currentTargetLookAt: vectorToPlain(currentTarget.current?.lookAt),
+        currentTargetFov: round4(currentTarget.current?.fov),
+        currentTargetFilmOffset: null,
+        deltaToResolvedProjectPosition: safeDistance(camera.position, resolvedProject?.position),
+        deltaToResolvedProjectLookAt: safeDistance(liveLookAt, resolvedProject?.lookAt),
+        deltaToResolvedOverviewPosition: safeDistance(camera.position, resolvedOverview?.position),
+        deltaToResolvedOverviewLookAt: safeDistance(liveLookAt, resolvedOverview?.lookAt),
+        facet: facetDebug,
+      });
+      if (shadow.samples.length > shadow.maxSamples) shadow.samples.shift();
+    };
+
     if (transitionActive && !shadow.active) {
       shadow.active = true;
       shadow.transitionId = transitionKey;
@@ -1686,33 +1717,25 @@ const UnifiedCameraController = ({
         deltaLiveToResolvedOverviewPosition: safeDistance(camera.position, resolvedOverview?.position),
         deltaLiveToResolvedOverviewLookAt: safeDistance(liveLookAt, resolvedOverview?.lookAt),
       };
+      pushRow('start');
+      return;
     }
+
     if (shadow.active) {
-      const progress = cameraMoveProgressRef.current;
-      shadow.samples.push({
-        t: round4(now), frame, delta: round4(delta), progress: round4(progress),
-        viewMode: animationData?.viewMode ?? null, state: animationData?.state ?? null, cameraState: animationData?.cameraState ?? null,
-        focusedProject: animationData?.focusedProject ?? null, selectedProject: animationData?.selectedProject ?? null,
-        transitionActive, cameraSettled: settled,
-        livePosition: vectorToPlain(camera.position), liveLookAt: vectorToPlain(liveLookAt), liveFov: round4(camera.fov), liveFilmOffset: round4(camera.filmOffset),
-        targetPosition: vectorToPlain(currentTarget.current?.position), targetLookAt: vectorToPlain(currentTarget.current?.lookAt), targetFov: round4(currentTarget.current?.fov),
-        resolvedOverviewPosition: vectorToPlain(resolvedOverview?.position), resolvedProjectPosition: vectorToPlain(resolvedProject?.position),
-        deltaToResolvedProjectPosition: safeDistance(camera.position, resolvedProject?.position),
-        deltaToResolvedProjectLookAt: safeDistance(liveLookAt, resolvedProject?.lookAt),
-        facet: facetDebug,
-      });
-      if (shadow.samples.length > shadow.maxSamples) shadow.samples.shift();
+      pushRow('active');
     }
+
     if (shadow.active && settled && animationData?.cameraState === 'project') {
-      shadow.active = false;
-      shadow.completedAt = now;
-      shadow.completedFrame = frame;
       shadow.completionSample = {
         livePosition: vectorToPlain(camera.position),
         liveLookAt: vectorToPlain(liveLookAt),
         deltaLiveToResolvedProjectPosition: safeDistance(camera.position, resolvedProject?.position),
         deltaLiveToResolvedProjectLookAt: safeDistance(liveLookAt, resolvedProject?.lookAt),
       };
+      pushRow('complete');
+      shadow.active = false;
+      shadow.completedAt = now;
+      shadow.completedFrame = frame;
     }
   };
 

--- a/src/components/three/UnifiedCameraController.jsx
+++ b/src/components/three/UnifiedCameraController.jsx
@@ -237,9 +237,10 @@ const UnifiedCameraController = ({
     startSample: null,
     completionSample: null,
     samples: [],
-    maxSamples: 240,
+    maxSamples: 120,
     printedStartForTransition: null,
     printedCompletionForTransition: null,
+    lastSkipReason: null,
   });
 
   const isOverviewToProjectPilotEnabled = () => {
@@ -1589,11 +1590,23 @@ const UnifiedCameraController = ({
     };
   };
 
+
+  const getOverviewProjectShadowStore = () => {
+    if (typeof globalThis === 'undefined') return overviewProjectShadowRef.current;
+    if (!globalThis.__overviewProjectShadowStore) {
+      globalThis.__overviewProjectShadowStore = overviewProjectShadowRef.current;
+    }
+    if (globalThis.__overviewProjectShadowStore !== overviewProjectShadowRef.current) {
+      globalThis.__overviewProjectShadowStore = overviewProjectShadowRef.current;
+    }
+    return globalThis.__overviewProjectShadowStore;
+  };
+
   const installOverviewProjectShadowHelpers = () => {
     if (!import.meta.env.DEV || typeof globalThis === 'undefined') return;
     if (globalThis.__overviewProjectShadowHelpersInstalled) return;
     globalThis.__printOverviewProjectTimingSummary = () => {
-      const shadow = overviewProjectShadowRef.current;
+      const shadow = getOverviewProjectShadowStore();
       console.log('[overview-project-shadow] summary', {
         active: shadow.active,
         transitionId: shadow.transitionId,
@@ -1606,13 +1619,19 @@ const UnifiedCameraController = ({
         sampleCount: shadow.samples.length,
         startSample: shadow.startSample,
         completionSample: shadow.completionSample,
+        lastSkipReason: shadow.lastSkipReason ?? null,
       });
     };
     globalThis.__printOverviewProjectTimingSamples = () => {
-      console.log('[overview-project-shadow] samples', overviewProjectShadowRef.current.samples);
+      const shadow = getOverviewProjectShadowStore();
+      if (!shadow.samples.length) {
+        console.log('[overview-project-shadow] samples', []);
+        return;
+      }
+      console.table(shadow.samples);
     };
     globalThis.__clearOverviewProjectTimingSamples = () => {
-      overviewProjectShadowRef.current.samples = [];
+      getOverviewProjectShadowStore().samples = []
       console.log('[overview-project-shadow] samples-cleared');
     };
     globalThis.__overviewProjectShadowHelpersInstalled = true;
@@ -1626,14 +1645,24 @@ const UnifiedCameraController = ({
       Boolean(focusedProject) &&
       viewMode !== 'caseStudy';
     const isActiveObservedOverviewToProject =
-      overviewProjectShadowRef.current.active &&
+      getOverviewProjectShadowStore().active &&
       nextCameraState === 'project' &&
       nextState !== 'about' &&
       viewMode !== 'caseStudy';
-    if (!isFreshOverviewToProject && !isActiveObservedOverviewToProject) return;
+    if (!isFreshOverviewToProject && !isActiveObservedOverviewToProject) {
+      getOverviewProjectShadowStore().lastSkipReason = {
+        prevCameraState,
+        nextCameraState,
+        nextState,
+        viewMode,
+        focusedProject: focusedProject ?? null,
+        reason: "outside-overview-to-project",
+      };
+      return;
+    }
 
     installOverviewProjectShadowHelpers();
-    const shadow = overviewProjectShadowRef.current;
+    const shadow = getOverviewProjectShadowStore();
     const now = state.clock.elapsedTime;
     const frame = state.clock.frame;
     const liveLookAt = getCameraLookAtFromTransform();

--- a/src/components/three/UnifiedCameraController.jsx
+++ b/src/components/three/UnifiedCameraController.jsx
@@ -227,6 +227,20 @@ const UnifiedCameraController = ({
   const lastOverviewToProjectKeyRef = useRef(null);
   const blockedOverviewToProjectKeyRef = useRef(null);
   const startPoseLogKeyRef = useRef(null);
+  const overviewProjectShadowRef = useRef({
+    active: false,
+    transitionId: null,
+    startedAt: null,
+    startedFrame: null,
+    completedAt: null,
+    completedFrame: null,
+    startSample: null,
+    completionSample: null,
+    samples: [],
+    maxSamples: 240,
+    printedStartForTransition: null,
+    printedCompletionForTransition: null,
+  });
 
   const isOverviewToProjectPilotEnabled = () => {
     // WARNING: Experimental pilot only; not production-ready.
@@ -1559,10 +1573,101 @@ const UnifiedCameraController = ({
   const quaternionToPlain = (q) => ({ x: round4(q?.x), y: round4(q?.y), z: round4(q?.z), w: round4(q?.w) });
   const safeDistance = (a, b) => (a && b ? round4(a.distanceTo(b)) : null);
   const quaternionAngleDelta = (q1, q2) => (q1 && q2 ? round4(q1.angleTo(q2)) : null);
-  const getCameraLookAtFromTransform = (distance = 10) => {
-    const forward = new THREE.Vector3();
-    camera.getWorldDirection(forward);
-    return camera.position.clone().addScaledVector(forward, distance);
+  const getOverviewProjectResolvedPose = (destination, projectId = null) => {
+    const resolved = resolveCameraDestination({ destination, projectId, mode: 'selected', config, animationData, isMobile });
+    if (!resolved || resolved?.meta?.unresolved) return null;
+    return {
+      position: new THREE.Vector3(...resolved.position),
+      lookAt: new THREE.Vector3(...resolved.lookAt),
+      fov: Number.isFinite(resolved.fov) ? resolved.fov : null,
+      filmOffset: Number.isFinite(resolved.filmOffset) ? resolved.filmOffset : 0,
+    };
+  };
+
+  const installOverviewProjectShadowHelpers = () => {
+    if (!import.meta.env.DEV || typeof globalThis === 'undefined') return;
+    if (globalThis.__overviewProjectShadowHelpersInstalled) return;
+    globalThis.__printOverviewProjectTimingSummary = () => {
+      const shadow = overviewProjectShadowRef.current;
+      console.log('[overview-project-shadow] summary', {
+        active: shadow.active,
+        transitionId: shadow.transitionId,
+        startedAt: shadow.startedAt,
+        completedAt: shadow.completedAt,
+        startedFrame: shadow.startedFrame,
+        completedFrame: shadow.completedFrame,
+        durationSecondsApprox: (shadow.startedAt != null && shadow.completedAt != null) ? round4(shadow.completedAt - shadow.startedAt) : null,
+        durationFramesApprox: (shadow.startedFrame != null && shadow.completedFrame != null) ? shadow.completedFrame - shadow.startedFrame : null,
+        sampleCount: shadow.samples.length,
+        startSample: shadow.startSample,
+        completionSample: shadow.completionSample,
+      });
+    };
+    globalThis.__printOverviewProjectTimingSamples = () => {
+      console.log('[overview-project-shadow] samples', overviewProjectShadowRef.current.samples);
+    };
+    globalThis.__clearOverviewProjectTimingSamples = () => {
+      overviewProjectShadowRef.current.samples = [];
+      console.log('[overview-project-shadow] samples-cleared');
+    };
+    globalThis.__overviewProjectShadowHelpersInstalled = true;
+  };
+
+  const sampleOverviewProjectShadow = ({ state, delta, transitionActive, transitionKey, focusedProject, settled }) => {
+    if (!import.meta.env.DEV) return;
+    installOverviewProjectShadowHelpers();
+    const shadow = overviewProjectShadowRef.current;
+    const now = state.clock.elapsedTime;
+    const frame = state.clock.frame;
+    const liveLookAt = getCameraLookAtFromTransform();
+    const resolvedOverview = getOverviewProjectResolvedPose('overview');
+    const resolvedProject = focusedProject ? getOverviewProjectResolvedPose('project', focusedProject) : null;
+    const facetDebug = globalThis?.__overviewProjectFacetDebug ?? null;
+    if (transitionActive && !shadow.active) {
+      shadow.active = true;
+      shadow.transitionId = transitionKey;
+      shadow.startedAt = now;
+      shadow.startedFrame = frame;
+      shadow.completedAt = null;
+      shadow.completedFrame = null;
+      shadow.startSample = {
+        livePosition: vectorToPlain(camera.position),
+        liveLookAt: vectorToPlain(liveLookAt),
+        liveFov: round4(camera.fov),
+        liveFilmOffset: round4(camera.filmOffset),
+        resolvedOverviewPosition: vectorToPlain(resolvedOverview?.position),
+        resolvedOverviewLookAt: vectorToPlain(resolvedOverview?.lookAt),
+        deltaLiveToResolvedOverviewPosition: safeDistance(camera.position, resolvedOverview?.position),
+        deltaLiveToResolvedOverviewLookAt: safeDistance(liveLookAt, resolvedOverview?.lookAt),
+      };
+    }
+    if (shadow.active) {
+      const progress = cameraMoveProgressRef.current;
+      shadow.samples.push({
+        t: round4(now), frame, delta: round4(delta), progress: round4(progress),
+        viewMode: animationData?.viewMode ?? null, state: animationData?.state ?? null, cameraState: animationData?.cameraState ?? null,
+        focusedProject: animationData?.focusedProject ?? null, selectedProject: animationData?.selectedProject ?? null,
+        transitionActive, cameraSettled: settled,
+        livePosition: vectorToPlain(camera.position), liveLookAt: vectorToPlain(liveLookAt), liveFov: round4(camera.fov), liveFilmOffset: round4(camera.filmOffset),
+        targetPosition: vectorToPlain(currentTarget.current?.position), targetLookAt: vectorToPlain(currentTarget.current?.lookAt), targetFov: round4(currentTarget.current?.fov),
+        resolvedOverviewPosition: vectorToPlain(resolvedOverview?.position), resolvedProjectPosition: vectorToPlain(resolvedProject?.position),
+        deltaToResolvedProjectPosition: safeDistance(camera.position, resolvedProject?.position),
+        deltaToResolvedProjectLookAt: safeDistance(liveLookAt, resolvedProject?.lookAt),
+        facet: facetDebug,
+      });
+      if (shadow.samples.length > shadow.maxSamples) shadow.samples.shift();
+    }
+    if (shadow.active && settled && animationData?.cameraState === 'project') {
+      shadow.active = false;
+      shadow.completedAt = now;
+      shadow.completedFrame = frame;
+      shadow.completionSample = {
+        livePosition: vectorToPlain(camera.position),
+        liveLookAt: vectorToPlain(liveLookAt),
+        deltaLiveToResolvedProjectPosition: safeDistance(camera.position, resolvedProject?.position),
+        deltaLiveToResolvedProjectLookAt: safeDistance(liveLookAt, resolvedProject?.lookAt),
+      };
+    }
   };
 
   useFrame((state, delta) => {
@@ -3404,6 +3509,15 @@ const UnifiedCameraController = ({
       settleFrameCount.current = 0;
       orbitInitDelayRef.current = 0; // ADDED: Reset orbit delay when not settled
     }
+
+    sampleOverviewProjectShadow({
+      state,
+      delta,
+      transitionActive: (cameFromOverview && enteredProject) || (animationData?.cameraState === 'project' && !cameraSettledRef.current),
+      transitionKey,
+      focusedProject: animationData?.focusedProject ?? null,
+      settled: cameraSettledRef.current,
+    });
 
     // FIXED: Enhanced orbit initiation with additional delay and stricter conditions
     if (

--- a/src/components/three/UnifiedCrystalScene.jsx
+++ b/src/components/three/UnifiedCrystalScene.jsx
@@ -453,6 +453,16 @@ const UnifiedCrystalScene = forwardRef(({
   }, [facetKeys]);
 
   const focusedSceneFacetKey = animationData?.focusedFacet || null;
+
+  useEffect(() => {
+    if (!import.meta.env.DEV || typeof globalThis === 'undefined') return undefined;
+    globalThis.__overviewProjectFacetDebug = globalThis.__overviewProjectFacetDebug || {};
+    return () => {
+      if (globalThis.__overviewProjectFacetDebug) {
+        delete globalThis.__overviewProjectFacetDebug;
+      }
+    };
+  }, []);
   const hideFacetMeshesDuringReformOverlap =
     animationData?.crystalForm === 'whole'
     && showWholeCrystal
@@ -2401,6 +2411,22 @@ const UnifiedCrystalScene = forwardRef(({
               ? caseStudyFocusQuat
               : (isProjectFocusedFacet ? projectFocusQuat : baseQuat))
           : neutralQuat;
+
+        if (import.meta.env.DEV && typeof globalThis !== 'undefined') {
+          const isFocusedFacet = isProjectFocusedFacet || isCaseStudyActiveProject;
+          if (isFocusedFacet) {
+            const facetProgress = 1 - Math.min(facetRef.current.quaternion.angleTo(targetQuat) / Math.PI, 1);
+            globalThis.__overviewProjectFacetDebug = {
+              projectId,
+              facetKey,
+              focusRotationProgress,
+              facetRotationProgressApprox: facetProgress,
+              cameraMoveProgress,
+              viewMode: animationData?.viewMode ?? null,
+              cameraState: animationData?.cameraState ?? null,
+            };
+          }
+        }
 
         if (isProjectFocusedFacet || isCaseStudyActiveProject) {
           facetRef.current.quaternion.slerp(targetQuat, focusedRotationLerp);


### PR DESCRIPTION
### Motivation
- Collect precise, observable measurements of the legacy Overview → Project transition timing and composition so a future CameraDirector pilot can consume matching choreography without guessing timings.
- Provide read-only, bounded diagnostics that observe cameraMoveProgress, resolved poses and facet coupling during transitions without changing runtime behavior or camera writes.

### Description
- Added DEV-only shadow sampler and bounded sample buffer in `UnifiedCameraController` to record inferred transition lifecycle, per-frame samples, start/completion snapshots, and live-vs-resolved deltas (file: `src/components/three/UnifiedCameraController.jsx`).
- Exposed lazy-installed manual helpers on `globalThis` to inspect/clear data: `__printOverviewProjectTimingSummary()`, `__printOverviewProjectTimingSamples()`, and `__clearOverviewProjectTimingSamples()` (file: `src/components/three/UnifiedCameraController.jsx`).
- Added DEV-only facet coupling debug snapshot output in `UnifiedCrystalScene` so samples can include focused facet/project id, focus rotation progress, and approximate facet rotation progress (file: `src/components/three/UnifiedCrystalScene.jsx`).
- Added documentation describing sampled fields, helper usage, test steps, and explicit shadow-only guarantees (file: `docs/camera-overview-project-shadow-instrumentation.md`).

### Testing
- Built the app with `npm run build` and the production build completed successfully (Vite warnings only), indicating the change compiles and bundles.
- No automated runtime behavioral tests were modified; the instrumentation is gated behind DEV checks and only exposes read-only helpers when enabled.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f51e9b51c832882b925d98926cc54)