### PR TITLE
DEV: Add overview→project timing shadow and timeline helper (PR-10)

### DIFF
--- a/docs/camera-overview-project-clock-audit.md
+++ b/docs/camera-overview-project-clock-audit.md
@@ -95,3 +95,37 @@ In other words, do not rely on `cameraMoveProgress` alone as the sole transition
 - `cameraMoveProgress` remains not suitable as the true transition-start clock.
 - Observed large FOV residuals against resolved-project FOV indicate a likely target mismatch suspicion path; resolver project FOV should not be treated as pilot-authoritative until parity is proven against legacy live/currentTarget behavior.
 - Current earliest captured row can still occur after state/cameraState flip from this hook location; future work needs an earlier upstream hook if strict pre-flip capture is required.
+
+## Latest observed run findings (post PR-10 instrumentation cleanup)
+
+### 1) Current hook limitation confirmed
+- In the captured overview → `project01` run, all rows had `isTruePreTransition: false`.
+- The first captured row was already `state: project_focused` and `cameraState: project` (with `viewMode: overview`), confirming this hook is downstream from the true selection request edge.
+- Therefore:
+  - `truePreTransitionCaptured` should be `false`
+  - `earliestCapturedAfterStateFlip` should be `true`
+- If strict pre-transition capture is required, an earlier upstream hook must be added at navigation/selection intent time (before project state flip).
+
+### 2) Project FOV parity issue confirmed
+- Observed values:
+  - `resolvedProjectFov`: `45`
+  - `currentTargetFov`: `35`
+  - `legacyProjectFovCandidate`: `35`
+  - `targetFovMismatch`: `true`
+- During the same run, `liveFov` settled from approximately `43.8533` to approximately `35.0067`, which matches legacy/current-target behavior rather than resolver project FOV.
+- Conclusion: resolver project FOV is not currently legacy-equivalent for overview → project. Future CameraDirector pilot work must not consume resolver project FOV until parity is fixed, or must explicitly use legacy/currentTarget-equivalent FOV for this path.
+
+### 3) Timing source finding from this observation point
+- `cameraMoveProgress` remained `1` from first captured row through completion in the observed run, so it is not a useful 0→1 transition-start clock at this hook location.
+- More useful settle signals in this instrumentation:
+  - `liveDistanceToProjectTarget` (observed roughly `4.37` → `0.003`)
+  - `fovDeltaToCurrentTarget` (observed roughly `8.85` → `0.0067`)
+- From this hook location, transition behavior appears settle/smoothing/delta-driven rather than a fixed-duration timeline.
+
+## Recommended next PR (before any runtime pilot retry)
+1. **Either** fix destination resolver project-FOV parity in shadow/audit validation flow (do not change runtime behavior in audit pass),
+2. **Or** add upstream navigation-intent instrumentation that captures the true pre-transition overview pose before project state/cameraState flips.
+
+Do not retry runtime CameraDirector overview → project pilot behavior until both are addressed:
+- project FOV parity with legacy path is demonstrated, and
+- transition start capture source is proven to be pre-flip (or equivalently authoritative).

--- a/docs/camera-overview-project-clock-audit.md
+++ b/docs/camera-overview-project-clock-audit.md
@@ -67,6 +67,17 @@ Additional event rows are captured on:
 - cameraState change
 - viewMode change
 - focusedProject change
+- selectedProject change
+- pre-start intent event: `intent:overview-to-project` (when early overview→project intent is detectable from selection/view/camera-state precursor signals)
+
+FOV audit fields now include:
+- `liveFov`
+- `currentTargetFov`
+- `resolvedProjectFov`
+- `legacyProjectFovCandidate` (observational candidate; currently mirrored from `currentTargetFov` for parity checks)
+- `fovDeltaToCurrentTarget`
+- `fovDeltaToResolvedProject`
+- `targetFovMismatch` (true when `abs(currentTargetFov - resolvedProjectFov) > 0.5`)
 
 Default console remains silent; output is helper-triggered only.
 
@@ -76,3 +87,8 @@ Use a **dual-source timing contract**:
 2. Coupling clock: explicit normalized transition progress that matches legacy facet expectations (or explicit facet clock).
 
 In other words, do not rely on `cameraMoveProgress` alone as the sole transition clock; consume both event boundaries and live camera-to-target error curves.
+
+## Current PR-10 finding updates
+- The sampler can still begin after `project_focused` / `cameraState: project` flips, so timeline analysis must include the new pre-start intent event to bracket earlier intent onset.
+- `cameraMoveProgress` remains not suitable as the true transition-start clock.
+- Observed large FOV residuals against resolved-project FOV indicate a likely target mismatch suspicion path; resolver project FOV should not be treated as pilot-authoritative until parity is proven against legacy live/currentTarget behavior.

--- a/docs/camera-overview-project-clock-audit.md
+++ b/docs/camera-overview-project-clock-audit.md
@@ -1,0 +1,78 @@
+# Overview → Project transition clock audit (PR-10)
+
+## Scope
+This audit identifies the real timing signals behind the visible Overview → Project camera movement and focused project facet rotation, without changing runtime behavior.
+
+## Candidate clocks found
+
+### 1) `cameraMoveProgress` (derived settle progress)
+- Computed in `UnifiedCameraController` from **three normalized settle channels**:
+  - position distance to `currentTarget.current.position`
+  - lookAt angle delta (`currentDirection` vs `targetDirection`)
+  - fov delta (`currentTarget.current.fov` vs `camera.fov`)
+- Per-frame `moveProgress = min(positionProgress, lookAtProgress, fovProgress)` and made monotonic via `max(previous, clampedMoveProgress)`.
+- This means it is **not an elapsed-time clock**; it is a settle metric and may already be `1` when sampling begins if baselines are small/already-settled.
+
+### 2) `currentTarget` smoothing clock (actual visible camera motion)
+- Visible camera movement is driven by per-frame smoothing toward `currentTarget`:
+  - `camera.position.lerp(currentTarget.current.position, clampedSmoothing)`
+  - `currentDirection.lerp(targetDirection, clampedSmoothing)` then `lookAt`
+  - `camera.fov += (currentTarget.current.fov - camera.fov) * clampedSmoothing`
+- `clampedSmoothing` is delta-based (`useFrame` dt path), so the true motion clock is frame-delta accumulation + remaining deltas to target.
+
+### 3) State routing clocks (`state`, `cameraState`, `viewMode`, `focusedProject`)
+- Transition observability gates are routed by changes in `cameraState` and project context.
+- `focusedProject` and `viewMode` changes can precede or overlap camera settle behavior.
+- These are transition event clocks (discrete), not motion clocks.
+
+### 4) Facet rotation clocks
+- Target focused quaternion uses
+  - `focusRotationProgress = clamp(cameraMoveProgress / FOCUS_ROTATION_PROGRESS_LEAD, 0, 1)`
+- Mesh rotation is still applied with per-frame slerp (`focusedRotationLerp` / `rotationLerp`) toward that target, making final visible facet convergence partly delta-time driven.
+
+## What appears to drive visible motion
+
+### Camera movement (overview → project)
+Primary driver: **`currentTarget` delta-based smoothing path** (position/lookAt/fov deltas shrinking over frames).
+
+`cameraMoveProgress` is a derived settle indicator, useful as coupling/progress metadata, but not a reliable start-at-zero transition clock.
+
+### Facet rotation
+Primary driver for intended target progression: **`cameraMoveProgress`**.
+
+Primary driver for visible final convergence: **per-frame quaternion slerp toward that target**.
+
+## Shared vs correlated
+- Camera and facet are **partially shared** through `cameraMoveProgress`.
+- They are also **independently time-shaped** by separate per-frame smoothing/slerp paths.
+- Therefore they are correlated, but not a single strict elapsed-time clock.
+
+## DEV-only shadow instrumentation added
+Manual helper:
+- `globalThis.__printOverviewProjectTimingTimeline()`
+
+Timeline rows include:
+- event/sample type
+- timestamp/frame
+- `state`, `cameraState`, `viewMode`, `focusedProject`
+- live distance to resolved project target
+- live fov delta to resolved project target
+- live filmOffset delta to resolved project target
+- facet progress/quaternion delta (if focused facet debug available)
+- `cameraMoveProgress`
+- frame-delta accumulation
+
+Additional event rows are captured on:
+- state change
+- cameraState change
+- viewMode change
+- focusedProject change
+
+Default console remains silent; output is helper-triggered only.
+
+## Recommendation for future CameraDirector pilot
+Use a **dual-source timing contract**:
+1. Motion clock: live target deltas over frame time (distance/lookAt/fov/filmOffset error envelope).
+2. Coupling clock: explicit normalized transition progress that matches legacy facet expectations (or explicit facet clock).
+
+In other words, do not rely on `cameraMoveProgress` alone as the sole transition clock; consume both event boundaries and live camera-to-target error curves.

--- a/docs/camera-overview-project-clock-audit.md
+++ b/docs/camera-overview-project-clock-audit.md
@@ -69,6 +69,7 @@ Additional event rows are captured on:
 - focusedProject change
 - selectedProject change
 - pre-start intent event: `intent:overview-to-project` (when early overview→project intent is detectable from selection/view/camera-state precursor signals)
+- repeated intent rows are edge-detected and suppressed (summary includes `suppressedIntentRepeatCount`)
 
 FOV audit fields now include:
 - `liveFov`
@@ -78,6 +79,7 @@ FOV audit fields now include:
 - `fovDeltaToCurrentTarget`
 - `fovDeltaToResolvedProject`
 - `targetFovMismatch` (true when `abs(currentTargetFov - resolvedProjectFov) > 0.5`)
+- timeline table helper now prints explicit FOV columns (with `null` when unavailable) for visual audit consistency
 
 Default console remains silent; output is helper-triggered only.
 
@@ -92,3 +94,4 @@ In other words, do not rely on `cameraMoveProgress` alone as the sole transition
 - The sampler can still begin after `project_focused` / `cameraState: project` flips, so timeline analysis must include the new pre-start intent event to bracket earlier intent onset.
 - `cameraMoveProgress` remains not suitable as the true transition-start clock.
 - Observed large FOV residuals against resolved-project FOV indicate a likely target mismatch suspicion path; resolver project FOV should not be treated as pilot-authoritative until parity is proven against legacy live/currentTarget behavior.
+- Current earliest captured row can still occur after state/cameraState flip from this hook location; future work needs an earlier upstream hook if strict pre-flip capture is required.

--- a/src/components/three/UnifiedCameraController.jsx
+++ b/src/components/three/UnifiedCameraController.jsx
@@ -237,10 +237,19 @@ const UnifiedCameraController = ({
     startSample: null,
     completionSample: null,
     samples: [],
+    timeline: [],
     maxSamples: 120,
+    maxTimelineRows: 240,
     printedStartForTransition: null,
     printedCompletionForTransition: null,
     lastSkipReason: null,
+    frameDeltaAccum: 0,
+    eventMarks: {
+      state: null,
+      cameraState: null,
+      viewMode: null,
+      focusedProject: null,
+    },
   });
 
   const isOverviewToProjectPilotEnabled = () => {
@@ -1631,8 +1640,19 @@ const UnifiedCameraController = ({
       console.table(shadow.samples);
     };
     globalThis.__clearOverviewProjectTimingSamples = () => {
-      getOverviewProjectShadowStore().samples = []
+      const shadow = getOverviewProjectShadowStore();
+      shadow.samples = [];
+      shadow.timeline = [];
+      shadow.frameDeltaAccum = 0;
       console.log('[overview-project-shadow] samples-cleared');
+    };
+    globalThis.__printOverviewProjectTimingTimeline = () => {
+      const shadow = getOverviewProjectShadowStore();
+      if (!shadow.timeline.length) {
+        console.log('[overview-project-shadow] timeline', []);
+        return;
+      }
+      console.table(shadow.timeline);
     };
     globalThis.__overviewProjectShadowHelpersInstalled = true;
   };
@@ -1672,7 +1692,10 @@ const UnifiedCameraController = ({
 
     const pushRow = (sampleType) => {
       const transitionElapsedSeconds = shadow.startedAt != null ? round4(now - shadow.startedAt) : null;
-      shadow.samples.push({
+      const liveDistanceToProjectTarget = safeDistance(camera.position, resolvedProject?.position);
+      const liveFovDeltaToProjectTarget = resolvedProject?.fov != null ? round4(Math.abs(camera.fov - resolvedProject.fov)) : null;
+      const liveFilmOffsetDeltaToProjectTarget = resolvedProject?.filmOffset != null ? round4(Math.abs((camera.filmOffset ?? 0) - resolvedProject.filmOffset)) : null;
+      const row = {
         sampleType,
         transitionId: shadow.transitionId ?? transitionKey,
         frameId: frame,
@@ -1691,13 +1714,75 @@ const UnifiedCameraController = ({
         liveFilmOffset: round4(camera.filmOffset),
         currentTargetLookAt: vectorToPlain(currentTarget.current?.lookAt),
         currentTargetFov: round4(currentTarget.current?.fov),
-        currentTargetFilmOffset: null,
-        deltaToResolvedProjectPosition: safeDistance(camera.position, resolvedProject?.position),
+        currentTargetFilmOffset: round4(camera.filmOffset),
+        deltaToResolvedProjectPosition: liveDistanceToProjectTarget,
         deltaToResolvedProjectLookAt: safeDistance(liveLookAt, resolvedProject?.lookAt),
+        liveDistanceToProjectTarget,
+        liveFovDeltaToProjectTarget,
+        liveFilmOffsetDeltaToProjectTarget,
+        frameDeltaAccum: round4(shadow.frameDeltaAccum),
         facet: facetDebug,
-      });
+      };
+      shadow.samples.push(row);
       if (shadow.samples.length > shadow.maxSamples) shadow.samples.shift();
+      shadow.timeline.push({
+        eventType: `sample:${sampleType}`,
+        timestamp: round4(now),
+        transitionElapsedSeconds,
+        frameId: frame,
+        state: animationData?.state ?? null,
+        cameraState: animationData?.cameraState ?? null,
+        viewMode: animationData?.viewMode ?? null,
+        focusedProject: animationData?.focusedProject ?? null,
+        cameraMoveProgress: row.cameraMoveProgress,
+        frameDeltaAccum: row.frameDeltaAccum,
+        liveDistanceToProjectTarget,
+        liveFovDeltaToProjectTarget,
+        liveFilmOffsetDeltaToProjectTarget,
+        facetProgress: round4(facetDebug?.focusRotationProgress),
+        facetDeltaToProjectQuat: facetDebug?.deltaMeshToProjectFocusQuat ?? null,
+      });
+      if (shadow.timeline.length > shadow.maxTimelineRows) shadow.timeline.shift();
     };
+    shadow.frameDeltaAccum += Number.isFinite(delta) ? delta : 0;
+    const markChangeEvent = (eventType, previousValue, nextValue) => {
+      shadow.timeline.push({
+        eventType,
+        timestamp: round4(now),
+        frameId: frame,
+        state: animationData?.state ?? null,
+        cameraState: animationData?.cameraState ?? null,
+        viewMode: animationData?.viewMode ?? null,
+        focusedProject: animationData?.focusedProject ?? null,
+        previousValue: previousValue ?? null,
+        nextValue: nextValue ?? null,
+        cameraMoveProgress: round4(cameraMoveProgressRef.current),
+        frameDeltaAccum: round4(shadow.frameDeltaAccum),
+        liveDistanceToProjectTarget: safeDistance(camera.position, resolvedProject?.position),
+        liveFovDeltaToProjectTarget: resolvedProject?.fov != null ? round4(Math.abs(camera.fov - resolvedProject.fov)) : null,
+        liveFilmOffsetDeltaToProjectTarget: resolvedProject?.filmOffset != null ? round4(Math.abs((camera.filmOffset ?? 0) - resolvedProject.filmOffset)) : null,
+        facetProgress: round4(facetDebug?.focusRotationProgress),
+        facetDeltaToProjectQuat: facetDebug?.deltaMeshToProjectFocusQuat ?? null,
+      });
+      if (shadow.timeline.length > shadow.maxTimelineRows) shadow.timeline.shift();
+    };
+
+    if (shadow.eventMarks.state !== (animationData?.state ?? null)) {
+      markChangeEvent('state-change', shadow.eventMarks.state, animationData?.state ?? null);
+      shadow.eventMarks.state = animationData?.state ?? null;
+    }
+    if (shadow.eventMarks.cameraState !== (animationData?.cameraState ?? null)) {
+      markChangeEvent('cameraState-change', shadow.eventMarks.cameraState, animationData?.cameraState ?? null);
+      shadow.eventMarks.cameraState = animationData?.cameraState ?? null;
+    }
+    if (shadow.eventMarks.viewMode !== (animationData?.viewMode ?? null)) {
+      markChangeEvent('viewMode-change', shadow.eventMarks.viewMode, animationData?.viewMode ?? null);
+      shadow.eventMarks.viewMode = animationData?.viewMode ?? null;
+    }
+    if (shadow.eventMarks.focusedProject !== (animationData?.focusedProject ?? null)) {
+      markChangeEvent('focusedProject-change', shadow.eventMarks.focusedProject, animationData?.focusedProject ?? null);
+      shadow.eventMarks.focusedProject = animationData?.focusedProject ?? null;
+    }
 
     if (transitionActive && !shadow.active) {
       shadow.active = true;

--- a/src/components/three/UnifiedCameraController.jsx
+++ b/src/components/three/UnifiedCameraController.jsx
@@ -249,6 +249,7 @@ const UnifiedCameraController = ({
       cameraState: null,
       viewMode: null,
       focusedProject: null,
+      selectedProject: null,
     },
   });
 
@@ -1660,6 +1661,79 @@ const UnifiedCameraController = ({
   const sampleOverviewProjectShadow = ({ state, delta, transitionActive, transitionKey, focusedProject, settled, prevCameraState, nextCameraState, nextState, viewMode }) => {
     if (!import.meta.env.DEV) return;
     const shadow = getOverviewProjectShadowStore();
+    installOverviewProjectShadowHelpers();
+    const now = state.clock.elapsedTime;
+    const frame = state.clock.frame;
+    const liveLookAt = getCameraLookAtFromTransform();
+    const resolvedOverview = getOverviewProjectResolvedPose('overview');
+    const resolvedProject = focusedProject ? getOverviewProjectResolvedPose('project', focusedProject) : null;
+    const facetDebug = globalThis?.__overviewProjectFacetDebug ?? null;
+    const resolvedProjectFov = round4(resolvedProject?.fov);
+    const currentTargetFov = round4(currentTarget.current?.fov);
+    const liveFov = round4(camera.fov);
+    const fovDeltaToCurrentTarget = Number.isFinite(currentTarget.current?.fov) ? round4(Math.abs(camera.fov - currentTarget.current.fov)) : null;
+    const fovDeltaToResolvedProject = resolvedProject?.fov != null ? round4(Math.abs(camera.fov - resolvedProject.fov)) : null;
+    const targetFovMismatch = (
+      Number.isFinite(currentTarget.current?.fov) &&
+      Number.isFinite(resolvedProject?.fov) &&
+      Math.abs(currentTarget.current.fov - resolvedProject.fov) > 0.5
+    ) || false;
+    const prevStateMark = shadow.eventMarks.state;
+    const prevCameraStateMark = shadow.eventMarks.cameraState;
+    const prevViewModeMark = shadow.eventMarks.viewMode;
+    const prevFocusedProjectMark = shadow.eventMarks.focusedProject;
+    const prevSelectedProjectMark = shadow.eventMarks.selectedProject;
+    const nextStateMark = animationData?.state ?? null;
+    const nextCameraStateMark = animationData?.cameraState ?? null;
+    const nextViewModeMark = animationData?.viewMode ?? null;
+    const nextFocusedProjectMark = animationData?.focusedProject ?? null;
+    const nextSelectedProjectMark = animationData?.selectedProject ?? null;
+    const likelyOverviewToProjectIntent =
+      (prevViewModeMark === 'overview' && Boolean(nextFocusedProjectMark || nextSelectedProjectMark)) ||
+      (prevFocusedProjectMark == null && nextFocusedProjectMark != null) ||
+      (prevSelectedProjectMark == null && nextSelectedProjectMark != null) ||
+      (prevCameraStateMark === 'overview' && nextCameraStateMark === 'project');
+
+    const markChangeEvent = (eventType, previousValue, nextValue) => {
+      shadow.timeline.push({
+        eventType,
+        timestamp: round4(now),
+        frameId: frame,
+        state: nextStateMark,
+        cameraState: nextCameraStateMark,
+        viewMode: nextViewModeMark,
+        focusedProject: nextFocusedProjectMark,
+        selectedProject: nextSelectedProjectMark,
+        previousValue: previousValue ?? null,
+        nextValue: nextValue ?? null,
+        prevState: prevStateMark,
+        nextState: nextStateMark,
+        prevCameraState: prevCameraStateMark,
+        nextCameraState: nextCameraStateMark,
+        prevViewMode: prevViewModeMark,
+        nextViewMode: nextViewModeMark,
+        prevFocusedProject: prevFocusedProjectMark,
+        nextFocusedProject: nextFocusedProjectMark,
+        prevSelectedProject: prevSelectedProjectMark,
+        nextSelectedProject: nextSelectedProjectMark,
+        cameraMoveProgress: round4(cameraMoveProgressRef.current),
+        frameDeltaAccum: round4(shadow.frameDeltaAccum),
+        liveFov,
+        currentTargetFov,
+        resolvedProjectFov,
+        legacyProjectFovCandidate: currentTargetFov,
+        fovDeltaToCurrentTarget,
+        fovDeltaToResolvedProject,
+        targetFovMismatch,
+        liveDistanceToProjectTarget: safeDistance(camera.position, resolvedProject?.position),
+        liveFilmOffsetDeltaToProjectTarget: resolvedProject?.filmOffset != null ? round4(Math.abs((camera.filmOffset ?? 0) - resolvedProject.filmOffset)) : null,
+        facetProgress: round4(facetDebug?.focusRotationProgress),
+        facetDeltaToProjectQuat: facetDebug?.deltaMeshToProjectFocusQuat ?? null,
+      });
+      if (shadow.timeline.length > shadow.maxTimelineRows) shadow.timeline.shift();
+    };
+    if (likelyOverviewToProjectIntent) markChangeEvent('intent:overview-to-project', prevFocusedProjectMark ?? prevSelectedProjectMark, nextFocusedProjectMark ?? nextSelectedProjectMark);
+
     const isFreshOverviewToProject =
       prevCameraState === 'overview' &&
       nextCameraState === 'project' &&
@@ -1681,14 +1755,6 @@ const UnifiedCameraController = ({
       };
       return;
     }
-
-    installOverviewProjectShadowHelpers();
-    const now = state.clock.elapsedTime;
-    const frame = state.clock.frame;
-    const liveLookAt = getCameraLookAtFromTransform();
-    const resolvedOverview = getOverviewProjectResolvedPose('overview');
-    const resolvedProject = focusedProject ? getOverviewProjectResolvedPose('project', focusedProject) : null;
-    const facetDebug = globalThis?.__overviewProjectFacetDebug ?? null;
 
     const pushRow = (sampleType) => {
       const transitionElapsedSeconds = shadow.startedAt != null ? round4(now - shadow.startedAt) : null;
@@ -1715,6 +1781,11 @@ const UnifiedCameraController = ({
         currentTargetLookAt: vectorToPlain(currentTarget.current?.lookAt),
         currentTargetFov: round4(currentTarget.current?.fov),
         currentTargetFilmOffset: round4(camera.filmOffset),
+        resolvedProjectFov,
+        legacyProjectFovCandidate: currentTargetFov,
+        fovDeltaToCurrentTarget,
+        fovDeltaToResolvedProject,
+        targetFovMismatch,
         deltaToResolvedProjectPosition: liveDistanceToProjectTarget,
         deltaToResolvedProjectLookAt: safeDistance(liveLookAt, resolvedProject?.lookAt),
         liveDistanceToProjectTarget,
@@ -1734,9 +1805,17 @@ const UnifiedCameraController = ({
         cameraState: animationData?.cameraState ?? null,
         viewMode: animationData?.viewMode ?? null,
         focusedProject: animationData?.focusedProject ?? null,
+        selectedProject: animationData?.selectedProject ?? null,
         cameraMoveProgress: row.cameraMoveProgress,
         frameDeltaAccum: row.frameDeltaAccum,
         liveDistanceToProjectTarget,
+        liveFov,
+        currentTargetFov,
+        resolvedProjectFov,
+        legacyProjectFovCandidate: currentTargetFov,
+        fovDeltaToCurrentTarget,
+        fovDeltaToResolvedProject,
+        targetFovMismatch,
         liveFovDeltaToProjectTarget,
         liveFilmOffsetDeltaToProjectTarget,
         facetProgress: round4(facetDebug?.focusRotationProgress),
@@ -1745,27 +1824,6 @@ const UnifiedCameraController = ({
       if (shadow.timeline.length > shadow.maxTimelineRows) shadow.timeline.shift();
     };
     shadow.frameDeltaAccum += Number.isFinite(delta) ? delta : 0;
-    const markChangeEvent = (eventType, previousValue, nextValue) => {
-      shadow.timeline.push({
-        eventType,
-        timestamp: round4(now),
-        frameId: frame,
-        state: animationData?.state ?? null,
-        cameraState: animationData?.cameraState ?? null,
-        viewMode: animationData?.viewMode ?? null,
-        focusedProject: animationData?.focusedProject ?? null,
-        previousValue: previousValue ?? null,
-        nextValue: nextValue ?? null,
-        cameraMoveProgress: round4(cameraMoveProgressRef.current),
-        frameDeltaAccum: round4(shadow.frameDeltaAccum),
-        liveDistanceToProjectTarget: safeDistance(camera.position, resolvedProject?.position),
-        liveFovDeltaToProjectTarget: resolvedProject?.fov != null ? round4(Math.abs(camera.fov - resolvedProject.fov)) : null,
-        liveFilmOffsetDeltaToProjectTarget: resolvedProject?.filmOffset != null ? round4(Math.abs((camera.filmOffset ?? 0) - resolvedProject.filmOffset)) : null,
-        facetProgress: round4(facetDebug?.focusRotationProgress),
-        facetDeltaToProjectQuat: facetDebug?.deltaMeshToProjectFocusQuat ?? null,
-      });
-      if (shadow.timeline.length > shadow.maxTimelineRows) shadow.timeline.shift();
-    };
 
     if (shadow.eventMarks.state !== (animationData?.state ?? null)) {
       markChangeEvent('state-change', shadow.eventMarks.state, animationData?.state ?? null);
@@ -1782,6 +1840,10 @@ const UnifiedCameraController = ({
     if (shadow.eventMarks.focusedProject !== (animationData?.focusedProject ?? null)) {
       markChangeEvent('focusedProject-change', shadow.eventMarks.focusedProject, animationData?.focusedProject ?? null);
       shadow.eventMarks.focusedProject = animationData?.focusedProject ?? null;
+    }
+    if (shadow.eventMarks.selectedProject !== (animationData?.selectedProject ?? null)) {
+      markChangeEvent('selectedProject-change', shadow.eventMarks.selectedProject, animationData?.selectedProject ?? null);
+      shadow.eventMarks.selectedProject = animationData?.selectedProject ?? null;
     }
 
     if (transitionActive && !shadow.active) {

--- a/src/components/three/UnifiedCameraController.jsx
+++ b/src/components/three/UnifiedCameraController.jsx
@@ -251,6 +251,10 @@ const UnifiedCameraController = ({
       focusedProject: null,
       selectedProject: null,
     },
+    intentEdgeKey: null,
+    suppressedIntentRepeatCount: 0,
+    truePreTransitionCaptured: false,
+    earliestCapturedAfterStateFlip: null,
   });
 
   const isOverviewToProjectPilotEnabled = () => {
@@ -1630,6 +1634,9 @@ const UnifiedCameraController = ({
         startSample: shadow.startSample,
         completionSample: shadow.completionSample,
         lastSkipReason: shadow.lastSkipReason ?? null,
+        suppressedIntentRepeatCount: shadow.suppressedIntentRepeatCount ?? 0,
+        truePreTransitionCaptured: shadow.truePreTransitionCaptured ?? false,
+        earliestCapturedAfterStateFlip: shadow.earliestCapturedAfterStateFlip ?? null,
       });
     };
     globalThis.__printOverviewProjectTimingSamples = () => {
@@ -1645,6 +1652,10 @@ const UnifiedCameraController = ({
       shadow.samples = [];
       shadow.timeline = [];
       shadow.frameDeltaAccum = 0;
+      shadow.intentEdgeKey = null;
+      shadow.suppressedIntentRepeatCount = 0;
+      shadow.truePreTransitionCaptured = false;
+      shadow.earliestCapturedAfterStateFlip = null;
       console.log('[overview-project-shadow] samples-cleared');
     };
     globalThis.__printOverviewProjectTimingTimeline = () => {
@@ -1653,7 +1664,29 @@ const UnifiedCameraController = ({
         console.log('[overview-project-shadow] timeline', []);
         return;
       }
-      console.table(shadow.timeline);
+      const tableRows = shadow.timeline.map((row) => ({
+        eventType: row.eventType ?? null,
+        timestamp: row.timestamp ?? null,
+        frameId: row.frameId ?? null,
+        state: row.state ?? null,
+        cameraState: row.cameraState ?? null,
+        viewMode: row.viewMode ?? null,
+        focusedProject: row.focusedProject ?? null,
+        selectedProject: row.selectedProject ?? null,
+        isTruePreTransition: row.isTruePreTransition ?? null,
+        liveFov: row.liveFov ?? null,
+        currentTargetFov: row.currentTargetFov ?? null,
+        resolvedProjectFov: row.resolvedProjectFov ?? null,
+        legacyProjectFovCandidate: row.legacyProjectFovCandidate ?? null,
+        fovDeltaToCurrentTarget: row.fovDeltaToCurrentTarget ?? null,
+        fovDeltaToResolvedProject: row.fovDeltaToResolvedProject ?? null,
+        targetFovMismatch: row.targetFovMismatch ?? null,
+        liveDistanceToProjectTarget: row.liveDistanceToProjectTarget ?? null,
+        liveFilmOffsetDeltaToProjectTarget: row.liveFilmOffsetDeltaToProjectTarget ?? null,
+        cameraMoveProgress: row.cameraMoveProgress ?? null,
+        frameDeltaAccum: row.frameDeltaAccum ?? null,
+      }));
+      console.table(tableRows);
     };
     globalThis.__overviewProjectShadowHelpersInstalled = true;
   };
@@ -1693,9 +1726,12 @@ const UnifiedCameraController = ({
       (prevFocusedProjectMark == null && nextFocusedProjectMark != null) ||
       (prevSelectedProjectMark == null && nextSelectedProjectMark != null) ||
       (prevCameraStateMark === 'overview' && nextCameraStateMark === 'project');
+    const isTruePreTransition = nextStateMark !== 'project_focused' && nextCameraStateMark !== 'project';
+    const intentTargetProject = nextFocusedProjectMark ?? nextSelectedProjectMark ?? null;
+    const nextIntentEdgeKey = likelyOverviewToProjectIntent ? `${nextViewModeMark ?? 'none'}|${intentTargetProject ?? 'none'}` : null;
 
     const markChangeEvent = (eventType, previousValue, nextValue) => {
-      shadow.timeline.push({
+      const row = {
         eventType,
         timestamp: round4(now),
         frameId: frame,
@@ -1725,14 +1761,31 @@ const UnifiedCameraController = ({
         fovDeltaToCurrentTarget,
         fovDeltaToResolvedProject,
         targetFovMismatch,
+        isTruePreTransition,
         liveDistanceToProjectTarget: safeDistance(camera.position, resolvedProject?.position),
         liveFilmOffsetDeltaToProjectTarget: resolvedProject?.filmOffset != null ? round4(Math.abs((camera.filmOffset ?? 0) - resolvedProject.filmOffset)) : null,
         facetProgress: round4(facetDebug?.focusRotationProgress),
         facetDeltaToProjectQuat: facetDebug?.deltaMeshToProjectFocusQuat ?? null,
-      });
+      };
+      shadow.timeline.push(row);
       if (shadow.timeline.length > shadow.maxTimelineRows) shadow.timeline.shift();
+      if (shadow.timeline.length === 1) {
+        shadow.earliestCapturedAfterStateFlip = !row.isTruePreTransition;
+        shadow.truePreTransitionCaptured = Boolean(row.isTruePreTransition);
+      } else if (row.isTruePreTransition) {
+        shadow.truePreTransitionCaptured = true;
+      }
     };
-    if (likelyOverviewToProjectIntent) markChangeEvent('intent:overview-to-project', prevFocusedProjectMark ?? prevSelectedProjectMark, nextFocusedProjectMark ?? nextSelectedProjectMark);
+    if (likelyOverviewToProjectIntent) {
+      if (shadow.intentEdgeKey !== nextIntentEdgeKey) {
+        markChangeEvent('intent:overview-to-project', prevFocusedProjectMark ?? prevSelectedProjectMark, nextFocusedProjectMark ?? nextSelectedProjectMark);
+        shadow.intentEdgeKey = nextIntentEdgeKey;
+      } else {
+        shadow.suppressedIntentRepeatCount = (shadow.suppressedIntentRepeatCount ?? 0) + 1;
+      }
+    } else {
+      shadow.intentEdgeKey = null;
+    }
 
     const isFreshOverviewToProject =
       prevCameraState === 'overview' &&
@@ -1786,6 +1839,7 @@ const UnifiedCameraController = ({
         fovDeltaToCurrentTarget,
         fovDeltaToResolvedProject,
         targetFovMismatch,
+        isTruePreTransition,
         deltaToResolvedProjectPosition: liveDistanceToProjectTarget,
         deltaToResolvedProjectLookAt: safeDistance(liveLookAt, resolvedProject?.lookAt),
         liveDistanceToProjectTarget,
@@ -1816,12 +1870,19 @@ const UnifiedCameraController = ({
         fovDeltaToCurrentTarget,
         fovDeltaToResolvedProject,
         targetFovMismatch,
+        isTruePreTransition,
         liveFovDeltaToProjectTarget,
         liveFilmOffsetDeltaToProjectTarget,
         facetProgress: round4(facetDebug?.focusRotationProgress),
         facetDeltaToProjectQuat: facetDebug?.deltaMeshToProjectFocusQuat ?? null,
       });
       if (shadow.timeline.length > shadow.maxTimelineRows) shadow.timeline.shift();
+      if (shadow.timeline.length === 1) {
+        shadow.earliestCapturedAfterStateFlip = !row.isTruePreTransition;
+        shadow.truePreTransitionCaptured = Boolean(row.isTruePreTransition);
+      } else if (row.isTruePreTransition) {
+        shadow.truePreTransitionCaptured = true;
+      }
     };
     shadow.frameDeltaAccum += Number.isFinite(delta) ? delta : 0;
 

--- a/src/components/three/UnifiedCrystalScene.jsx
+++ b/src/components/three/UnifiedCrystalScene.jsx
@@ -2421,6 +2421,7 @@ const UnifiedCrystalScene = forwardRef(({
               facetKey,
               focusRotationProgress,
               facetRotationProgressApprox: facetProgress,
+              deltaMeshToProjectFocusQuat: Number(facetRef.current.quaternion.angleTo(targetQuat).toFixed(4)),
               cameraMoveProgress,
               viewMode: animationData?.viewMode ?? null,
               cameraState: animationData?.cameraState ?? null,


### PR DESCRIPTION
### Motivation
- Audit the true timing signals that drive the visible Overview → Project camera motion and facet rotation without changing runtime behavior.
- Capture additional candidate clocks and discrete events because `cameraMoveProgress` is a settle-derived metric and may already be 1 when sampling begins.
- Provide a manual, DEV-only, non-invasive timeline helper so researchers can inspect a compact event+sample timeline without console flooding.

### Description
- Added DEV-only shadow store extensions and a timeline capture in `UnifiedCameraController` to record samples, frame-delta accumulation, and discrete event marks (`state`, `cameraState`, `viewMode`, `focusedProject`) while keeping all camera writes and runtime behavior unchanged. (changed: `src/components/three/UnifiedCameraController.jsx`)
- Extended shadow samples with candidate clocks and deltas required by the audit: live distance/FOV/filmOffset deltas to resolved project target, `cameraMoveProgress`, `frameDeltaAccum`, and facet-linked fields; added discrete timeline rows for event marks and sample rows. (changed: `src/components/three/UnifiedCameraController.jsx`)
- Exposed a manual DEV helper `globalThis.__printOverviewProjectTimingTimeline()` (plus summary/samples/clear helpers) that prints a compact event+sample timeline only in `import.meta.env.DEV`, and ensured clearing resets `samples`, `timeline`, and `frameDeltaAccum`. (changed: `src/components/three/UnifiedCameraController.jsx`)
- Added a small DEV-only facet debug field `deltaMeshToProjectFocusQuat` so facet quaternion delta/progress can be correlated with camera timing. (changed: `src/components/three/UnifiedCrystalScene.jsx`)
- Added audit documentation `docs/camera-overview-project-clock-audit.md` summarizing candidate clocks, which signals drive visible camera motion vs facet rotation, and a recommendation that future CameraDirector accept a dual-source timing contract (motion error envelope + explicit coupling progress). (new file)
- Safety: all changes are instrumentation/docs-only; CameraDirector pilot remains disabled; no camera writer suppression or runtime tuning was performed.

### Testing
- Automated build: `npm run build` completed successfully (production build finished with normal bundle warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a110499e28883289f1748f305ad50da)