### PR TITLE
Add disabled CameraDirector pilot for project → project transitions

### DIFF
--- a/docs/camera-director-pilot-project-project.md
+++ b/docs/camera-director-pilot-project-project.md
@@ -1,49 +1,97 @@
 # CameraDirector Pilot: Project → Project (PR-14)
 
 ## Feature flag
-- `globalThis.__ENABLE_CAMERA_DIRECTOR_PROJECT_TO_PROJECT__ = true`
-- Default is disabled (`false` / `undefined`).
+- Flag: `globalThis.__ENABLE_CAMERA_DIRECTOR_PROJECT_TO_PROJECT__`
+- Default: disabled (`false` / `undefined`).
+- With flag off, legacy behavior is unchanged.
 
-## Activation conditions
-Pilot activates only when all are true:
-- feature flag enabled
-- no other CameraDirector pilot active
-- `cameraState` stays `project` and source/target selected project ids differ
-- not in `caseStudy` view mode
+## Activation strategy (focusedProject + last stable project)
+Project→project pilot activation is gated and only starts when all are true:
+- project→project pilot flag is enabled
+- no other camera-director pilot is active
+- `prevCameraState === 'project'` and `nextCameraState === 'project'`
+- `fromProjectId` resolves from the last stable project id (focused project history)
+- `toProjectId` resolves from current `focusedProject` (selected project is fallback only)
+- `fromProjectId !== toProjectId`
+- `viewMode !== 'caseStudy'`
+
+## Duplicate-start guard
+- Stable transition key is used:
+  - `project-to-project:${fromProjectId}->${toProjectId}`
+- Duplicate starts are blocked if the same transition key is already handled/active.
+- Bounded duplicate suppression diagnostic:
+  - `[camera-director-pilot] project-to-project restart-blocked`
+
+## False mid-transition start blocking
+To avoid false late starts (already settled state), starts are blocked when the transition appears invalid/post-settle.
+- Bounded diagnostic:
+  - `[camera-director-pilot] project-to-project start-blocked`
 
 ## fromPose strategy
-- Capture live visible camera pose at pilot start.
-- Preserve live position/lookAt/fov/filmOffset for first write continuity.
-- If pre-start lookAt changed, prefer previous-frame lookAt to avoid a start snap.
+- Capture visible live camera pose on start.
+- Preserve first-write continuity (`position`/`lookAt`/`fov`/`filmOffset`) to avoid start jump.
 
-## target pose strategy
-- Resolve target selected project pose from camera destination resolver.
-- Use legacy-equivalent composition for fov/filmOffset by preferring live/currentTarget equivalents.
-- Maintain strict settle thresholds and max-duration fallback to avoid hard hangs.
+## Target pose strategy
+- Resolve target pose with `resolveCameraDestination(... destination: 'project', mode: 'selected')`.
+- Preserve legacy-equivalent composition behavior for `fov`/`filmOffset`.
+- If target pose cannot resolve, parity rows are still recorded with null pose deltas and reason fields.
+
+## Final curve strategy (active)
+- `progressEasingSource`: `project-to-project:legacy-settle-ease-out`
+- Camera position uses a front-loaded but moderated project→project remap (closer to legacy 25/50/75 settle pacing).
+- LookAt resolves early (faster than old smooth interpolation) while keeping no-start-jump behavior.
+
+## Facet/choreography parity
+- Project→project pilot preserves legacy-like facet choreography behavior.
+- Camera pilot keeps camera ownership, but shared choreography progress is preserved so facet lag vs legacy is avoided.
+
+## Completion strategy
+- Strict completion remains:
+  - near-zero position/lookAt/fov deltas
+  - filmOffset parity preserved
+  - completion reason remains `thresholds-met` when strict criteria are met
 
 ## Parity helpers
 - `globalThis.__clearProjectProjectPilotParity()`
 - `globalThis.__printProjectProjectPilotParitySummary()`
 - `globalThis.__printProjectProjectPilotParitySamples()`
 
-Captured parity fields include mode, from/to project ids, sample buckets, view mode, camera deltas to resolved project, progress fields, completion reason, and progress easing source.
+## Known diagnostics (bounded)
+- `[camera-director-pilot] project-to-project activation-check`
+- `[camera-director-pilot] project-to-project activation-matched`
+- `[camera-director-pilot] project-to-project parity-start-written`
+- `[camera-director-pilot] project-to-project restart-blocked`
+- `[camera-director-pilot] project-to-project start-blocked`
+- `[camera-director-pilot] project-to-project curve-path`
+- `[camera-director-pilot] project-to-project motion-curve-summary`
+- `[camera-director-pilot] project-to-project complete`
+- `[camera-director-pilot] project-to-project fallback`
 
-## Rollback plan
-- Set `globalThis.__ENABLE_CAMERA_DIRECTOR_PROJECT_TO_PROJECT__ = false` (or remove override).
-- Behavior immediately returns to legacy without writer suppression.
+## Final successful status (current)
+- Flag off: unchanged legacy behavior.
+- Flag on: project→project starts once, no start jump, no end pop, correct landing, and parity rows are captured.
 
-## Test checklist
-- Flag off: verify project→project remains legacy.
-- Flag on: verify project transitions trigger one pilot start per selection change.
-- Validate no start jump, no end pop, and final composition parity.
-- Verify overview/project, project/overview, and caseStudy-related transitions remain unaffected.
+## Recommended test checklist
+1. Set `globalThis.__ENABLE_CAMERA_DIRECTOR_PROJECT_TO_PROJECT__ = false` and confirm all transitions remain legacy.
+2. Set flag true.
+3. Run:
+   - `__clearProjectProjectPilotParity()`
+4. Navigate:
+   - Overview → Project 1
+   - Project 1 → Project 2
+5. Verify:
+   - single project→project pilot activation
+   - no start jump / no end pop
+   - bounded logs only (no console flooding)
+6. Inspect parity:
+   - `__printProjectProjectPilotParitySummary()`
+   - `__printProjectProjectPilotParitySamples()`
+7. Confirm completion remains strict and final deltas settle correctly.
+
+## Rollback
+- Disable the flag (`false`/unset) to return immediately to legacy project→project behavior.
 
 ## Non-goals
 - No changes to hero/overview/about transitions.
 - No changes to overview→project or project→overview pilot behavior.
-- No global tuning for fragments, particles, glow, or ring.
-
-## PR-14 tuning note (v2)
-- Updated project→project pilot easing label to `project-to-project:legacy-settle-ease-out-v2`.
-- Position easing was reduced from the prior over-aggressive front-load to better align with legacy 25/50/75 pacing while preserving no-start-jump/no-end-pop behavior.
-- LookAt still resolves early, but less aggressively than the previous iteration to avoid visibly finishing far ahead of facet rotation.
+- No global visual-system tuning (fragments/particles/glow/ring).

--- a/docs/camera-director-pilot-project-project.md
+++ b/docs/camera-director-pilot-project-project.md
@@ -3,53 +3,55 @@
 ## Feature flag
 - Flag: `globalThis.__ENABLE_CAMERA_DIRECTOR_PROJECT_TO_PROJECT__`
 - Default: disabled (`false` / `undefined`).
-- With flag off, legacy behavior is unchanged.
+- With flag off, behavior remains legacy.
 
-## Activation strategy (focusedProject + last stable project)
-Project→project pilot activation is gated and only starts when all are true:
-- project→project pilot flag is enabled
+## Activation strategy (focusedProject + last stable project id)
+Project→project pilot activates only when all are true:
+- feature flag enabled
 - no other camera-director pilot is active
 - `prevCameraState === 'project'` and `nextCameraState === 'project'`
-- `fromProjectId` resolves from the last stable project id (focused project history)
-- `toProjectId` resolves from current `focusedProject` (selected project is fallback only)
+- `fromProjectId` resolves from last stable focused project id
+- `toProjectId` resolves from current `focusedProject` (`selectedProject` fallback only)
 - `fromProjectId !== toProjectId`
 - `viewMode !== 'caseStudy'`
 
 ## Duplicate-start guard
-- Stable transition key is used:
+- Stable transition key:
   - `project-to-project:${fromProjectId}->${toProjectId}`
-- Duplicate starts are blocked if the same transition key is already handled/active.
-- Bounded duplicate suppression diagnostic:
+- Duplicate starts blocked for same key while active/handled.
+- Bounded diagnostic:
   - `[camera-director-pilot] project-to-project restart-blocked`
 
 ## False mid-transition start blocking
-To avoid false late starts (already settled state), starts are blocked when the transition appears invalid/post-settle.
+- Invalid starts are blocked when activation is detected post-settle / invalid mid-transition state.
 - Bounded diagnostic:
   - `[camera-director-pilot] project-to-project start-blocked`
 
 ## fromPose strategy
-- Capture visible live camera pose on start.
-- Preserve first-write continuity (`position`/`lookAt`/`fov`/`filmOffset`) to avoid start jump.
+- Capture live visible camera pose at pilot start.
+- Preserve first-write continuity to avoid start jump.
 
 ## Target pose strategy
-- Resolve target pose with `resolveCameraDestination(... destination: 'project', mode: 'selected')`.
-- Preserve legacy-equivalent composition behavior for `fov`/`filmOffset`.
-- If target pose cannot resolve, parity rows are still recorded with null pose deltas and reason fields.
+- Resolve `toPose` with `resolveCameraDestination(... destination: 'project', mode: 'selected')`.
+- Keep target composition parity for `fov` / `filmOffset`.
+- If target cannot resolve, parity rows still record with null deltas and reason fields.
 
-## Final curve strategy (active)
-- `progressEasingSource`: `project-to-project:legacy-settle-ease-out`
-- Camera position uses a front-loaded but moderated project→project remap (closer to legacy 25/50/75 settle pacing).
-- LookAt resolves early (faster than old smooth interpolation) while keeping no-start-jump behavior.
+## Final curve strategy (accepted)
+- Position uses project→project easing tuned to legacy-like pacing while maintaining no-jump/no-pop.
+- LookAt resolves early enough to avoid lingering mismatch.
+- Camera settle is synchronized against facet progress in project→project pilot path for acceptable visual end alignment.
 
-## Facet/choreography parity
-- Project→project pilot preserves legacy-like facet choreography behavior.
-- Camera pilot keeps camera ownership, but shared choreography progress is preserved so facet lag vs legacy is avoided.
+## progressEasingSource
+- Final descriptive label:
+  - `project-to-project:facet-synced-settle`
 
-## Completion strategy
-- Strict completion remains:
-  - near-zero position/lookAt/fov deltas
-  - filmOffset parity preserved
-  - completion reason remains `thresholds-met` when strict criteria are met
+## Final accepted status
+- Flag off unchanged.
+- Flag on project→project transitions accepted for merge quality:
+  - no start jump
+  - no end pop
+  - correct landing
+  - acceptable camera/facet timing
 
 ## Parity helpers
 - `globalThis.__clearProjectProjectPilotParity()`
@@ -67,31 +69,33 @@ To avoid false late starts (already settled state), starts are blocked when the 
 - `[camera-director-pilot] project-to-project complete`
 - `[camera-director-pilot] project-to-project fallback`
 
-## Final successful status (current)
-- Flag off: unchanged legacy behavior.
-- Flag on: project→project starts once, no start jump, no end pop, correct landing, and parity rows are captured.
-
 ## Recommended test checklist
-1. Set `globalThis.__ENABLE_CAMERA_DIRECTOR_PROJECT_TO_PROJECT__ = false` and confirm all transitions remain legacy.
-2. Set flag true.
-3. Run:
+1. Flag off (`false`/unset) and verify legacy behavior remains unchanged.
+2. Flag on and run:
    - `__clearProjectProjectPilotParity()`
-4. Navigate:
+3. Navigate:
    - Overview → Project 1
    - Project 1 → Project 2
-5. Verify:
-   - single project→project pilot activation
+   - Project 2 → Project 3
+   - Project 3 → Project 1
+4. Verify:
+   - one pilot start per project→project transition
    - no start jump / no end pop
-   - bounded logs only (no console flooding)
-6. Inspect parity:
+   - correct project landing
+   - bounded diagnostics only
+5. Inspect parity:
    - `__printProjectProjectPilotParitySummary()`
    - `__printProjectProjectPilotParitySamples()`
-7. Confirm completion remains strict and final deltas settle correctly.
+6. Re-check unaffected routes:
+   - overview→project
+   - project→overview
+   - hero/overview
+   - about
 
 ## Rollback
-- Disable the flag (`false`/unset) to return immediately to legacy project→project behavior.
+- Disable/unset `__ENABLE_CAMERA_DIRECTOR_PROJECT_TO_PROJECT__` to return immediately to legacy behavior.
 
 ## Non-goals
-- No changes to hero/overview/about transitions.
-- No changes to overview→project or project→overview pilot behavior.
+- No changes to overview→project or project→overview pilot systems.
+- No changes to hero/about/caseStudy route behavior.
 - No global visual-system tuning (fragments/particles/glow/ring).

--- a/docs/camera-director-pilot-project-project.md
+++ b/docs/camera-director-pilot-project-project.md
@@ -1,0 +1,44 @@
+# CameraDirector Pilot: Project → Project (PR-14)
+
+## Feature flag
+- `globalThis.__ENABLE_CAMERA_DIRECTOR_PROJECT_TO_PROJECT__ = true`
+- Default is disabled (`false` / `undefined`).
+
+## Activation conditions
+Pilot activates only when all are true:
+- feature flag enabled
+- no other CameraDirector pilot active
+- `cameraState` stays `project` and source/target selected project ids differ
+- not in `caseStudy` view mode
+
+## fromPose strategy
+- Capture live visible camera pose at pilot start.
+- Preserve live position/lookAt/fov/filmOffset for first write continuity.
+- If pre-start lookAt changed, prefer previous-frame lookAt to avoid a start snap.
+
+## target pose strategy
+- Resolve target selected project pose from camera destination resolver.
+- Use legacy-equivalent composition for fov/filmOffset by preferring live/currentTarget equivalents.
+- Maintain strict settle thresholds and max-duration fallback to avoid hard hangs.
+
+## Parity helpers
+- `globalThis.__clearProjectProjectPilotParity()`
+- `globalThis.__printProjectProjectPilotParitySummary()`
+- `globalThis.__printProjectProjectPilotParitySamples()`
+
+Captured parity fields include mode, from/to project ids, sample buckets, view mode, camera deltas to resolved project, progress fields, completion reason, and progress easing source.
+
+## Rollback plan
+- Set `globalThis.__ENABLE_CAMERA_DIRECTOR_PROJECT_TO_PROJECT__ = false` (or remove override).
+- Behavior immediately returns to legacy without writer suppression.
+
+## Test checklist
+- Flag off: verify project→project remains legacy.
+- Flag on: verify project transitions trigger one pilot start per selection change.
+- Validate no start jump, no end pop, and final composition parity.
+- Verify overview/project, project/overview, and caseStudy-related transitions remain unaffected.
+
+## Non-goals
+- No changes to hero/overview/about transitions.
+- No changes to overview→project or project→overview pilot behavior.
+- No global tuning for fragments, particles, glow, or ring.

--- a/docs/camera-director-pilot-project-project.md
+++ b/docs/camera-director-pilot-project-project.md
@@ -42,3 +42,8 @@ Captured parity fields include mode, from/to project ids, sample buckets, view m
 - No changes to hero/overview/about transitions.
 - No changes to overview→project or project→overview pilot behavior.
 - No global tuning for fragments, particles, glow, or ring.
+
+## PR-14 tuning note (v2)
+- Updated project→project pilot easing label to `project-to-project:legacy-settle-ease-out-v2`.
+- Position easing was reduced from the prior over-aggressive front-load to better align with legacy 25/50/75 pacing while preserving no-start-jump/no-end-pop behavior.
+- LookAt still resolves early, but less aggressively than the previous iteration to avoid visibly finishing far ahead of facet rotation.

--- a/src/components/three/UnifiedCameraController.jsx
+++ b/src/components/three/UnifiedCameraController.jsx
@@ -2818,7 +2818,7 @@ const UnifiedCameraController = ({
         transitionKey: projectToProjectTransitionKey,
         fromProjectIdUnavailableReason,
         toProjectIdUnavailableReason,
-        progressEasingSource: 'project-to-project:default-smoothstep',
+        progressEasingSource: 'project-to-project:legacy-settle-ease-out',
         completionReason: 'not-detected',
         forceStart: true,
       });
@@ -3233,6 +3233,8 @@ const UnifiedCameraController = ({
       const isFirstPilotWrite = pilot.firstWriteLogged !== true;
       const writeProgress = isFirstPilotWrite ? 0 : pilotProgress;
       const projectOverviewEasedProgress = 1 - Math.pow(1 - writeProgress, 3.2);
+      const projectToProjectEasedProgress = 1 - Math.pow(1 - writeProgress, 5.2);
+      const projectToProjectLookAtProgress = 1 - Math.pow(1 - writeProgress, 9.5);
       if (pilot.direction === 'project-to-overview') {
         if (isFirstPilotWrite) {
           camera.position.copy(pilot.transition.fromPose.position);
@@ -3243,6 +3245,12 @@ const UnifiedCameraController = ({
             projectOverviewEasedProgress
           );
         }
+      } else if (pilot.direction === 'project-to-project') {
+        camera.position.lerpVectors(
+          pilot.transition.fromPose.position,
+          pilot.transition.toPose.position,
+          projectToProjectEasedProgress
+        );
       } else {
         const curveDriver = facetProgress == null ? writeProgress : Math.min(writeProgress, facetProgress);
         const laggedDriver = THREE.MathUtils.clamp(curveDriver - 0.05, 0, 1);
@@ -3253,13 +3261,24 @@ const UnifiedCameraController = ({
           easedPositionProgress
         );
       }
-      const appliedLookAt = (pilot.direction === 'project-to-overview' && !isFirstPilotWrite)
-        ? new THREE.Vector3().lerpVectors(
-            pilot.transition.fromPose.lookAt,
-            pilot.transition.toPose.lookAt,
-            projectOverviewEasedProgress
-          )
-        : (isFirstPilotWrite ? pilot.transition.fromPose.lookAt : step.pose.lookAt);
+      let appliedLookAt;
+      if (pilot.direction === 'project-to-overview' && !isFirstPilotWrite) {
+        appliedLookAt = new THREE.Vector3().lerpVectors(
+          pilot.transition.fromPose.lookAt,
+          pilot.transition.toPose.lookAt,
+          projectOverviewEasedProgress
+        );
+      } else if (pilot.direction === 'project-to-project') {
+        appliedLookAt = isFirstPilotWrite
+          ? pilot.transition.fromPose.lookAt
+          : new THREE.Vector3().lerpVectors(
+              pilot.transition.fromPose.lookAt,
+              pilot.transition.toPose.lookAt,
+              projectToProjectLookAtProgress
+            );
+      } else {
+        appliedLookAt = isFirstPilotWrite ? pilot.transition.fromPose.lookAt : step.pose.lookAt;
+      }
       camera.lookAt(appliedLookAt);
       camera.fov = (pilot.direction === 'project-to-overview' && !isFirstPilotWrite)
         ? THREE.MathUtils.lerp(pilot.transition.fromPose.fov, pilot.transition.toPose.fov, projectOverviewEasedProgress)
@@ -3425,7 +3444,7 @@ const UnifiedCameraController = ({
             console.log('[camera-director-pilot] project-to-project motion-curve-summary', {
               fromProjectId: pilot.fromProjectId ?? null,
               toProjectId: pilot.selectedProject ?? null,
-              progressEasingSource: 'project-to-project:default-smoothstep',
+              progressEasingSource: 'project-to-project:legacy-settle-ease-out',
               rawProgress: round4(pilotProgress),
               completionReason,
               durationSeconds: round4(durationSeconds),
@@ -3445,7 +3464,7 @@ const UnifiedCameraController = ({
       } else {
         sampleOverviewProjectPilotParity({ state, prevCameraState, nextCameraState, focusedProject: pilot.selectedProject ?? focusedProject ?? null });
         if (pilot.direction === 'project-to-project') {
-          sampleProjectProjectPilotParity({ state, prevCameraState, nextCameraState, fromProjectId: pilot.fromProjectId ?? null, toProjectId: pilot.selectedProject ?? null, progressEasingSource: 'project-to-project:default-smoothstep', completionReason: pilot.completedLogged ? 'thresholds-met' : null });
+          sampleProjectProjectPilotParity({ state, prevCameraState, nextCameraState, fromProjectId: pilot.fromProjectId ?? null, toProjectId: pilot.selectedProject ?? null, progressEasingSource: 'project-to-project:legacy-settle-ease-out', completionReason: pilot.completedLogged ? 'thresholds-met' : null });
         }
       }
       return;
@@ -3464,7 +3483,7 @@ const UnifiedCameraController = ({
       nextCameraState,
       fromProjectId: projectProjectFromId,
       toProjectId: projectProjectToId,
-      progressEasingSource: isProjectToProjectPilotEnabled() ? 'project-to-project:default-smoothstep' : 'legacy-camera-move-progress',
+      progressEasingSource: isProjectToProjectPilotEnabled() ? 'project-to-project:legacy-settle-ease-out' : 'legacy-camera-move-progress',
     });
 
     if (import.meta.env.DEV && pilotHandoffDebugRef.current.pending && animationData?.cameraState === 'project') {

--- a/src/components/three/UnifiedCameraController.jsx
+++ b/src/components/three/UnifiedCameraController.jsx
@@ -283,6 +283,7 @@ const UnifiedCameraController = ({
     pending: null,
   });
   const projectProjectActivationLogKeyRef = useRef(null);
+  const projectProjectActivationMatchedLogKeyRef = useRef(null);
   const previousSelectedProjectRef = useRef(null);
   const previousFramePoseRef = useRef({
     position: null,
@@ -2269,10 +2270,27 @@ const UnifiedCameraController = ({
     }
     const run = store.activeRun;
     const resolvedProject = run?.toProjectId ? getOverviewProjectResolvedPose('project', run.toProjectId) : null;
+    const targetPoseUnavailableReason = (!resolvedProject && run?.toProjectId)
+      ? 'resolved-project-pose-unavailable'
+      : (!run?.toProjectId ? 'to-project-id-missing' : null);
     if (!run) return;
     const liveLookAt = currentTarget.current?.lookAt ? currentTarget.current.lookAt.clone() : getCameraLookAtFromTransform();
-    const pushRow = (sampleType) => run.rows.push({ sampleType, state: animationData?.state ?? null, cameraState: animationData?.cameraState ?? null, viewMode: animationData?.viewMode ?? null, fromProjectId: run.fromProjectId, toProjectId: run.toProjectId, fromProjectIdUnavailableReason: run.fromProjectId ? null : (run.fromProjectIdUnavailableReason ?? 'from-project-id-missing'), toProjectIdUnavailableReason: run.toProjectId ? null : (run.toProjectIdUnavailableReason ?? 'to-project-id-missing'), liveDistanceToResolvedProjectPosition: resolvedProject ? safeDistance(camera.position, resolvedProject.position) : null, liveLookAtDeltaToResolvedProject: resolvedProject ? safeDistance(liveLookAt, resolvedProject.lookAt) : null, liveFovDeltaToResolvedProject: resolvedProject ? round4(Math.abs(camera.fov - (resolvedProject.fov ?? camera.fov))) : null, liveFilmOffsetDeltaToResolvedProject: resolvedProject ? round4(Math.abs((camera.filmOffset ?? 0) - (resolvedProject.filmOffset ?? 0))) : null, cameraMoveProgress: round4(cameraMoveProgressRef.current), facetRotationProgress: round4(globalThis?.__overviewProjectFacetDebug?.focusRotationProgress), completionReason: completionReason ?? run.completionReason, progressEasingSource });
-    if (isStart) pushRow('start');
+    const pushRow = (sampleType) => run.rows.push({ sampleType, state: animationData?.state ?? null, cameraState: animationData?.cameraState ?? null, viewMode: animationData?.viewMode ?? null, fromProjectId: run.fromProjectId, toProjectId: run.toProjectId, fromProjectIdUnavailableReason: run.fromProjectId ? null : (run.fromProjectIdUnavailableReason ?? 'from-project-id-missing'), toProjectIdUnavailableReason: run.toProjectId ? null : (run.toProjectIdUnavailableReason ?? 'to-project-id-missing'), targetPoseUnavailableReason, liveDistanceToResolvedProjectPosition: resolvedProject ? safeDistance(camera.position, resolvedProject.position) : null, liveLookAtDeltaToResolvedProject: resolvedProject ? safeDistance(liveLookAt, resolvedProject.lookAt) : null, liveFovDeltaToResolvedProject: resolvedProject ? round4(Math.abs(camera.fov - (resolvedProject.fov ?? camera.fov))) : null, liveFilmOffsetDeltaToResolvedProject: resolvedProject ? round4(Math.abs((camera.filmOffset ?? 0) - (resolvedProject.filmOffset ?? 0))) : null, cameraMoveProgress: round4(cameraMoveProgressRef.current), facetRotationProgress: round4(globalThis?.__overviewProjectFacetDebug?.focusRotationProgress), completionReason: completionReason ?? run.completionReason, progressEasingSource });
+    if (isStart) {
+      pushRow('start');
+      const rowsAfter = store.runs.flatMap((r) => r.rows);
+      const lastSample = rowsAfter[rowsAfter.length - 1] ?? null;
+      console.log('[camera-director-pilot] project-to-project parity-start-written', {
+        runId: run.id,
+        mode: run.mode,
+        fromProjectId: run.fromProjectId ?? null,
+        toProjectId: run.toProjectId ?? null,
+        sampleType: 'start',
+        parityStoreSampleCountAfter: rowsAfter.length,
+        parityStoreRunCountAfter: store.runs.length,
+        lastSample,
+      });
+    }
     const elapsed = state.clock.elapsedTime - run.startedAt;
     const normalizedTime = THREE.MathUtils.clamp(elapsed / 0.9, 0, 1);
     if (!run.bucket25 && normalizedTime >= 0.25) { run.bucket25 = true; pushRow('bucket-25%'); }
@@ -2659,6 +2677,25 @@ const UnifiedCameraController = ({
       }
     }
     if (shouldStartProjectToProjectPilot) {
+      const store = getProjectProjectPilotParityStore();
+      const runId = `${projectProjectFlagEnabled ? 'pilot' : 'legacy'}:${state.clock.elapsedTime}:${projectProjectFromId ?? 'unknown'}->${projectProjectToId ?? 'unknown'}`;
+      const activationMatchedLogKey = `${runId}:${previousProjectId ?? 'none'}:${currentProjectId ?? 'none'}:${nextState ?? 'none'}:${nextCameraState ?? 'none'}:${viewMode ?? 'none'}`;
+      if (projectProjectActivationMatchedLogKeyRef.current !== activationMatchedLogKey) {
+        projectProjectActivationMatchedLogKeyRef.current = activationMatchedLogKey;
+        const sampleCountBefore = store.runs.flatMap((run) => run.rows).length;
+        console.log('[camera-director-pilot] project-to-project activation-matched', {
+          fromProjectId: projectProjectFromId ?? null,
+          toProjectId: projectProjectToId ?? null,
+          previousProjectId: previousProjectId ?? null,
+          currentProjectId: currentProjectId ?? null,
+          state: nextState ?? null,
+          cameraState: nextCameraState ?? null,
+          viewMode: viewMode ?? null,
+          runId,
+          parityStoreSampleCountBefore: sampleCountBefore,
+          parityStoreRunCountBefore: store.runs.length,
+        });
+      }
       sampleProjectProjectPilotParity({
         state,
         prevCameraState,

--- a/src/components/three/UnifiedCameraController.jsx
+++ b/src/components/three/UnifiedCameraController.jsx
@@ -286,6 +286,7 @@ const UnifiedCameraController = ({
   const projectProjectActivationMatchedLogKeyRef = useRef(null);
   const projectProjectIdSnapshotLogKeyRef = useRef(null);
   const previousSelectedProjectRef = useRef(null);
+  const lastStableProjectIdRef = useRef(null);
   const previousFramePoseRef = useRef({
     position: null,
     lookAt: null,
@@ -2617,13 +2618,14 @@ const UnifiedCameraController = ({
       prevCameraState === 'project' &&
       nextCameraState === 'overview' &&
       viewMode !== 'caseStudy';
+    const lastStableProjectId = lastStableProjectIdRef.current ?? null;
     const previousProjectId = previousFocusedProject ?? previousSelectedProject ?? null;
     const currentProjectId = focusedProject ?? selectedProject ?? null;
-    const projectProjectFromId = previousProjectId ?? selectedProject ?? null;
-    const projectProjectToId = currentProjectId ?? previousFocusedProject ?? null;
+    const projectProjectFromId = lastStableProjectId ?? previousProjectId ?? selectedProject ?? null;
+    const projectProjectToId = focusedProject ?? selectedProject ?? null;
     const fromProjectIdUnavailableReason = projectProjectFromId ? null : 'missing-previous-focused-and-previous-selected-project';
     const toProjectIdUnavailableReason = projectProjectToId ? null : 'missing-focused-and-selected-project';
-    const projectChanged = Boolean(previousProjectId && currentProjectId && previousProjectId !== currentProjectId);
+    const projectChanged = Boolean(projectProjectFromId && projectProjectToId && projectProjectFromId !== projectProjectToId);
     const projectProjectFlagEnabled = isProjectToProjectPilotEnabled();
     const shouldStartProjectToProjectPilot =
       projectProjectFlagEnabled &&
@@ -2640,8 +2642,8 @@ const UnifiedCameraController = ({
               ? 'camera-state-not-project-project'
               : (viewMode === 'caseStudy'
                   ? 'view-mode-caseStudy'
-                  : (!previousProjectId || !currentProjectId
-                      ? 'previous-or-current-project-id-missing'
+                  : (!projectProjectFromId || !projectProjectToId
+                      ? 'from-or-to-project-id-missing'
                       : (projectChanged ? null : 'project-ids-not-changed')))));
     const isProjectRelatedState = nextCameraState === 'project' || prevCameraState === 'project' || viewMode === 'project' || Boolean(focusedProject) || Boolean(selectedProject);
     if (import.meta.env.DEV && projectProjectFlagEnabled && isProjectRelatedState) {
@@ -2688,11 +2690,12 @@ const UnifiedCameraController = ({
         nextState ?? 'none',
         nextCameraState ?? 'none',
         viewMode ?? 'none',
-        previousFocusedProject ?? 'none',
-        previousSelectedProject ?? 'none',
-        focusedProject ?? 'none',
-        selectedProject ?? 'none',
-        previousProjectId ?? 'none',
+          previousFocusedProject ?? 'none',
+          previousSelectedProject ?? 'none',
+          lastStableProjectId ?? 'none',
+          focusedProject ?? 'none',
+          selectedProject ?? 'none',
+          previousProjectId ?? 'none',
         currentProjectId ?? 'none',
         projectChanged ? 'changed' : 'same',
         shouldStartProjectToProjectPilot ? 'matched' : (projectProjectActivationRejectReason ?? 'not-matched'),
@@ -2711,6 +2714,7 @@ const UnifiedCameraController = ({
           projectChanged,
           focusedProject: focusedProject ?? null,
           selectedProject: selectedProject ?? null,
+          lastStableProjectId: lastStableProjectId ?? null,
           previousFocusedProject: previousFocusedProject ?? null,
           previousSelectedProject: previousSelectedProject ?? null,
           activationMatched: shouldStartProjectToProjectPilot,
@@ -2728,6 +2732,8 @@ const UnifiedCameraController = ({
         console.log('[camera-director-pilot] project-to-project activation-matched', {
           fromProjectId: projectProjectFromId ?? null,
           toProjectId: projectProjectToId ?? null,
+          focusedProject: focusedProject ?? null,
+          lastStableProjectId: lastStableProjectId ?? null,
           previousProjectId: previousProjectId ?? null,
           currentProjectId: currentProjectId ?? null,
           state: nextState ?? null,
@@ -3116,6 +3122,11 @@ const UnifiedCameraController = ({
     prevStateRef.current = nextState;
     prevCameraStateRef.current = nextCameraState;
     previousSelectedProjectRef.current = selectedProject;
+    if (focusedProject) {
+      lastStableProjectIdRef.current = focusedProject;
+    } else if (!nextCameraState || nextCameraState !== 'project') {
+      lastStableProjectIdRef.current = null;
+    }
 
     if (cameraDirectorPilotRef.current.active) {
       const pilot = cameraDirectorPilotRef.current;

--- a/src/components/three/UnifiedCameraController.jsx
+++ b/src/components/three/UnifiedCameraController.jsx
@@ -236,6 +236,8 @@ const UnifiedCameraController = ({
   const lastProjectToOverviewSourceProjectIdRef = useRef(null);
   const lastOverviewToProjectKeyRef = useRef(null);
   const blockedOverviewToProjectKeyRef = useRef(null);
+  const lastProjectToProjectHandledKeyRef = useRef(null);
+  const blockedProjectToProjectKeyRef = useRef(null);
   const startPoseLogKeyRef = useRef(null);
   const preStartContinuityLogKeyRef = useRef(null);
   const startContinuityLogKeyRef = useRef(null);
@@ -2589,6 +2591,8 @@ const UnifiedCameraController = ({
     if (returnedToOverview) {
       lastOverviewToProjectKeyRef.current = null;
       blockedOverviewToProjectKeyRef.current = null;
+      lastProjectToProjectHandledKeyRef.current = null;
+      blockedProjectToProjectKeyRef.current = null;
     }
     const transitionKey = [
       'overview-to-project',
@@ -2627,13 +2631,16 @@ const UnifiedCameraController = ({
     const toProjectIdUnavailableReason = projectProjectToId ? null : 'missing-focused-and-selected-project';
     const projectChanged = Boolean(projectProjectFromId && projectProjectToId && projectProjectFromId !== projectProjectToId);
     const projectProjectFlagEnabled = isProjectToProjectPilotEnabled();
+    const projectToProjectTransitionKey = `project-to-project:${projectProjectFromId ?? 'none'}->${projectProjectToId ?? 'none'}`;
+    const alreadyHandledProjectToProject = lastProjectToProjectHandledKeyRef.current === projectToProjectTransitionKey;
     const shouldStartProjectToProjectPilot =
       projectProjectFlagEnabled &&
       !cameraDirectorPilotRef.current.active &&
       prevCameraState === 'project' &&
       nextCameraState === 'project' &&
       projectChanged &&
-      viewMode !== 'caseStudy';
+      viewMode !== 'caseStudy' &&
+      !alreadyHandledProjectToProject;
     const projectProjectActivationRejectReason = !projectProjectFlagEnabled
       ? 'flag-disabled'
       : (cameraDirectorPilotRef.current.active
@@ -3080,9 +3087,34 @@ const UnifiedCameraController = ({
         };
         console.log('[camera-director-pilot] project-to-project pre-start-continuity', { fromProjectId: projectProjectFromId, toProjectId: projectProjectToId, deltaLookAt: round4(fromPose.lookAt.distanceTo(liveLookAt)) });
         console.log('[camera-director-pilot] project-to-project target-parity', { fromProjectId: projectProjectFromId, toProjectId: projectProjectToId, resolverFov: round4(destination.fov), pilotTargetFov: round4(toPose.fov), resolverFilmOffset: round4(destination.filmOffset), pilotTargetFilmOffset: round4(toPose.filmOffset) });
-        const transition = createCameraDirectorPilotTransition({ id: `project-to-project:${state.clock.elapsedTime}:${projectProjectFromId}->${projectProjectToId}`, fromPose, toPose, startedAt: state.clock.elapsedTime, durationSeconds: 0.9 });
+        const transition = createCameraDirectorPilotTransition({ id: projectToProjectTransitionKey, fromPose, toPose, startedAt: state.clock.elapsedTime, durationSeconds: 0.9 });
         cameraDirectorPilotRef.current = { active: true, transition, selectedProject: projectProjectToId, fromProjectId: projectProjectFromId, completedLogged: false, firstWriteLogged: false, direction: 'project-to-project' };
+        blockedProjectToProjectKeyRef.current = null;
+        lastProjectToProjectHandledKeyRef.current = projectToProjectTransitionKey;
         console.log('[camera-director-pilot] project-to-project start', { fromProjectId: projectProjectFromId, toProjectId: projectProjectToId });
+      }
+    } else if (
+      projectProjectFlagEnabled &&
+      prevCameraState === 'project' &&
+      nextCameraState === 'project' &&
+      (alreadyHandledProjectToProject || (
+        cameraDirectorPilotRef.current.active &&
+        cameraDirectorPilotRef.current.direction === 'project-to-project' &&
+        cameraDirectorPilotRef.current.transition?.id === projectToProjectTransitionKey
+      ))
+    ) {
+      const reason = alreadyHandledProjectToProject ? 'already-handled-transition-key' : 'same-transition-active';
+      const restartBlockKey = `${projectToProjectTransitionKey}:${reason}`;
+      if (import.meta.env.DEV && blockedProjectToProjectKeyRef.current !== restartBlockKey) {
+        blockedProjectToProjectKeyRef.current = restartBlockKey;
+        console.log('[camera-director-pilot] project-to-project restart-blocked', {
+          transitionKey: projectToProjectTransitionKey,
+          activeTransitionKey: cameraDirectorPilotRef.current.transition?.id ?? null,
+          lastHandledTransitionKey: lastProjectToProjectHandledKeyRef.current ?? null,
+          fromProjectId: projectProjectFromId ?? null,
+          toProjectId: projectProjectToId ?? null,
+          reason,
+        });
       }
     } else if (
       isOverviewToProjectPilotEnabled() &&

--- a/src/components/three/UnifiedCameraController.jsx
+++ b/src/components/three/UnifiedCameraController.jsx
@@ -2825,7 +2825,7 @@ const UnifiedCameraController = ({
         transitionKey: projectToProjectTransitionKey,
         fromProjectIdUnavailableReason,
         toProjectIdUnavailableReason,
-        progressEasingSource: 'project-to-project:legacy-settle-ease-out',
+        progressEasingSource: 'project-to-project:facet-synced-settle',
         completionReason: 'not-detected',
         forceStart: true,
       });
@@ -3263,7 +3263,7 @@ const UnifiedCameraController = ({
             easedProgress: round4(projectToProjectEasedProgress),
             cameraPositionProgress: round4(projectToProjectPositionProgress),
             facetProgressObserved: round4(facetProgress),
-            progressEasingSource: 'project-to-project:legacy-settle-ease-out',
+            progressEasingSource: 'project-to-project:facet-synced-settle',
             activeCurveFunction: 'power-ease-out-2.6-position / 4.5-lookAt',
             curvePathReached: true,
           });
@@ -3479,7 +3479,7 @@ const UnifiedCameraController = ({
             console.log('[camera-director-pilot] project-to-project motion-curve-summary', {
               fromProjectId: pilot.fromProjectId ?? null,
               toProjectId: pilot.selectedProject ?? null,
-              progressEasingSource: 'project-to-project:legacy-settle-ease-out',
+              progressEasingSource: 'project-to-project:facet-synced-settle',
               rawProgress: round4(pilotProgress),
               completionReason,
               durationSeconds: round4(durationSeconds),
@@ -3499,7 +3499,7 @@ const UnifiedCameraController = ({
       } else {
         sampleOverviewProjectPilotParity({ state, prevCameraState, nextCameraState, focusedProject: pilot.selectedProject ?? focusedProject ?? null });
         if (pilot.direction === 'project-to-project') {
-          sampleProjectProjectPilotParity({ state, prevCameraState, nextCameraState, fromProjectId: pilot.fromProjectId ?? null, toProjectId: pilot.selectedProject ?? null, progressEasingSource: 'project-to-project:legacy-settle-ease-out', completionReason: pilot.completedLogged ? 'thresholds-met' : null });
+          sampleProjectProjectPilotParity({ state, prevCameraState, nextCameraState, fromProjectId: pilot.fromProjectId ?? null, toProjectId: pilot.selectedProject ?? null, progressEasingSource: 'project-to-project:facet-synced-settle', completionReason: pilot.completedLogged ? 'thresholds-met' : null });
         }
       }
       return;
@@ -3518,7 +3518,7 @@ const UnifiedCameraController = ({
       nextCameraState,
       fromProjectId: projectProjectFromId,
       toProjectId: projectProjectToId,
-      progressEasingSource: isProjectToProjectPilotEnabled() ? 'project-to-project:legacy-settle-ease-out' : 'legacy-camera-move-progress',
+      progressEasingSource: isProjectToProjectPilotEnabled() ? 'project-to-project:facet-synced-settle' : 'legacy-camera-move-progress',
     });
 
     if (import.meta.env.DEV && pilotHandoffDebugRef.current.pending && animationData?.cameraState === 'project') {

--- a/src/components/three/UnifiedCameraController.jsx
+++ b/src/components/three/UnifiedCameraController.jsx
@@ -238,6 +238,7 @@ const UnifiedCameraController = ({
   const blockedOverviewToProjectKeyRef = useRef(null);
   const lastProjectToProjectHandledKeyRef = useRef(null);
   const blockedProjectToProjectKeyRef = useRef(null);
+  const blockedProjectToProjectStartKeyRef = useRef(null);
   const startPoseLogKeyRef = useRef(null);
   const preStartContinuityLogKeyRef = useRef(null);
   const startContinuityLogKeyRef = useRef(null);
@@ -2606,6 +2607,7 @@ const UnifiedCameraController = ({
       blockedOverviewToProjectKeyRef.current = null;
       lastProjectToProjectHandledKeyRef.current = null;
       blockedProjectToProjectKeyRef.current = null;
+      blockedProjectToProjectStartKeyRef.current = null;
     }
     const transitionKey = [
       'overview-to-project',
@@ -2654,6 +2656,21 @@ const UnifiedCameraController = ({
       projectChanged &&
       viewMode !== 'caseStudy' &&
       !alreadyHandledProjectToProject;
+    const projectToProjectResolvedAtStart = projectProjectToId ? getOverviewProjectResolvedPose('project', projectProjectToId) : null;
+    const projectToProjectLiveLookAt = currentTarget.current?.lookAt ? currentTarget.current.lookAt.clone() : getCameraLookAtFromTransform();
+    const projectToProjectStartPositionDelta = projectToProjectResolvedAtStart ? safeDistance(camera.position, projectToProjectResolvedAtStart.position) : null;
+    const projectToProjectStartLookAtDelta = projectToProjectResolvedAtStart ? safeDistance(projectToProjectLiveLookAt, projectToProjectResolvedAtStart.lookAt) : null;
+    const projectToProjectStartMoveProgress = round4(cameraMoveProgressRef.current);
+    const projectToProjectStartFacetProgress = round4(globalThis?.__overviewProjectFacetDebug?.focusRotationProgress);
+    const projectToProjectActivationTimingCandidate = ((projectToProjectStartPositionDelta != null && projectToProjectStartPositionDelta <= 0.02 && (projectToProjectStartMoveProgress ?? 1) >= 0.99 && (projectToProjectStartFacetProgress ?? 1) >= 0.99)
+      ? 'post-settle'
+      : ((projectToProjectStartMoveProgress ?? 0) <= 0.1 ? 'pre-transition' : 'mid-transition'));
+    const shouldBlockInvalidMidTransitionStart =
+      shouldStartProjectToProjectPilot &&
+      projectToProjectActivationTimingCandidate === 'mid-transition' &&
+      (projectToProjectStartMoveProgress ?? 0) >= 0.99 &&
+      (projectToProjectStartFacetProgress ?? 0) >= 0.99 &&
+      (projectToProjectStartLookAtDelta ?? Number.POSITIVE_INFINITY) <= 0.05;
     const projectProjectActivationRejectReason = !projectProjectFlagEnabled
       ? 'flag-disabled'
       : (cameraDirectorPilotRef.current.active
@@ -2743,7 +2760,21 @@ const UnifiedCameraController = ({
       }
     }
     if (shouldStartProjectToProjectPilot) {
-      if (alreadyHandledProjectToProject) {
+      if (shouldBlockInvalidMidTransitionStart) {
+        const startBlockKey = `${projectToProjectTransitionKey}:post-settle-or-invalid-mid-transition`;
+        if (import.meta.env.DEV && blockedProjectToProjectStartKeyRef.current !== startBlockKey) {
+          blockedProjectToProjectStartKeyRef.current = startBlockKey;
+          console.log('[camera-director-pilot] project-to-project start-blocked', {
+            transitionKey: projectToProjectTransitionKey,
+            activationTiming: projectToProjectActivationTimingCandidate,
+            cameraMoveProgress: projectToProjectStartMoveProgress,
+            facetRotationProgress: projectToProjectStartFacetProgress,
+            liveDistanceToResolvedProjectPosition: projectToProjectStartPositionDelta,
+            liveLookAtDeltaToResolvedProject: projectToProjectStartLookAtDelta,
+            reason: 'post-settle-or-invalid-mid-transition',
+          });
+        }
+      } else if (alreadyHandledProjectToProject) {
         const restartBlockKey = `${projectToProjectTransitionKey}:already-handled-transition-key`;
         if (import.meta.env.DEV && blockedProjectToProjectKeyRef.current !== restartBlockKey) {
           blockedProjectToProjectKeyRef.current = restartBlockKey;

--- a/src/components/three/UnifiedCameraController.jsx
+++ b/src/components/three/UnifiedCameraController.jsx
@@ -2004,7 +2004,7 @@ const UnifiedCameraController = ({
     const store = getProjectOverviewPilotParityStore();
     const mode = isProjectToOverviewPilotEnabled() ? 'pilot' : 'legacy';
     const isStart = prevCameraState === 'project' && nextCameraState === 'overview';
-    if (isStart) {
+    if (isStart && !store.activeRun) {
       store.activeRun = {
         id: `${mode}:${state.clock.elapsedTime}`,
         mode,
@@ -2256,22 +2256,22 @@ const UnifiedCameraController = ({
       store.activeRun = null;
     }
   };
-  const sampleProjectProjectPilotParity = ({ state, prevCameraState, nextCameraState, fromProjectId, toProjectId, progressEasingSource = null, completionReason = null }) => {
+  const sampleProjectProjectPilotParity = ({ state, prevCameraState, nextCameraState, fromProjectId, toProjectId, fromProjectIdUnavailableReason = null, toProjectIdUnavailableReason = null, progressEasingSource = null, completionReason = null, forceStart = false }) => {
     if (!import.meta.env.DEV) return;
     installOverviewProjectShadowHelpers();
     const store = getProjectProjectPilotParityStore();
     const mode = isProjectToProjectPilotEnabled() ? 'pilot' : 'legacy';
-    const isStart = prevCameraState === 'project' && nextCameraState === 'project' && fromProjectId !== toProjectId;
+    const isStart = forceStart || (prevCameraState === 'project' && nextCameraState === 'project' && fromProjectId !== toProjectId);
     if (isStart) {
-      store.activeRun = { id: `${mode}:${state.clock.elapsedTime}:${fromProjectId}->${toProjectId}`, mode, fromProjectId, toProjectId, startedAt: state.clock.elapsedTime, rows: [], completed: false, completionReason: 'not-detected', durationSeconds: null };
+      store.activeRun = { id: `${mode}:${state.clock.elapsedTime}:${fromProjectId ?? 'unknown'}->${toProjectId ?? 'unknown'}`, mode, fromProjectId, toProjectId, fromProjectIdUnavailableReason, toProjectIdUnavailableReason, startedAt: state.clock.elapsedTime, rows: [], completed: false, completionReason: 'not-detected', durationSeconds: null };
       store.runs.push(store.activeRun);
       if (store.runs.length > store.maxRuns) store.runs.shift();
     }
     const run = store.activeRun;
     const resolvedProject = run?.toProjectId ? getOverviewProjectResolvedPose('project', run.toProjectId) : null;
-    if (!run || !resolvedProject) return;
+    if (!run) return;
     const liveLookAt = currentTarget.current?.lookAt ? currentTarget.current.lookAt.clone() : getCameraLookAtFromTransform();
-    const pushRow = (sampleType) => run.rows.push({ sampleType, state: animationData?.state ?? null, cameraState: animationData?.cameraState ?? null, viewMode: animationData?.viewMode ?? null, fromProjectId: run.fromProjectId, toProjectId: run.toProjectId, liveDistanceToResolvedProjectPosition: safeDistance(camera.position, resolvedProject.position), liveLookAtDeltaToResolvedProject: safeDistance(liveLookAt, resolvedProject.lookAt), liveFovDeltaToResolvedProject: round4(Math.abs(camera.fov - (resolvedProject.fov ?? camera.fov))), liveFilmOffsetDeltaToResolvedProject: round4(Math.abs((camera.filmOffset ?? 0) - (resolvedProject.filmOffset ?? 0))), cameraMoveProgress: round4(cameraMoveProgressRef.current), facetRotationProgress: round4(globalThis?.__overviewProjectFacetDebug?.focusRotationProgress), completionReason: completionReason ?? run.completionReason, progressEasingSource });
+    const pushRow = (sampleType) => run.rows.push({ sampleType, state: animationData?.state ?? null, cameraState: animationData?.cameraState ?? null, viewMode: animationData?.viewMode ?? null, fromProjectId: run.fromProjectId, toProjectId: run.toProjectId, fromProjectIdUnavailableReason: run.fromProjectId ? null : (run.fromProjectIdUnavailableReason ?? 'from-project-id-missing'), toProjectIdUnavailableReason: run.toProjectId ? null : (run.toProjectIdUnavailableReason ?? 'to-project-id-missing'), liveDistanceToResolvedProjectPosition: resolvedProject ? safeDistance(camera.position, resolvedProject.position) : null, liveLookAtDeltaToResolvedProject: resolvedProject ? safeDistance(liveLookAt, resolvedProject.lookAt) : null, liveFovDeltaToResolvedProject: resolvedProject ? round4(Math.abs(camera.fov - (resolvedProject.fov ?? camera.fov))) : null, liveFilmOffsetDeltaToResolvedProject: resolvedProject ? round4(Math.abs((camera.filmOffset ?? 0) - (resolvedProject.filmOffset ?? 0))) : null, cameraMoveProgress: round4(cameraMoveProgressRef.current), facetRotationProgress: round4(globalThis?.__overviewProjectFacetDebug?.focusRotationProgress), completionReason: completionReason ?? run.completionReason, progressEasingSource });
     if (isStart) pushRow('start');
     const elapsed = state.clock.elapsedTime - run.startedAt;
     const normalizedTime = THREE.MathUtils.clamp(elapsed / 0.9, 0, 1);
@@ -2594,17 +2594,22 @@ const UnifiedCameraController = ({
       prevCameraState === 'project' &&
       nextCameraState === 'overview' &&
       viewMode !== 'caseStudy';
-    const projectProjectFromId = previousFocusedProject ?? previousSelectedProject ?? selectedProject ?? null;
-    const projectProjectToId = focusedProject ?? selectedProject ?? previousFocusedProject ?? null;
+    const previousProjectId = previousFocusedProject ?? previousSelectedProject ?? null;
+    const currentProjectId = focusedProject ?? selectedProject ?? null;
+    const projectProjectFromId = previousProjectId ?? selectedProject ?? null;
+    const projectProjectToId = currentProjectId ?? previousFocusedProject ?? null;
+    const fromProjectIdUnavailableReason = projectProjectFromId ? null : 'missing-previous-focused-and-previous-selected-project';
+    const toProjectIdUnavailableReason = projectProjectToId ? null : 'missing-focused-and-selected-project';
+    const projectChanged = Boolean(previousProjectId && currentProjectId && previousProjectId !== currentProjectId);
     const projectProjectFlagEnabled = isProjectToProjectPilotEnabled();
     const shouldStartProjectToProjectPilot =
       projectProjectFlagEnabled &&
       !cameraDirectorPilotRef.current.active &&
       prevCameraState === 'project' &&
       nextCameraState === 'project' &&
-      projectProjectFromId !== projectProjectToId &&
+      projectChanged &&
       viewMode !== 'caseStudy';
-    const projectProjectActivationReason = !projectProjectFlagEnabled
+    const projectProjectActivationRejectReason = !projectProjectFlagEnabled
       ? 'flag-disabled'
       : (cameraDirectorPilotRef.current.active
           ? 'another-pilot-active'
@@ -2612,7 +2617,9 @@ const UnifiedCameraController = ({
               ? 'camera-state-not-project-project'
               : (viewMode === 'caseStudy'
                   ? 'view-mode-caseStudy'
-                  : (projectProjectFromId === projectProjectToId ? 'project-ids-not-changed' : null))));
+                  : (!previousProjectId || !currentProjectId
+                      ? 'previous-or-current-project-id-missing'
+                      : (projectChanged ? null : 'project-ids-not-changed')))));
     const isProjectRelatedState = nextCameraState === 'project' || prevCameraState === 'project' || viewMode === 'project' || Boolean(focusedProject) || Boolean(selectedProject);
     if (import.meta.env.DEV && projectProjectFlagEnabled && isProjectRelatedState) {
       const activationLogKey = [
@@ -2625,7 +2632,10 @@ const UnifiedCameraController = ({
         previousSelectedProject ?? 'none',
         focusedProject ?? 'none',
         selectedProject ?? 'none',
-        shouldStartProjectToProjectPilot ? 'matched' : (projectProjectActivationReason ?? 'not-matched'),
+        previousProjectId ?? 'none',
+        currentProjectId ?? 'none',
+        projectChanged ? 'changed' : 'same',
+        shouldStartProjectToProjectPilot ? 'matched' : (projectProjectActivationRejectReason ?? 'not-matched'),
       ].join(':');
       if (projectProjectActivationLogKeyRef.current !== activationLogKey) {
         projectProjectActivationLogKeyRef.current = activationLogKey;
@@ -2634,16 +2644,33 @@ const UnifiedCameraController = ({
           state: nextState ?? null,
           cameraState: nextCameraState ?? null,
           viewMode: viewMode ?? null,
-          previousProjectId: projectProjectFromId,
-          currentProjectId: projectProjectToId,
+          previousProjectId,
+          currentProjectId,
+          fromProjectId: projectProjectFromId,
+          toProjectId: projectProjectToId,
+          projectChanged,
           focusedProject: focusedProject ?? null,
           selectedProject: selectedProject ?? null,
           previousFocusedProject: previousFocusedProject ?? null,
           previousSelectedProject: previousSelectedProject ?? null,
           activationMatched: shouldStartProjectToProjectPilot,
-          reason: shouldStartProjectToProjectPilot ? null : (projectProjectActivationReason ?? 'activation-conditions-not-met'),
+          activationRejectReason: shouldStartProjectToProjectPilot ? null : (projectProjectActivationRejectReason ?? 'activation-conditions-not-met'),
         });
       }
+    }
+    if (shouldStartProjectToProjectPilot) {
+      sampleProjectProjectPilotParity({
+        state,
+        prevCameraState,
+        nextCameraState,
+        fromProjectId: projectProjectFromId,
+        toProjectId: projectProjectToId,
+        fromProjectIdUnavailableReason,
+        toProjectIdUnavailableReason,
+        progressEasingSource: 'project-to-project:default-smoothstep',
+        completionReason: 'not-detected',
+        forceStart: true,
+      });
     }
 
     if (shouldStartOverviewToProjectPilot) {

--- a/src/components/three/UnifiedCameraController.jsx
+++ b/src/components/three/UnifiedCameraController.jsx
@@ -2825,7 +2825,7 @@ const UnifiedCameraController = ({
         transitionKey: projectToProjectTransitionKey,
         fromProjectIdUnavailableReason,
         toProjectIdUnavailableReason,
-        progressEasingSource: 'project-to-project:legacy-settle-ease-out-v2',
+        progressEasingSource: 'project-to-project:legacy-settle-ease-out',
         completionReason: 'not-detected',
         forceStart: true,
       });
@@ -3265,7 +3265,7 @@ const UnifiedCameraController = ({
             transitionKey: pilot.transition?.id ?? null,
             rawProgress: round4(writeProgress),
             easedProgress: round4(projectToProjectEasedProgress),
-            progressEasingSource: 'project-to-project:legacy-settle-ease-out-v2',
+            progressEasingSource: 'project-to-project:legacy-settle-ease-out',
             activeCurveFunction: 'piecewise-linear-legacy-target-remap',
             curvePathReached: true,
           });
@@ -3481,7 +3481,7 @@ const UnifiedCameraController = ({
             console.log('[camera-director-pilot] project-to-project motion-curve-summary', {
               fromProjectId: pilot.fromProjectId ?? null,
               toProjectId: pilot.selectedProject ?? null,
-              progressEasingSource: 'project-to-project:legacy-settle-ease-out-v2',
+              progressEasingSource: 'project-to-project:legacy-settle-ease-out',
               rawProgress: round4(pilotProgress),
               completionReason,
               durationSeconds: round4(durationSeconds),
@@ -3501,7 +3501,7 @@ const UnifiedCameraController = ({
       } else {
         sampleOverviewProjectPilotParity({ state, prevCameraState, nextCameraState, focusedProject: pilot.selectedProject ?? focusedProject ?? null });
         if (pilot.direction === 'project-to-project') {
-          sampleProjectProjectPilotParity({ state, prevCameraState, nextCameraState, fromProjectId: pilot.fromProjectId ?? null, toProjectId: pilot.selectedProject ?? null, progressEasingSource: 'project-to-project:legacy-settle-ease-out-v2', completionReason: pilot.completedLogged ? 'thresholds-met' : null });
+          sampleProjectProjectPilotParity({ state, prevCameraState, nextCameraState, fromProjectId: pilot.fromProjectId ?? null, toProjectId: pilot.selectedProject ?? null, progressEasingSource: 'project-to-project:legacy-settle-ease-out', completionReason: pilot.completedLogged ? 'thresholds-met' : null });
         }
       }
       return;
@@ -3520,7 +3520,7 @@ const UnifiedCameraController = ({
       nextCameraState,
       fromProjectId: projectProjectFromId,
       toProjectId: projectProjectToId,
-      progressEasingSource: isProjectToProjectPilotEnabled() ? 'project-to-project:legacy-settle-ease-out-v2' : 'legacy-camera-move-progress',
+      progressEasingSource: isProjectToProjectPilotEnabled() ? 'project-to-project:legacy-settle-ease-out' : 'legacy-camera-move-progress',
     });
 
     if (import.meta.env.DEV && pilotHandoffDebugRef.current.pending && animationData?.cameraState === 'project') {

--- a/src/components/three/UnifiedCameraController.jsx
+++ b/src/components/three/UnifiedCameraController.jsx
@@ -2546,6 +2546,7 @@ const UnifiedCameraController = ({
     const viewMode = animationData?.viewMode ?? null;
     const focusedProject = animationData?.focusedProject ?? null;
     const selectedProject = animationData?.selectedProject ?? null;
+    const previousFramePose = previousFramePoseRef.current ?? null;
     const previousFocusedProject = previousFramePose?.focusedProject ?? null;
     const cameFromOverview = prevCameraState === 'overview';
     const enteredProject = nextCameraState === 'project';

--- a/src/components/three/UnifiedCameraController.jsx
+++ b/src/components/three/UnifiedCameraController.jsx
@@ -2546,7 +2546,7 @@ const UnifiedCameraController = ({
     const viewMode = animationData?.viewMode ?? null;
     const focusedProject = animationData?.focusedProject ?? null;
     const selectedProject = animationData?.selectedProject ?? null;
-    const previousFocusedProject = previousFramePoseRef.current?.focusedProject ?? null;
+    const previousFocusedProject = previousFramePose?.focusedProject ?? null;
     const cameFromOverview = prevCameraState === 'overview';
     const enteredProject = nextCameraState === 'project';
     const returnedToOverview = nextCameraState === 'overview' && prevCameraState !== 'overview';

--- a/src/components/three/UnifiedCameraController.jsx
+++ b/src/components/three/UnifiedCameraController.jsx
@@ -284,6 +284,7 @@ const UnifiedCameraController = ({
   });
   const projectProjectActivationLogKeyRef = useRef(null);
   const projectProjectActivationMatchedLogKeyRef = useRef(null);
+  const projectProjectIdSnapshotLogKeyRef = useRef(null);
   const previousSelectedProjectRef = useRef(null);
   const previousFramePoseRef = useRef({
     position: null,
@@ -2569,6 +2570,10 @@ const UnifiedCameraController = ({
     const previousFramePose = previousFramePoseRef.current ?? null;
     const previousFocusedProject = previousFramePose?.focusedProject ?? null;
     const previousSelectedProject = previousSelectedProjectRef.current ?? null;
+    const animationDataProjectId = animationData?.projectInfo?.project ?? animationData?.activeProjectId ?? null;
+    const focusedProjectId = focusedProject ?? null;
+    const selectedProjectId = selectedProject ?? null;
+    const activeProjectId = animationDataProjectId ?? focusedProjectId ?? selectedProjectId ?? null;
     const cameFromOverview = prevCameraState === 'overview';
     const enteredProject = nextCameraState === 'project';
     const returnedToOverview = nextCameraState === 'overview' && prevCameraState !== 'overview';
@@ -2639,6 +2644,43 @@ const UnifiedCameraController = ({
                       ? 'previous-or-current-project-id-missing'
                       : (projectChanged ? null : 'project-ids-not-changed')))));
     const isProjectRelatedState = nextCameraState === 'project' || prevCameraState === 'project' || viewMode === 'project' || Boolean(focusedProject) || Boolean(selectedProject);
+    if (import.meta.env.DEV && projectProjectFlagEnabled && isProjectRelatedState) {
+      const snapshotKey = [
+        nextState ?? 'none',
+        nextCameraState ?? 'none',
+        viewMode ?? 'none',
+        focusedProject ?? 'none',
+        selectedProject ?? 'none',
+        previousFocusedProject ?? 'none',
+        previousSelectedProject ?? 'none',
+        currentProjectId ?? 'none',
+        previousProjectId ?? 'none',
+        activeProjectId ?? 'none',
+      ].join(':');
+      if (projectProjectIdSnapshotLogKeyRef.current !== snapshotKey) {
+        projectProjectIdSnapshotLogKeyRef.current = snapshotKey;
+        console.log('[camera-director-pilot] project-to-project id-snapshot', {
+          state: nextState ?? null,
+          cameraState: nextCameraState ?? null,
+          viewMode: viewMode ?? null,
+          focusedProject: focusedProject ?? null,
+          selectedProject: selectedProject ?? null,
+          previousFocusedProject: previousFocusedProject ?? null,
+          previousSelectedProject: previousSelectedProject ?? null,
+          currentProjectId: currentProjectId ?? null,
+          previousProjectId: previousProjectId ?? null,
+          activeProjectId: activeProjectId ?? null,
+          focusedProjectId: focusedProjectId ?? null,
+          selectedProjectId: selectedProjectId ?? null,
+          projectIndex: animationData?.projectInfo?.index ?? null,
+          previousProjectIndex: null,
+          currentTargetProjectId: currentTarget.current?.projectId ?? null,
+          animationDataProjectId: animationDataProjectId ?? null,
+          navigationIntentProjectId: animationData?.directProjectOverride ?? null,
+          scrollZoneProjectId: animationData?.zoneInfo?.project ?? null,
+        });
+      }
+    }
     if (import.meta.env.DEV && projectProjectFlagEnabled && isProjectRelatedState) {
       const activationLogKey = [
         prevState ?? 'none',

--- a/src/components/three/UnifiedCameraController.jsx
+++ b/src/components/three/UnifiedCameraController.jsx
@@ -240,6 +240,12 @@ const UnifiedCameraController = ({
   const blockedProjectToProjectKeyRef = useRef(null);
   const blockedProjectToProjectStartKeyRef = useRef(null);
   const projectProjectCurveLogKeyRef = useRef(null);
+  const projectProjectProgressMetaRef = useRef({
+    rawProgress: null,
+    easedProgress: null,
+    cameraPositionProgress: null,
+    facetProgressSource: 'unknown',
+  });
   const startPoseLogKeyRef = useRef(null);
   const preStartContinuityLogKeyRef = useRef(null);
   const startContinuityLogKeyRef = useRef(null);
@@ -2292,7 +2298,7 @@ const UnifiedCameraController = ({
             ? 'post-settle'
             : ((moveProgress ?? 0) <= 0.1 ? 'pre-transition' : 'mid-transition'))
         : null;
-      run.rows.push({ sampleType, activationTiming, state: animationData?.state ?? null, cameraState: animationData?.cameraState ?? null, viewMode: animationData?.viewMode ?? null, fromProjectId: run.fromProjectId, toProjectId: run.toProjectId, fromProjectIdUnavailableReason: run.fromProjectId ? null : (run.fromProjectIdUnavailableReason ?? 'from-project-id-missing'), toProjectIdUnavailableReason: run.toProjectId ? null : (run.toProjectIdUnavailableReason ?? 'to-project-id-missing'), targetPoseUnavailableReason, liveDistanceToResolvedProjectPosition: positionDelta, liveLookAtDeltaToResolvedProject: resolvedProject ? safeDistance(liveLookAt, resolvedProject.lookAt) : null, liveFovDeltaToResolvedProject: resolvedProject ? round4(Math.abs(camera.fov - (resolvedProject.fov ?? camera.fov))) : null, liveFilmOffsetDeltaToResolvedProject: resolvedProject ? round4(Math.abs((camera.filmOffset ?? 0) - (resolvedProject.filmOffset ?? 0))) : null, cameraMoveProgress: moveProgress, facetRotationProgress: facetProgress, rawProgress: moveProgress, easedProgress: moveProgress, completionReason: completionReason ?? run.completionReason, progressEasingSource });
+      run.rows.push({ sampleType, activationTiming, state: animationData?.state ?? null, cameraState: animationData?.cameraState ?? null, viewMode: animationData?.viewMode ?? null, fromProjectId: run.fromProjectId, toProjectId: run.toProjectId, fromProjectIdUnavailableReason: run.fromProjectId ? null : (run.fromProjectIdUnavailableReason ?? 'from-project-id-missing'), toProjectIdUnavailableReason: run.toProjectId ? null : (run.toProjectIdUnavailableReason ?? 'to-project-id-missing'), targetPoseUnavailableReason, liveDistanceToResolvedProjectPosition: positionDelta, liveLookAtDeltaToResolvedProject: resolvedProject ? safeDistance(liveLookAt, resolvedProject.lookAt) : null, liveFovDeltaToResolvedProject: resolvedProject ? round4(Math.abs(camera.fov - (resolvedProject.fov ?? camera.fov))) : null, liveFilmOffsetDeltaToResolvedProject: resolvedProject ? round4(Math.abs((camera.filmOffset ?? 0) - (resolvedProject.filmOffset ?? 0))) : null, cameraMoveProgress: moveProgress, facetRotationProgress: facetProgress, rawProgress: round4(projectProjectProgressMetaRef.current?.rawProgress), easedProgress: round4(projectProjectProgressMetaRef.current?.easedProgress), cameraPositionProgress: round4(projectProjectProgressMetaRef.current?.cameraPositionProgress), facetProgressSource: projectProjectProgressMetaRef.current?.facetProgressSource ?? null, completionReason: completionReason ?? run.completionReason, progressEasingSource });
       run.sampleTypesWritten?.add(sampleType);
     };
     if (isStart) {
@@ -3243,6 +3249,14 @@ const UnifiedCameraController = ({
       };
       const projectToProjectEasedProgress = remapProjectToProjectProgress(writeProgress);
       const projectToProjectLookAtProgress = 1 - Math.pow(1 - writeProgress, 7.2);
+      if (pilot.direction === 'project-to-project') {
+        projectProjectProgressMetaRef.current = {
+          rawProgress: writeProgress,
+          easedProgress: projectToProjectEasedProgress,
+          cameraPositionProgress: projectToProjectEasedProgress,
+          facetProgressSource: 'legacy-preserved',
+        };
+      }
       if (pilot.direction === 'project-to-project' && import.meta.env.DEV) {
         const curveLogKey = `${pilot.transition?.id ?? 'none'}:${Math.floor(writeProgress * 4)}`;
         if (projectProjectCurveLogKeyRef.current !== curveLogKey) {
@@ -3337,9 +3351,10 @@ const UnifiedCameraController = ({
         });
       }
       pilot.firstWriteLogged = true;
-      cameraMoveProgressRef.current = pilotProgress;
-      if (sharedCameraMoveProgressRef) sharedCameraMoveProgressRef.current = pilotProgress;
-      animationData?.setCameraMoveProgress?.(pilotProgress);
+      const publishedProgress = pilot.direction === 'project-to-project' ? 1 : pilotProgress;
+      cameraMoveProgressRef.current = publishedProgress;
+      if (sharedCameraMoveProgressRef) sharedCameraMoveProgressRef.current = publishedProgress;
+      animationData?.setCameraMoveProgress?.(publishedProgress);
       if (cameraSettledRef.current) {
         cameraSettledRef.current = false;
         animationData?.setCameraSettled?.(false);

--- a/src/components/three/UnifiedCameraController.jsx
+++ b/src/components/three/UnifiedCameraController.jsx
@@ -3249,11 +3249,14 @@ const UnifiedCameraController = ({
       };
       const projectToProjectEasedProgress = remapProjectToProjectProgress(writeProgress);
       const projectToProjectLookAtProgress = 1 - Math.pow(1 - writeProgress, 7.2);
+      const projectToProjectPositionProgress = facetProgress == null
+        ? projectToProjectEasedProgress
+        : Math.min(projectToProjectEasedProgress, THREE.MathUtils.clamp(facetProgress, 0, 1));
       if (pilot.direction === 'project-to-project') {
         projectProjectProgressMetaRef.current = {
           rawProgress: writeProgress,
           easedProgress: projectToProjectEasedProgress,
-          cameraPositionProgress: projectToProjectEasedProgress,
+          cameraPositionProgress: projectToProjectPositionProgress,
           facetProgressSource: 'legacy-preserved',
         };
       }
@@ -3265,6 +3268,8 @@ const UnifiedCameraController = ({
             transitionKey: pilot.transition?.id ?? null,
             rawProgress: round4(writeProgress),
             easedProgress: round4(projectToProjectEasedProgress),
+            cameraPositionProgress: round4(projectToProjectPositionProgress),
+            facetProgressObserved: round4(facetProgress),
             progressEasingSource: 'project-to-project:legacy-settle-ease-out',
             activeCurveFunction: 'piecewise-linear-legacy-target-remap',
             curvePathReached: true,
@@ -3285,7 +3290,7 @@ const UnifiedCameraController = ({
         camera.position.lerpVectors(
           pilot.transition.fromPose.position,
           pilot.transition.toPose.position,
-          projectToProjectEasedProgress
+          projectToProjectPositionProgress
         );
       } else {
         const curveDriver = facetProgress == null ? writeProgress : Math.min(writeProgress, facetProgress);

--- a/src/components/three/UnifiedCameraController.jsx
+++ b/src/components/three/UnifiedCameraController.jsx
@@ -3154,7 +3154,7 @@ const UnifiedCameraController = ({
         };
         console.log('[camera-director-pilot] project-to-project pre-start-continuity', { fromProjectId: projectProjectFromId, toProjectId: projectProjectToId, deltaLookAt: round4(fromPose.lookAt.distanceTo(liveLookAt)) });
         console.log('[camera-director-pilot] project-to-project target-parity', { fromProjectId: projectProjectFromId, toProjectId: projectProjectToId, resolverFov: round4(destination.fov), pilotTargetFov: round4(toPose.fov), resolverFilmOffset: round4(destination.filmOffset), pilotTargetFilmOffset: round4(toPose.filmOffset) });
-        const transition = createCameraDirectorPilotTransition({ id: projectToProjectTransitionKey, fromPose, toPose, startedAt: state.clock.elapsedTime, durationSeconds: 0.9 });
+        const transition = createCameraDirectorPilotTransition({ id: projectToProjectTransitionKey, fromPose, toPose, startedAt: state.clock.elapsedTime, durationSeconds: 1.0 });
         cameraDirectorPilotRef.current = { active: true, transition, selectedProject: projectProjectToId, fromProjectId: projectProjectFromId, completedLogged: false, firstWriteLogged: false, direction: 'project-to-project' };
         blockedProjectToProjectKeyRef.current = null;
         lastProjectToProjectHandledKeyRef.current = projectToProjectTransitionKey;

--- a/src/components/three/UnifiedCameraController.jsx
+++ b/src/components/three/UnifiedCameraController.jsx
@@ -274,6 +274,11 @@ const UnifiedCameraController = ({
     activeRun: null,
     maxRuns: 20,
   });
+  const projectProjectPilotParityRef = useRef({
+    runs: [],
+    activeRun: null,
+    maxRuns: 20,
+  });
   const pilotHandoffDebugRef = useRef({
     pending: null,
   });
@@ -299,6 +304,12 @@ const UnifiedCameraController = ({
   const isProjectToOverviewPilotEnabled = () => {
     if (typeof globalThis?.__ENABLE_CAMERA_DIRECTOR_PROJECT_TO_OVERVIEW__ === 'boolean') {
       return globalThis.__ENABLE_CAMERA_DIRECTOR_PROJECT_TO_OVERVIEW__;
+    }
+    return false;
+  };
+  const isProjectToProjectPilotEnabled = () => {
+    if (typeof globalThis?.__ENABLE_CAMERA_DIRECTOR_PROJECT_TO_PROJECT__ === 'boolean') {
+      return globalThis.__ENABLE_CAMERA_DIRECTOR_PROJECT_TO_PROJECT__;
     }
     return false;
   };
@@ -1683,6 +1694,16 @@ const UnifiedCameraController = ({
     }
     return globalThis.__projectOverviewPilotParityStore;
   };
+  const getProjectProjectPilotParityStore = () => {
+    if (typeof globalThis === 'undefined') return projectProjectPilotParityRef.current;
+    if (!globalThis.__projectProjectPilotParityStore) {
+      globalThis.__projectProjectPilotParityStore = projectProjectPilotParityRef.current;
+    }
+    if (globalThis.__projectProjectPilotParityStore !== projectProjectPilotParityRef.current) {
+      globalThis.__projectProjectPilotParityStore = projectProjectPilotParityRef.current;
+    }
+    return globalThis.__projectProjectPilotParityStore;
+  };
 
   const installOverviewProjectShadowHelpers = () => {
     if (!import.meta.env.DEV || typeof globalThis === 'undefined') return;
@@ -1947,6 +1968,33 @@ const UnifiedCameraController = ({
         pilotSampleCount: latestPilot?.sampleCount ?? 0,
       });
     };
+    globalThis.__clearProjectProjectPilotParity = () => {
+      const store = getProjectProjectPilotParityStore();
+      store.runs = [];
+      store.activeRun = null;
+      console.log('[project-project-pilot-parity] cleared');
+    };
+    globalThis.__printProjectProjectPilotParitySamples = () => {
+      const store = getProjectProjectPilotParityStore();
+      const rows = store.runs.flatMap((run) => run.rows.map((row) => ({ runId: run.id, mode: run.mode, ...row })));
+      if (!rows.length) return console.log('[project-project-pilot-parity] samples', []);
+      console.log('[project-project-pilot-parity] samples');
+      console.table(rows);
+    };
+    globalThis.__printProjectProjectPilotParitySummary = () => {
+      const store = getProjectProjectPilotParityStore();
+      const latestLegacy = [...store.runs].reverse().find((run) => run.mode === 'legacy') ?? null;
+      const latestPilot = [...store.runs].reverse().find((run) => run.mode === 'pilot') ?? null;
+      console.log('[project-project-pilot-parity] summary', {
+        runCount: store.runs.length,
+        legacyRunId: latestLegacy?.id ?? null,
+        pilotRunId: latestPilot?.id ?? null,
+        legacyCompleted: latestLegacy?.completed ?? false,
+        pilotCompleted: latestPilot?.completed ?? false,
+        legacyDurationSeconds: latestLegacy?.durationSeconds ?? null,
+        pilotDurationSeconds: latestPilot?.durationSeconds ?? null,
+      });
+    };
   };
   const sampleProjectOverviewPilotParity = ({ state, prevCameraState, nextCameraState, projectId, sourceProjectId, sourceProjectIdUnavailableReason = null }) => {
     if (!import.meta.env.DEV) return;
@@ -2205,6 +2253,32 @@ const UnifiedCameraController = ({
       pushRow('complete');
       store.activeRun = null;
     }
+  };
+  const sampleProjectProjectPilotParity = ({ state, prevCameraState, nextCameraState, fromProjectId, toProjectId, progressEasingSource = null, completionReason = null }) => {
+    if (!import.meta.env.DEV) return;
+    installOverviewProjectShadowHelpers();
+    const store = getProjectProjectPilotParityStore();
+    const mode = isProjectToProjectPilotEnabled() ? 'pilot' : 'legacy';
+    const isStart = prevCameraState === 'project' && nextCameraState === 'project' && Boolean(fromProjectId) && Boolean(toProjectId) && fromProjectId !== toProjectId;
+    if (isStart) {
+      store.activeRun = { id: `${mode}:${state.clock.elapsedTime}:${fromProjectId}->${toProjectId}`, mode, fromProjectId, toProjectId, startedAt: state.clock.elapsedTime, rows: [], completed: false, completionReason: 'not-detected', durationSeconds: null };
+      store.runs.push(store.activeRun);
+      if (store.runs.length > store.maxRuns) store.runs.shift();
+    }
+    const run = store.activeRun;
+    const resolvedProject = run?.toProjectId ? getOverviewProjectResolvedPose('project', run.toProjectId) : null;
+    if (!run || !resolvedProject) return;
+    const liveLookAt = currentTarget.current?.lookAt ? currentTarget.current.lookAt.clone() : getCameraLookAtFromTransform();
+    const pushRow = (sampleType) => run.rows.push({ sampleType, state: animationData?.state ?? null, cameraState: animationData?.cameraState ?? null, viewMode: animationData?.viewMode ?? null, fromProjectId: run.fromProjectId, toProjectId: run.toProjectId, liveDistanceToResolvedProjectPosition: safeDistance(camera.position, resolvedProject.position), liveLookAtDeltaToResolvedProject: safeDistance(liveLookAt, resolvedProject.lookAt), liveFovDeltaToResolvedProject: round4(Math.abs(camera.fov - (resolvedProject.fov ?? camera.fov))), liveFilmOffsetDeltaToResolvedProject: round4(Math.abs((camera.filmOffset ?? 0) - (resolvedProject.filmOffset ?? 0))), cameraMoveProgress: round4(cameraMoveProgressRef.current), facetRotationProgress: round4(globalThis?.__overviewProjectFacetDebug?.focusRotationProgress), completionReason: completionReason ?? run.completionReason, progressEasingSource });
+    if (isStart) pushRow('start');
+    const elapsed = state.clock.elapsedTime - run.startedAt;
+    const normalizedTime = THREE.MathUtils.clamp(elapsed / 0.9, 0, 1);
+    if (!run.bucket25 && normalizedTime >= 0.25) { run.bucket25 = true; pushRow('bucket-25%'); }
+    if (!run.sawMid && elapsed >= 0.45) { run.sawMid = true; pushRow('mid'); }
+    if (!run.bucket50 && normalizedTime >= 0.50) { run.bucket50 = true; pushRow('bucket-50%'); }
+    if (!run.bucket75 && normalizedTime >= 0.75) { run.bucket75 = true; pushRow('bucket-75%'); }
+    if (!run.sawViewModeChange && animationData?.viewMode === 'project') { run.sawViewModeChange = true; pushRow('viewMode-change'); }
+    if (!run.completed && completionReason) { run.completed = true; run.completionReason = completionReason; run.durationSeconds = round4(elapsed); pushRow('complete'); store.activeRun = null; }
   };
 
   const sampleOverviewProjectShadow = ({ state, delta, transitionActive, transitionKey, focusedProject, settled, prevCameraState, nextCameraState, nextState, viewMode }) => {
@@ -2471,6 +2545,8 @@ const UnifiedCameraController = ({
     const nextCameraState = animationData?.cameraState ?? null;
     const viewMode = animationData?.viewMode ?? null;
     const focusedProject = animationData?.focusedProject ?? null;
+    const selectedProject = animationData?.selectedProject ?? null;
+    const previousFocusedProject = previousFramePoseRef.current?.focusedProject ?? null;
     const cameFromOverview = prevCameraState === 'overview';
     const enteredProject = nextCameraState === 'project';
     const returnedToOverview = nextCameraState === 'overview' && prevCameraState !== 'overview';
@@ -2513,6 +2589,17 @@ const UnifiedCameraController = ({
       !cameraDirectorPilotRef.current.active &&
       prevCameraState === 'project' &&
       nextCameraState === 'overview' &&
+      viewMode !== 'caseStudy';
+    const projectProjectFromId = previousFocusedProject ?? selectedProject ?? null;
+    const projectProjectToId = focusedProject ?? selectedProject ?? null;
+    const shouldStartProjectToProjectPilot =
+      isProjectToProjectPilotEnabled() &&
+      !cameraDirectorPilotRef.current.active &&
+      prevCameraState === 'project' &&
+      nextCameraState === 'project' &&
+      Boolean(projectProjectFromId) &&
+      Boolean(projectProjectToId) &&
+      projectProjectFromId !== projectProjectToId &&
       viewMode !== 'caseStudy';
 
     if (shouldStartOverviewToProjectPilot) {
@@ -2816,6 +2903,31 @@ const UnifiedCameraController = ({
         cameraDirectorPilotRef.current = { active: true, transition, selectedProject: focusedProject, completedLogged: false, firstWriteLogged: false, direction: 'project-to-overview' };
         console.log('[camera-director-pilot] project-to-overview start', { projectId: focusedProject ?? null });
       }
+    } else if (shouldStartProjectToProjectPilot) {
+      const liveLookAt = currentTarget.current?.lookAt ? currentTarget.current.lookAt.clone() : getCameraLookAtFromTransform();
+      const previousFramePose = previousFramePoseRef.current ?? null;
+      const fromPose = {
+        position: camera.position.clone(),
+        lookAt: previousFramePose?.lookAt instanceof THREE.Vector3 ? previousFramePose.lookAt.clone() : liveLookAt.clone(),
+        fov: Number.isFinite(camera.fov) ? camera.fov : 45,
+        filmOffset: Number.isFinite(camera.filmOffset) ? camera.filmOffset : 0,
+      };
+      const destination = resolveCameraDestination({ destination: 'project', projectId: projectProjectToId, mode: 'selected', config, animationData, isMobile });
+      if (destination?.meta?.unresolved) {
+        console.log('[camera-director-pilot] project-to-project fallback', { reason: destination?.meta?.reason ?? 'unresolved-project', fromProjectId: projectProjectFromId, toProjectId: projectProjectToId });
+      } else {
+        const toPose = {
+          position: new THREE.Vector3(...destination.position),
+          lookAt: new THREE.Vector3(...destination.lookAt),
+          fov: Number.isFinite(currentTarget.current?.fov) ? currentTarget.current.fov : (Number.isFinite(destination.fov) ? destination.fov : fromPose.fov),
+          filmOffset: Number.isFinite(camera.filmOffset) ? camera.filmOffset : (Number.isFinite(destination.filmOffset) ? destination.filmOffset : fromPose.filmOffset),
+        };
+        console.log('[camera-director-pilot] project-to-project pre-start-continuity', { fromProjectId: projectProjectFromId, toProjectId: projectProjectToId, deltaLookAt: round4(fromPose.lookAt.distanceTo(liveLookAt)) });
+        console.log('[camera-director-pilot] project-to-project target-parity', { fromProjectId: projectProjectFromId, toProjectId: projectProjectToId, resolverFov: round4(destination.fov), pilotTargetFov: round4(toPose.fov), resolverFilmOffset: round4(destination.filmOffset), pilotTargetFilmOffset: round4(toPose.filmOffset) });
+        const transition = createCameraDirectorPilotTransition({ id: `project-to-project:${state.clock.elapsedTime}:${projectProjectFromId}->${projectProjectToId}`, fromPose, toPose, startedAt: state.clock.elapsedTime, durationSeconds: 0.9 });
+        cameraDirectorPilotRef.current = { active: true, transition, selectedProject: projectProjectToId, fromProjectId: projectProjectFromId, completedLogged: false, firstWriteLogged: false, direction: 'project-to-project' };
+        console.log('[camera-director-pilot] project-to-project start', { fromProjectId: projectProjectFromId, toProjectId: projectProjectToId });
+      }
     } else if (
       isOverviewToProjectPilotEnabled() &&
       cameFromOverview &&
@@ -2856,6 +2968,7 @@ const UnifiedCameraController = ({
 
     if (cameraDirectorPilotRef.current.active) {
       const pilot = cameraDirectorPilotRef.current;
+      const directionLabel = pilot.direction === 'project-to-overview' ? 'project-to-overview' : (pilot.direction === 'project-to-project' ? 'project-to-project' : 'overview-to-project');
       const step = updateCameraDirectorPilotTransition({
         transition: pilot.transition,
         now: state.clock.elapsedTime,
@@ -2909,7 +3022,7 @@ const UnifiedCameraController = ({
       currentTarget.current.lookAt.copy(appliedLookAt);
       currentTarget.current.fov = camera.fov;
       if (isFirstPilotWrite) {
-        console.log(`[camera-director-pilot] ${pilot.direction === 'project-to-overview' ? 'project-to-overview' : 'overview-to-project'} first-write-continuity`, {
+        console.log(`[camera-director-pilot] ${directionLabel} first-write-continuity`, {
           projectId: pilot.selectedProject,
           transitionKey: pilot.transition.id,
           progress: round4(writeProgress),
@@ -2972,10 +3085,10 @@ const UnifiedCameraController = ({
       const canCompleteByMaxDurationFallback = exceededMaxDuration && step.complete;
       const canComplete = canCompleteByThresholds || canCompleteByMissingProgressFallback || canCompleteByMaxDurationFallback;
       guardRecord(
-        pilot.direction === 'project-to-overview' ? 'CAMERA_DIRECTOR_PROJECT_TO_OVERVIEW' : 'CAMERA_DIRECTOR_OVERVIEW_TO_PROJECT',
+        pilot.direction === 'project-to-overview' ? 'CAMERA_DIRECTOR_PROJECT_TO_OVERVIEW' : (pilot.direction === 'project-to-project' ? 'CAMERA_DIRECTOR_PROJECT_TO_PROJECT' : 'CAMERA_DIRECTOR_OVERVIEW_TO_PROJECT'),
         ['position', 'lookAt', 'fov', 'filmOffset', 'currentTarget'],
         animationData?.cameraState || animationData?.state || 'unknown',
-        pilot.direction === 'project-to-overview' ? 'project-to-overview-pilot-active' : 'overview-to-project-pilot-active'
+        pilot.direction === 'project-to-overview' ? 'project-to-overview-pilot-active' : (pilot.direction === 'project-to-project' ? 'project-to-project-pilot-active' : 'overview-to-project-pilot-active')
       );
       if (canComplete && !pilot.completedLogged) {
         pilot.completedLogged = true;
@@ -3027,7 +3140,7 @@ const UnifiedCameraController = ({
         cameraSettledRef.current = true;
         animationData?.setCameraSettled?.(true);
         if (import.meta.env.DEV) {
-          console.log(`[camera-director-pilot] ${pilot.direction === 'project-to-overview' ? 'project-to-overview' : 'overview-to-project'} complete`, {
+          console.log(`[camera-director-pilot] ${directionLabel} complete`, {
             projectId: pilot.selectedProject,
             transitionId: pilot.transition.id,
             completionReason,
@@ -3054,6 +3167,15 @@ const UnifiedCameraController = ({
               elapsedAtFallback: completionReason === 'max-duration-fallback' ? round4(durationSeconds) : null,
               maxDuration: completionReason === 'max-duration-fallback' ? round4(MAX_PILOT_DURATION_SECONDS) : null,
             });
+          } else if (pilot.direction === 'project-to-project') {
+            console.log('[camera-director-pilot] project-to-project motion-curve-summary', {
+              fromProjectId: pilot.fromProjectId ?? null,
+              toProjectId: pilot.selectedProject ?? null,
+              progressEasingSource: 'project-to-project:default-smoothstep',
+              rawProgress: round4(pilotProgress),
+              completionReason,
+              durationSeconds: round4(durationSeconds),
+            });
           }
         }
       }
@@ -3068,6 +3190,9 @@ const UnifiedCameraController = ({
         });
       } else {
         sampleOverviewProjectPilotParity({ state, prevCameraState, nextCameraState, focusedProject: pilot.selectedProject ?? focusedProject ?? null });
+        if (pilot.direction === 'project-to-project') {
+          sampleProjectProjectPilotParity({ state, prevCameraState, nextCameraState, fromProjectId: pilot.fromProjectId ?? null, toProjectId: pilot.selectedProject ?? null, progressEasingSource: 'project-to-project:default-smoothstep', completionReason: pilot.completedLogged ? 'thresholds-met' : null });
+        }
       }
       return;
     }
@@ -3078,6 +3203,14 @@ const UnifiedCameraController = ({
       projectId: focusedProject,
       sourceProjectId: lastProjectToOverviewSourceProjectIdRef.current ?? previousFramePoseRef.current?.focusedProject ?? animationData?.selectedProject ?? focusedProject ?? null,
       sourceProjectIdUnavailableReason: 'previous-frame-focusedProject-and-selectedProject-missing',
+    });
+    sampleProjectProjectPilotParity({
+      state,
+      prevCameraState,
+      nextCameraState,
+      fromProjectId: projectProjectFromId,
+      toProjectId: projectProjectToId,
+      progressEasingSource: isProjectToProjectPilotEnabled() ? 'project-to-project:default-smoothstep' : 'legacy-camera-move-progress',
     });
 
     if (import.meta.env.DEV && pilotHandoffDebugRef.current.pending && animationData?.cameraState === 'project') {

--- a/src/components/three/UnifiedCameraController.jsx
+++ b/src/components/three/UnifiedCameraController.jsx
@@ -2261,14 +2261,15 @@ const UnifiedCameraController = ({
       store.activeRun = null;
     }
   };
-  const sampleProjectProjectPilotParity = ({ state, prevCameraState, nextCameraState, fromProjectId, toProjectId, fromProjectIdUnavailableReason = null, toProjectIdUnavailableReason = null, progressEasingSource = null, completionReason = null, forceStart = false }) => {
+  const sampleProjectProjectPilotParity = ({ state, prevCameraState, nextCameraState, fromProjectId, toProjectId, transitionKey = null, fromProjectIdUnavailableReason = null, toProjectIdUnavailableReason = null, progressEasingSource = null, completionReason = null, forceStart = false }) => {
     if (!import.meta.env.DEV) return;
     installOverviewProjectShadowHelpers();
     const store = getProjectProjectPilotParityStore();
     const mode = isProjectToProjectPilotEnabled() ? 'pilot' : 'legacy';
+    const stableTransitionKey = transitionKey ?? `project-to-project:${fromProjectId ?? 'none'}->${toProjectId ?? 'none'}`;
     const isStart = forceStart || (prevCameraState === 'project' && nextCameraState === 'project' && fromProjectId !== toProjectId);
-    if (isStart) {
-      store.activeRun = { id: `${mode}:${state.clock.elapsedTime}:${fromProjectId ?? 'unknown'}->${toProjectId ?? 'unknown'}`, mode, fromProjectId, toProjectId, fromProjectIdUnavailableReason, toProjectIdUnavailableReason, startedAt: state.clock.elapsedTime, rows: [], completed: false, completionReason: 'not-detected', durationSeconds: null };
+    if (isStart && !store.activeRun) {
+      store.activeRun = { id: `${mode}:${state.clock.elapsedTime}:${fromProjectId ?? 'unknown'}->${toProjectId ?? 'unknown'}`, transitionKey: stableTransitionKey, mode, fromProjectId, toProjectId, fromProjectIdUnavailableReason, toProjectIdUnavailableReason, startedAt: state.clock.elapsedTime, rows: [], sampleTypesWritten: new Set(), completed: false, completionReason: 'not-detected', durationSeconds: null };
       store.runs.push(store.activeRun);
       if (store.runs.length > store.maxRuns) store.runs.shift();
     }
@@ -2279,7 +2280,19 @@ const UnifiedCameraController = ({
       : (!run?.toProjectId ? 'to-project-id-missing' : null);
     if (!run) return;
     const liveLookAt = currentTarget.current?.lookAt ? currentTarget.current.lookAt.clone() : getCameraLookAtFromTransform();
-    const pushRow = (sampleType) => run.rows.push({ sampleType, state: animationData?.state ?? null, cameraState: animationData?.cameraState ?? null, viewMode: animationData?.viewMode ?? null, fromProjectId: run.fromProjectId, toProjectId: run.toProjectId, fromProjectIdUnavailableReason: run.fromProjectId ? null : (run.fromProjectIdUnavailableReason ?? 'from-project-id-missing'), toProjectIdUnavailableReason: run.toProjectId ? null : (run.toProjectIdUnavailableReason ?? 'to-project-id-missing'), targetPoseUnavailableReason, liveDistanceToResolvedProjectPosition: resolvedProject ? safeDistance(camera.position, resolvedProject.position) : null, liveLookAtDeltaToResolvedProject: resolvedProject ? safeDistance(liveLookAt, resolvedProject.lookAt) : null, liveFovDeltaToResolvedProject: resolvedProject ? round4(Math.abs(camera.fov - (resolvedProject.fov ?? camera.fov))) : null, liveFilmOffsetDeltaToResolvedProject: resolvedProject ? round4(Math.abs((camera.filmOffset ?? 0) - (resolvedProject.filmOffset ?? 0))) : null, cameraMoveProgress: round4(cameraMoveProgressRef.current), facetRotationProgress: round4(globalThis?.__overviewProjectFacetDebug?.focusRotationProgress), completionReason: completionReason ?? run.completionReason, progressEasingSource });
+    const pushRow = (sampleType) => {
+      if (run.sampleTypesWritten?.has(sampleType)) return;
+      const positionDelta = resolvedProject ? safeDistance(camera.position, resolvedProject.position) : null;
+      const moveProgress = round4(cameraMoveProgressRef.current);
+      const facetProgress = round4(globalThis?.__overviewProjectFacetDebug?.focusRotationProgress);
+      const activationTiming = sampleType === 'start'
+        ? ((positionDelta != null && positionDelta <= 0.02 && (moveProgress ?? 1) >= 0.99 && (facetProgress ?? 1) >= 0.99)
+            ? 'post-settle'
+            : ((moveProgress ?? 0) <= 0.1 ? 'pre-transition' : 'mid-transition'))
+        : null;
+      run.rows.push({ sampleType, activationTiming, state: animationData?.state ?? null, cameraState: animationData?.cameraState ?? null, viewMode: animationData?.viewMode ?? null, fromProjectId: run.fromProjectId, toProjectId: run.toProjectId, fromProjectIdUnavailableReason: run.fromProjectId ? null : (run.fromProjectIdUnavailableReason ?? 'from-project-id-missing'), toProjectIdUnavailableReason: run.toProjectId ? null : (run.toProjectIdUnavailableReason ?? 'to-project-id-missing'), targetPoseUnavailableReason, liveDistanceToResolvedProjectPosition: positionDelta, liveLookAtDeltaToResolvedProject: resolvedProject ? safeDistance(liveLookAt, resolvedProject.lookAt) : null, liveFovDeltaToResolvedProject: resolvedProject ? round4(Math.abs(camera.fov - (resolvedProject.fov ?? camera.fov))) : null, liveFilmOffsetDeltaToResolvedProject: resolvedProject ? round4(Math.abs((camera.filmOffset ?? 0) - (resolvedProject.filmOffset ?? 0))) : null, cameraMoveProgress: moveProgress, facetRotationProgress: facetProgress, completionReason: completionReason ?? run.completionReason, progressEasingSource });
+      run.sampleTypesWritten?.add(sampleType);
+    };
     if (isStart) {
       pushRow('start');
       const rowsAfter = store.runs.flatMap((r) => r.rows);
@@ -2730,6 +2743,20 @@ const UnifiedCameraController = ({
       }
     }
     if (shouldStartProjectToProjectPilot) {
+      if (alreadyHandledProjectToProject) {
+        const restartBlockKey = `${projectToProjectTransitionKey}:already-handled-transition-key`;
+        if (import.meta.env.DEV && blockedProjectToProjectKeyRef.current !== restartBlockKey) {
+          blockedProjectToProjectKeyRef.current = restartBlockKey;
+          console.log('[camera-director-pilot] project-to-project restart-blocked', {
+            transitionKey: projectToProjectTransitionKey,
+            activeTransitionKey: cameraDirectorPilotRef.current.transition?.id ?? null,
+            lastHandledTransitionKey: lastProjectToProjectHandledKeyRef.current ?? null,
+            fromProjectId: projectProjectFromId ?? null,
+            toProjectId: projectProjectToId ?? null,
+            reason: 'already-handled-transition-key',
+          });
+        }
+      } else {
       const store = getProjectProjectPilotParityStore();
       const runId = `${projectProjectFlagEnabled ? 'pilot' : 'legacy'}:${state.clock.elapsedTime}:${projectProjectFromId ?? 'unknown'}->${projectProjectToId ?? 'unknown'}`;
       const activationMatchedLogKey = `${runId}:${previousProjectId ?? 'none'}:${currentProjectId ?? 'none'}:${nextState ?? 'none'}:${nextCameraState ?? 'none'}:${viewMode ?? 'none'}`;
@@ -2757,12 +2784,14 @@ const UnifiedCameraController = ({
         nextCameraState,
         fromProjectId: projectProjectFromId,
         toProjectId: projectProjectToId,
+        transitionKey: projectToProjectTransitionKey,
         fromProjectIdUnavailableReason,
         toProjectIdUnavailableReason,
         progressEasingSource: 'project-to-project:default-smoothstep',
         completionReason: 'not-detected',
         forceStart: true,
       });
+      }
     }
 
     if (shouldStartOverviewToProjectPilot) {

--- a/src/components/three/UnifiedCameraController.jsx
+++ b/src/components/three/UnifiedCameraController.jsx
@@ -239,6 +239,7 @@ const UnifiedCameraController = ({
   const lastProjectToProjectHandledKeyRef = useRef(null);
   const blockedProjectToProjectKeyRef = useRef(null);
   const blockedProjectToProjectStartKeyRef = useRef(null);
+  const projectProjectCurveLogKeyRef = useRef(null);
   const startPoseLogKeyRef = useRef(null);
   const preStartContinuityLogKeyRef = useRef(null);
   const startContinuityLogKeyRef = useRef(null);
@@ -2291,7 +2292,7 @@ const UnifiedCameraController = ({
             ? 'post-settle'
             : ((moveProgress ?? 0) <= 0.1 ? 'pre-transition' : 'mid-transition'))
         : null;
-      run.rows.push({ sampleType, activationTiming, state: animationData?.state ?? null, cameraState: animationData?.cameraState ?? null, viewMode: animationData?.viewMode ?? null, fromProjectId: run.fromProjectId, toProjectId: run.toProjectId, fromProjectIdUnavailableReason: run.fromProjectId ? null : (run.fromProjectIdUnavailableReason ?? 'from-project-id-missing'), toProjectIdUnavailableReason: run.toProjectId ? null : (run.toProjectIdUnavailableReason ?? 'to-project-id-missing'), targetPoseUnavailableReason, liveDistanceToResolvedProjectPosition: positionDelta, liveLookAtDeltaToResolvedProject: resolvedProject ? safeDistance(liveLookAt, resolvedProject.lookAt) : null, liveFovDeltaToResolvedProject: resolvedProject ? round4(Math.abs(camera.fov - (resolvedProject.fov ?? camera.fov))) : null, liveFilmOffsetDeltaToResolvedProject: resolvedProject ? round4(Math.abs((camera.filmOffset ?? 0) - (resolvedProject.filmOffset ?? 0))) : null, cameraMoveProgress: moveProgress, facetRotationProgress: facetProgress, completionReason: completionReason ?? run.completionReason, progressEasingSource });
+      run.rows.push({ sampleType, activationTiming, state: animationData?.state ?? null, cameraState: animationData?.cameraState ?? null, viewMode: animationData?.viewMode ?? null, fromProjectId: run.fromProjectId, toProjectId: run.toProjectId, fromProjectIdUnavailableReason: run.fromProjectId ? null : (run.fromProjectIdUnavailableReason ?? 'from-project-id-missing'), toProjectIdUnavailableReason: run.toProjectId ? null : (run.toProjectIdUnavailableReason ?? 'to-project-id-missing'), targetPoseUnavailableReason, liveDistanceToResolvedProjectPosition: positionDelta, liveLookAtDeltaToResolvedProject: resolvedProject ? safeDistance(liveLookAt, resolvedProject.lookAt) : null, liveFovDeltaToResolvedProject: resolvedProject ? round4(Math.abs(camera.fov - (resolvedProject.fov ?? camera.fov))) : null, liveFilmOffsetDeltaToResolvedProject: resolvedProject ? round4(Math.abs((camera.filmOffset ?? 0) - (resolvedProject.filmOffset ?? 0))) : null, cameraMoveProgress: moveProgress, facetRotationProgress: facetProgress, rawProgress: moveProgress, easedProgress: moveProgress, completionReason: completionReason ?? run.completionReason, progressEasingSource });
       run.sampleTypesWritten?.add(sampleType);
     };
     if (isStart) {
@@ -2818,7 +2819,7 @@ const UnifiedCameraController = ({
         transitionKey: projectToProjectTransitionKey,
         fromProjectIdUnavailableReason,
         toProjectIdUnavailableReason,
-        progressEasingSource: 'project-to-project:legacy-settle-ease-out',
+        progressEasingSource: 'project-to-project:legacy-settle-ease-out-v2',
         completionReason: 'not-detected',
         forceStart: true,
       });
@@ -3233,8 +3234,29 @@ const UnifiedCameraController = ({
       const isFirstPilotWrite = pilot.firstWriteLogged !== true;
       const writeProgress = isFirstPilotWrite ? 0 : pilotProgress;
       const projectOverviewEasedProgress = 1 - Math.pow(1 - writeProgress, 3.2);
-      const projectToProjectEasedProgress = 1 - Math.pow(1 - writeProgress, 5.2);
-      const projectToProjectLookAtProgress = 1 - Math.pow(1 - writeProgress, 9.5);
+      const remapProjectToProjectProgress = (t) => {
+        const x = THREE.MathUtils.clamp(t, 0, 1);
+        if (x <= 0.25) return THREE.MathUtils.lerp(0, 0.73, x / 0.25);
+        if (x <= 0.50) return THREE.MathUtils.lerp(0.73, 0.93, (x - 0.25) / 0.25);
+        if (x <= 0.75) return THREE.MathUtils.lerp(0.93, 0.98, (x - 0.50) / 0.25);
+        return THREE.MathUtils.lerp(0.98, 1, (x - 0.75) / 0.25);
+      };
+      const projectToProjectEasedProgress = remapProjectToProjectProgress(writeProgress);
+      const projectToProjectLookAtProgress = 1 - Math.pow(1 - writeProgress, 7.2);
+      if (pilot.direction === 'project-to-project' && import.meta.env.DEV) {
+        const curveLogKey = `${pilot.transition?.id ?? 'none'}:${Math.floor(writeProgress * 4)}`;
+        if (projectProjectCurveLogKeyRef.current !== curveLogKey) {
+          projectProjectCurveLogKeyRef.current = curveLogKey;
+          console.log('[camera-director-pilot] project-to-project curve-path', {
+            transitionKey: pilot.transition?.id ?? null,
+            rawProgress: round4(writeProgress),
+            easedProgress: round4(projectToProjectEasedProgress),
+            progressEasingSource: 'project-to-project:legacy-settle-ease-out-v2',
+            activeCurveFunction: 'piecewise-linear-legacy-target-remap',
+            curvePathReached: true,
+          });
+        }
+      }
       if (pilot.direction === 'project-to-overview') {
         if (isFirstPilotWrite) {
           camera.position.copy(pilot.transition.fromPose.position);
@@ -3444,7 +3466,7 @@ const UnifiedCameraController = ({
             console.log('[camera-director-pilot] project-to-project motion-curve-summary', {
               fromProjectId: pilot.fromProjectId ?? null,
               toProjectId: pilot.selectedProject ?? null,
-              progressEasingSource: 'project-to-project:legacy-settle-ease-out',
+              progressEasingSource: 'project-to-project:legacy-settle-ease-out-v2',
               rawProgress: round4(pilotProgress),
               completionReason,
               durationSeconds: round4(durationSeconds),
@@ -3464,7 +3486,7 @@ const UnifiedCameraController = ({
       } else {
         sampleOverviewProjectPilotParity({ state, prevCameraState, nextCameraState, focusedProject: pilot.selectedProject ?? focusedProject ?? null });
         if (pilot.direction === 'project-to-project') {
-          sampleProjectProjectPilotParity({ state, prevCameraState, nextCameraState, fromProjectId: pilot.fromProjectId ?? null, toProjectId: pilot.selectedProject ?? null, progressEasingSource: 'project-to-project:legacy-settle-ease-out', completionReason: pilot.completedLogged ? 'thresholds-met' : null });
+          sampleProjectProjectPilotParity({ state, prevCameraState, nextCameraState, fromProjectId: pilot.fromProjectId ?? null, toProjectId: pilot.selectedProject ?? null, progressEasingSource: 'project-to-project:legacy-settle-ease-out-v2', completionReason: pilot.completedLogged ? 'thresholds-met' : null });
         }
       }
       return;
@@ -3483,7 +3505,7 @@ const UnifiedCameraController = ({
       nextCameraState,
       fromProjectId: projectProjectFromId,
       toProjectId: projectProjectToId,
-      progressEasingSource: isProjectToProjectPilotEnabled() ? 'project-to-project:legacy-settle-ease-out' : 'legacy-camera-move-progress',
+      progressEasingSource: isProjectToProjectPilotEnabled() ? 'project-to-project:legacy-settle-ease-out-v2' : 'legacy-camera-move-progress',
     });
 
     if (import.meta.env.DEV && pilotHandoffDebugRef.current.pending && animationData?.cameraState === 'project') {

--- a/src/components/three/UnifiedCameraController.jsx
+++ b/src/components/three/UnifiedCameraController.jsx
@@ -282,6 +282,8 @@ const UnifiedCameraController = ({
   const pilotHandoffDebugRef = useRef({
     pending: null,
   });
+  const projectProjectActivationLogKeyRef = useRef(null);
+  const previousSelectedProjectRef = useRef(null);
   const previousFramePoseRef = useRef({
     position: null,
     lookAt: null,
@@ -2259,7 +2261,7 @@ const UnifiedCameraController = ({
     installOverviewProjectShadowHelpers();
     const store = getProjectProjectPilotParityStore();
     const mode = isProjectToProjectPilotEnabled() ? 'pilot' : 'legacy';
-    const isStart = prevCameraState === 'project' && nextCameraState === 'project' && Boolean(fromProjectId) && Boolean(toProjectId) && fromProjectId !== toProjectId;
+    const isStart = prevCameraState === 'project' && nextCameraState === 'project' && fromProjectId !== toProjectId;
     if (isStart) {
       store.activeRun = { id: `${mode}:${state.clock.elapsedTime}:${fromProjectId}->${toProjectId}`, mode, fromProjectId, toProjectId, startedAt: state.clock.elapsedTime, rows: [], completed: false, completionReason: 'not-detected', durationSeconds: null };
       store.runs.push(store.activeRun);
@@ -2548,6 +2550,7 @@ const UnifiedCameraController = ({
     const selectedProject = animationData?.selectedProject ?? null;
     const previousFramePose = previousFramePoseRef.current ?? null;
     const previousFocusedProject = previousFramePose?.focusedProject ?? null;
+    const previousSelectedProject = previousSelectedProjectRef.current ?? null;
     const cameFromOverview = prevCameraState === 'overview';
     const enteredProject = nextCameraState === 'project';
     const returnedToOverview = nextCameraState === 'overview' && prevCameraState !== 'overview';
@@ -2591,17 +2594,57 @@ const UnifiedCameraController = ({
       prevCameraState === 'project' &&
       nextCameraState === 'overview' &&
       viewMode !== 'caseStudy';
-    const projectProjectFromId = previousFocusedProject ?? selectedProject ?? null;
-    const projectProjectToId = focusedProject ?? selectedProject ?? null;
+    const projectProjectFromId = previousFocusedProject ?? previousSelectedProject ?? selectedProject ?? null;
+    const projectProjectToId = focusedProject ?? selectedProject ?? previousFocusedProject ?? null;
+    const projectProjectFlagEnabled = isProjectToProjectPilotEnabled();
     const shouldStartProjectToProjectPilot =
-      isProjectToProjectPilotEnabled() &&
+      projectProjectFlagEnabled &&
       !cameraDirectorPilotRef.current.active &&
       prevCameraState === 'project' &&
       nextCameraState === 'project' &&
-      Boolean(projectProjectFromId) &&
-      Boolean(projectProjectToId) &&
       projectProjectFromId !== projectProjectToId &&
       viewMode !== 'caseStudy';
+    const projectProjectActivationReason = !projectProjectFlagEnabled
+      ? 'flag-disabled'
+      : (cameraDirectorPilotRef.current.active
+          ? 'another-pilot-active'
+          : (prevCameraState !== 'project' || nextCameraState !== 'project'
+              ? 'camera-state-not-project-project'
+              : (viewMode === 'caseStudy'
+                  ? 'view-mode-caseStudy'
+                  : (projectProjectFromId === projectProjectToId ? 'project-ids-not-changed' : null))));
+    const isProjectRelatedState = nextCameraState === 'project' || prevCameraState === 'project' || viewMode === 'project' || Boolean(focusedProject) || Boolean(selectedProject);
+    if (import.meta.env.DEV && projectProjectFlagEnabled && isProjectRelatedState) {
+      const activationLogKey = [
+        prevState ?? 'none',
+        prevCameraState ?? 'none',
+        nextState ?? 'none',
+        nextCameraState ?? 'none',
+        viewMode ?? 'none',
+        previousFocusedProject ?? 'none',
+        previousSelectedProject ?? 'none',
+        focusedProject ?? 'none',
+        selectedProject ?? 'none',
+        shouldStartProjectToProjectPilot ? 'matched' : (projectProjectActivationReason ?? 'not-matched'),
+      ].join(':');
+      if (projectProjectActivationLogKeyRef.current !== activationLogKey) {
+        projectProjectActivationLogKeyRef.current = activationLogKey;
+        console.log('[camera-director-pilot] project-to-project activation-check', {
+          flagEnabled: projectProjectFlagEnabled,
+          state: nextState ?? null,
+          cameraState: nextCameraState ?? null,
+          viewMode: viewMode ?? null,
+          previousProjectId: projectProjectFromId,
+          currentProjectId: projectProjectToId,
+          focusedProject: focusedProject ?? null,
+          selectedProject: selectedProject ?? null,
+          previousFocusedProject: previousFocusedProject ?? null,
+          previousSelectedProject: previousSelectedProject ?? null,
+          activationMatched: shouldStartProjectToProjectPilot,
+          reason: shouldStartProjectToProjectPilot ? null : (projectProjectActivationReason ?? 'activation-conditions-not-met'),
+        });
+      }
+    }
 
     if (shouldStartOverviewToProjectPilot) {
       const liveLookAt = currentTarget.current?.lookAt
@@ -2966,6 +3009,7 @@ const UnifiedCameraController = ({
 
     prevStateRef.current = nextState;
     prevCameraStateRef.current = nextCameraState;
+    previousSelectedProjectRef.current = selectedProject;
 
     if (cameraDirectorPilotRef.current.active) {
       const pilot = cameraDirectorPilotRef.current;

--- a/src/components/three/UnifiedCameraController.jsx
+++ b/src/components/three/UnifiedCameraController.jsx
@@ -3240,15 +3240,8 @@ const UnifiedCameraController = ({
       const isFirstPilotWrite = pilot.firstWriteLogged !== true;
       const writeProgress = isFirstPilotWrite ? 0 : pilotProgress;
       const projectOverviewEasedProgress = 1 - Math.pow(1 - writeProgress, 3.2);
-      const remapProjectToProjectProgress = (t) => {
-        const x = THREE.MathUtils.clamp(t, 0, 1);
-        if (x <= 0.25) return THREE.MathUtils.lerp(0, 0.73, x / 0.25);
-        if (x <= 0.50) return THREE.MathUtils.lerp(0.73, 0.93, (x - 0.25) / 0.25);
-        if (x <= 0.75) return THREE.MathUtils.lerp(0.93, 0.98, (x - 0.50) / 0.25);
-        return THREE.MathUtils.lerp(0.98, 1, (x - 0.75) / 0.25);
-      };
-      const projectToProjectEasedProgress = remapProjectToProjectProgress(writeProgress);
-      const projectToProjectLookAtProgress = 1 - Math.pow(1 - writeProgress, 7.2);
+      const projectToProjectEasedProgress = 1 - Math.pow(1 - writeProgress, 2.6);
+      const projectToProjectLookAtProgress = 1 - Math.pow(1 - writeProgress, 4.5);
       const projectToProjectPositionProgress = facetProgress == null
         ? projectToProjectEasedProgress
         : Math.min(projectToProjectEasedProgress, THREE.MathUtils.clamp(facetProgress, 0, 1));
@@ -3271,7 +3264,7 @@ const UnifiedCameraController = ({
             cameraPositionProgress: round4(projectToProjectPositionProgress),
             facetProgressObserved: round4(facetProgress),
             progressEasingSource: 'project-to-project:legacy-settle-ease-out',
-            activeCurveFunction: 'piecewise-linear-legacy-target-remap',
+            activeCurveFunction: 'power-ease-out-2.6-position / 4.5-lookAt',
             curvePathReached: true,
           });
         }

--- a/src/components/three/UnifiedCrystalScene.jsx
+++ b/src/components/three/UnifiedCrystalScene.jsx
@@ -897,9 +897,27 @@ const UnifiedCrystalScene = forwardRef(({
     (facetKey) => getProjectIdByAnyKey(facetKey),
     []
   );
+  const projectSelectionSignalLogRef = useRef({ from: null, to: null, clicked: null });
 
   const selectProjectAndNavigate = useCallback((projectKey) => {
     if (!projectKey) return;
+    if (import.meta.env.DEV) {
+      const fromProjectId = animationData?.focusedProject ?? null;
+      const logKey = `${fromProjectId ?? 'none'}->${projectKey}`;
+      const prevKey = `${projectSelectionSignalLogRef.current.from ?? 'none'}->${projectSelectionSignalLogRef.current.to ?? 'none'}`;
+      if (logKey !== prevKey || projectSelectionSignalLogRef.current.clicked !== projectKey) {
+        projectSelectionSignalLogRef.current = { from: fromProjectId, to: projectKey, clicked: projectKey };
+        console.log('[camera-director-pilot] project-selection-signal', {
+          fromProjectId,
+          toProjectId: projectKey,
+          clickedProjectId: projectKey,
+          previousSelected: null,
+          previousFocused: fromProjectId,
+          resultingSelected: projectKey,
+          resultingFocused: projectKey,
+        });
+      }
+    }
 
     const sectionNode = typeof document !== 'undefined'
       ? document.getElementById(`project-${projectKey}`)
@@ -924,7 +942,7 @@ const UnifiedCrystalScene = forwardRef(({
     const sectionStart = ANIMATION_CONFIG.projectSections?.[projectKey]?.start;
     if (sectionStart === undefined || sectionStart === null) return;
     scrollToProgress?.(sectionStart, 'auto');
-  }, [onDirectProjectSelect, scrollToProgress, scrollToProject]);
+  }, [animationData?.focusedProject, onDirectProjectSelect, scrollToProgress, scrollToProject]);
 
   const handleFacetClick = useCallback((facetKey) => {
     if (!inActiveOverview) return;


### PR DESCRIPTION
### Motivation
- Introduce a conservative, flag-gated CameraDirector pilot for direct project → project selected-project transitions while preserving legacy behavior by default. 
- Provide parity instrumentation and bounded diagnostics to evaluate pilot vs legacy composition and motion without affecting other transition flows. 
- Keep the feature off by default and avoid changing overview↔project, hero, about, caseStudy, or global visual systems.

### Description
- Added a boolean feature flag `globalThis.__ENABLE_CAMERA_DIRECTOR_PROJECT_TO_PROJECT__` and helper `isProjectToProjectPilotEnabled()` that defaults to disabled when unset. 
- Implemented conservative activation and start logic that only triggers when `prevCameraState === 'project'`, `nextCameraState === 'project'`, a distinct source/target selected project id is available, no other pilot is active, and `viewMode !== 'caseStudy'`. 
- Added parity storage, sampling, and developer helpers (`__clearProjectProjectPilotParity()`, `__printProjectProjectPilotParitySummary()`, `__printProjectProjectPilotParitySamples()`), plus bounded diagnostics logs for `start`, `pre-start-continuity`, `first-write-continuity`, `target-parity`, `motion-curve-summary`, `complete`, and `fallback`. 
- Wired the project→project pilot into the existing pilot transition machinery preserving live fromPose capture, protecting against pre-start lookAt snaps, resolving the target with conservative fov/filmOffset choices, reusing the established progress/settle thresholds and handoff checks, and added documentation in `docs/camera-director-pilot-project-project.md`.

### Testing
- Ran the production build via `npm run build` (Vite) and the build completed successfully without errors. 
- No automated test suites were modified; the change is gated by the flag so default (flag-off) runtime behavior remains the legacy code path.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a138966948c8328a5bf9b37a1e57954)