### PR TITLE
Fix project destination resolver FOV parity in shadow mode

### DIFF
--- a/docs/camera-destination-resolver.md
+++ b/docs/camera-destination-resolver.md
@@ -18,3 +18,9 @@ Supported canonical destinations:
 - No transition timing changes.
 - Hero→Overview behavior intentionally untouched.
 - Known About corruption remains unresolved in this PR.
+
+## PR-11: Project FOV parity fix (overview → project)
+- Root cause: resolver project/caseStudy branch returned the default base FOV (`45`) because it only resolved position/target from `projectCameraSettings` and never sourced FOV for project destinations.
+- Legacy/runtime target source for this transition remains `animationData.cameraConfig.fov` (observed project target `35`), so shadow compare showed `resolvedProjectFov=45` vs `currentTargetFov=35`.
+- Fix: project/caseStudy resolver path now reads FOV from `animationData.cameraConfig.fov` (same source used by legacy runtime targeting) and keeps fallback to base FOV only when animation data is unavailable.
+- Non-goal unchanged: transition timing/start-capture instrumentation is still downstream and not addressed here.

--- a/src/camera/destinationResolver.js
+++ b/src/camera/destinationResolver.js
@@ -22,7 +22,9 @@ export const resolveCameraDestination = ({ destination, projectId = null, mode =
       ...base,
       position: addVec3(toVec3(branch.position), globalOffsetPos),
       lookAt: addVec3(toVec3(branch.target), globalOffsetTarget),
-      meta: { ...base.meta, source: `projectCameraSettings.${projectMode}` },
+      fov: animationData?.cameraConfig?.fov ?? base.fov,
+      filmOffset: config?.cameraComposition?.hero?.filmOffsetX ?? 0,
+      meta: { ...base.meta, source: `projectCameraSettings.${projectMode}+animationData.cameraConfig.fov` },
     };
   }
 


### PR DESCRIPTION
### Motivation
- The passive resolver returned the base FOV (`45`) for `project`/`caseStudy` because it only pulled `position`/`target` from `projectCameraSettings`, causing a parity mismatch with the legacy/runtime target (`animationData.cameraConfig.fov`, observed `35`).
- The change must be strictly passive: keep resolver read-only, do not alter runtime camera writes, transitions, or timing.

### Description
- Updated `resolveCameraDestination(...)` so the `project`/`caseStudy` branch reads FOV from `animationData.cameraConfig.fov` with a fallback to the resolver base FOV via `fov: animationData?.cameraConfig?.fov ?? base.fov` and added `filmOffset` parity from hero composition.
- Kept the resolver pure and passive (no state mutation, no camera writes, no transition triggering) and updated `meta.source` to reflect the FOV source for traceability.
- Files changed: `src/camera/destinationResolver.js` and `docs/camera-destination-resolver.md` (added PR-11 notes describing root cause and fix).
- Confirmed no runtime camera controller code, camera write guards, or pilot toggles were modified so runtime camera behavior and CameraDirector pilot remain unchanged.

### Testing
- Ran `npm run build` and the build completed successfully with no errors (vite production build completed).
- Committed the change as `Fix resolver project FOV parity in shadow mode` and recorded commit hash `b9e2eb6`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11e23ec8888328b95b6a15e7592839)