### PR TITLE
Add Milestone C cinematic timeline for Hero → Overview pilot

### DIFF
--- a/docs/camera-director-pilot-hero-overview.md
+++ b/docs/camera-director-pilot-hero-overview.md
@@ -262,3 +262,43 @@ With the pilot flag on, test Hero → Overview and look specifically for:
 ### Out of scope for Milestone C
 
 No fragments, particles, glow, ring, material, layout, UI, object explosion timing, About-route behavior, or non-Hero→Overview routes were intentionally changed.
+
+## Milestone C follow-up: first-write live hold-pose lock
+
+The first Milestone C implementation proved that the phase hold concept works, but visual testing showed a start jump: the pilot could hold the activation/scaffold pose instead of the actual rendered Hero orbit pose at the moment the pilot first owned the camera. That made the first run jump farther back than the visible Hero camera, and later runs could appear to snap to an orbit-start/baseline pose.
+
+The fix keeps the activation capture for diagnostics, but it no longer treats that early capture as the authoritative hold source for active camera ownership. On the first active `HERO_OVERVIEW_PILOT` camera write, immediately before writing any held camera pose, the pilot now locks the active hold pose from the live rendered camera transform:
+
+- `camera.position.clone()`
+- `camera.getWorldDirection(...) + camera.position` for lookAt
+- `camera.up.clone()`
+- `camera.quaternion.clone()`
+- current `camera.fov`
+- current `camera.filmOffset`
+
+That locked first-write hold pose becomes the source for `fractureCharge`, `explosionImpulse`, `bulletTimeSlowdown`, and the start of `overviewTravel`. It is not recaptured during the run.
+
+The first active pilot write also forces camera travel progress to `0` for that frame, so the pilot captures the visible live camera and writes the same pose back. Diagnostics compare the live camera immediately before the first pilot write against the held pose written by the pilot:
+
+- `activationFromPoseSource`
+- `activeHoldPoseSource`
+- `holdPoseLockedAtFrame`
+- `holdPoseLockedAtPhase`
+- `holdPoseLockedAfterHeroOrbitWrite`
+- `liveCameraBeforeFirstPilotWriteX/Y/Z`
+- `liveLookAtBeforeFirstPilotWriteX/Y/Z`
+- `heldCameraX/Y/Z`
+- `heldLookAtX/Y/Z`
+- `holdPosePositionDeltaFromLiveAtLock`
+- `holdPoseLookAtDeltaFromLiveAtLock`
+- `holdPoseQuaternionDeltaFromLiveAtLock`
+- `startJumpDistance`
+- `startLookAtJumpDistance`
+- `firstPilotWriteMovedCamera`
+- `firstPilotWriteMoveDistance`
+- `respectsCurrentHeroOrbitPose`
+- `orbitPhaseOrAngleAtCapture`
+
+`globalThis.__printHeroOverviewPilotCinematic?.()` now reports the hold-pose source, lock phase/frame, start jump, first-write move distance, current-orbit-respect status, first travel phase, configured travel start, and per-phase camera distance totals.
+
+Rollback remains the same: disable `globalThis.__ENABLE_CAMERA_DIRECTOR_HERO_OVERVIEW__` or leave the default flag-off path active. No fragments, particles, materials, styling, About behavior, object explosion timing, or other routes are affected by this hold-pose lock.

--- a/docs/camera-director-pilot-hero-overview.md
+++ b/docs/camera-director-pilot-hero-overview.md
@@ -194,3 +194,71 @@ The proposed pilot should:
 - At pilot completion, before the normal overview branch can resume, the pilot now clears the legacy fracture/explosion camera takeover flags that previously caused post-handoff tilt/pop regressions: `fractureTiltActiveRef.current = false`, `fractureTiltRef.current = 0`, and `heroExplosionTransitionRef.current.active = false`.
 - Completion and handoff diagnostics now record whether fracture/explosion takeover flags were active at completion, whether they were cleared before the first normal overview frame, and whether post-pilot fracture re-entry was detected.
 - The canonical-up guard from PR-24 remains in place; PR-25 layers the known-good live-lookAt and takeover-clear protections on top without changing flag-off legacy behavior, object/facet explosion timing, or the pilot's baseline-parity camera curve.
+
+## Milestone C: explicit cinematic camera phase timeline
+
+Milestone C is the first cinematic refinement pass for the flag-on Hero → Overview owning pilot. It does **not** attempt final art direction polish; it only gives the pilot an explicit, tunable camera choreography timeline so future passes can tune the Overwatch / Play-of-the-Game style beat structure without re-opening camera ownership conflicts.
+
+### Flag and rollback safety
+- The pilot remains disabled by default.
+- Enable only in DEV with `globalThis.__ENABLE_CAMERA_DIRECTOR_HERO_OVERVIEW__ = true` or the existing `VITE_CAMERA_DIRECTOR_HERO_OVERVIEW_PILOT` DEV flag.
+- Flag-off behavior still uses the legacy Hero → Overview path.
+- Rollback is immediate: turn the flag off and the Milestone C timeline is not used.
+- Milestone C keeps the PR-25 guardrails: live from-pose capture, camera-world-direction lookAt capture, `hero-overview-legacy-final-pose` target parity, target `fov: 44`, target `filmOffset: 0`, monotonic pilot progress, canonical up at completion, and fracture/explosion takeover flag clearing.
+
+### Camera phase timeline
+
+The flag-on pilot now owns a dedicated `HERO_OVERVIEW_PILOT_CAMERA_TIMELINE` in `UnifiedCameraController.jsx`:
+
+| Phase | Progress window | Camera mode | Starting behavior |
+| --- | ---: | --- | --- |
+| `fractureCharge` | `0.00 → 0.16` | `hold` | Hold exact captured live Hero camera pose. |
+| `explosionImpulse` | `0.16 → 0.26` | `impactHold` | Hold exact captured live Hero camera pose. |
+| `bulletTimeSlowdown` | `0.26 → 0.42` | `suspendedHold` | Hold exact captured live Hero camera pose for the conservative first pass. |
+| `overviewTravel` | `0.42 → 0.88` | `travel` | Main camera interpolation to final Overview, using `expoOut`. |
+| `overviewSettle` | `0.88 → 1.00` | `settle` | Lock exactly onto final Overview pose, canonical up, `fov: 44`, `filmOffset: 0`. |
+
+This means the camera should no longer dolly toward Overview during the fracture/charge, explosion impulse, or bullet-time slowdown beats. The first intentional travel should begin at pilot global progress `0.42`, inside `overviewTravel`.
+
+### How to tune timing
+
+Adjust only the constants in `HERO_OVERVIEW_PILOT_CAMERA_TIMELINE` for this pass:
+- Move `overviewTravel.start` earlier/later to control when the dolly begins.
+- Move `overviewTravel.end` to control how long the main travel lasts.
+- Move `overviewSettle.start` with `overviewTravel.end` so settle remains the final stabilization window.
+- Change `overviewTravel.easing` if a later pass needs a different travel feel.
+
+Keep phase ranges monotonic and contiguous between `0` and `1`. Avoid routing gaps; the owning pilot should write a stable camera pose every frame.
+
+### Diagnostics
+
+Milestone C adds/updates per-frame pilot diagnostics with:
+- `pilotCinematicMilestone: "Milestone C"`
+- phase metadata: `cameraMode`, `phaseStart`, `phaseEnd`, `phaseLocalProgress`
+- camera travel metadata: `cameraTravelProgress`, `cameraTravelEasedProgress`, `cameraTravelEasing`
+- hold metadata: `heldCameraPosition`, `heldLookAt`, `isHoldingCamera`, `fovChangedDuringHold`, `filmOffsetChangedDuringHold`
+- travel metadata: `firstTravelFrame`, `travelStartTime`, `travelStartProgress`, `travelDuration`, `settleStartProgress`, `finalPoseLocked`
+- cumulative per-phase camera movement: `distanceMovedDuringFractureCharge`, `distanceMovedDuringExplosionImpulse`, `distanceMovedDuringBulletTimeSlowdown`, `distanceMovedDuringOverviewTravel`, `distanceMovedDuringOverviewSettle`
+
+New helper:
+
+```js
+globalThis.__printHeroOverviewPilotCinematic?.();
+```
+
+It summarizes hold phases, first actual travel phase, camera distance moved per phase, whether `fractureCharge` and `explosionImpulse` stayed still, whether travel begins in `overviewTravel`, whether final target parity passes, whether the up/roll guard remains clean, and whether a competing writer appeared.
+
+### Visual test focus
+
+With the pilot flag on, test Hero → Overview and look specifically for:
+1. No start jump from Hero into the pilot.
+2. Camera holds during `fractureCharge`.
+3. Camera still does not obviously dolly toward Overview during `explosionImpulse`.
+4. `bulletTimeSlowdown` reads as a short suspended moment.
+5. The main Overview travel begins intentionally in `overviewTravel`.
+6. The final Overview composition matches the existing Overview target.
+7. No end tilt/roll, and no `HERO_OVERVIEW_PILOT <> FORCED_HERO_TO_OVERVIEW` conflict.
+
+### Out of scope for Milestone C
+
+No fragments, particles, glow, ring, material, layout, UI, object explosion timing, About-route behavior, or non-Hero→Overview routes were intentionally changed.

--- a/docs/camera-director-pilot-hero-overview.md
+++ b/docs/camera-director-pilot-hero-overview.md
@@ -334,3 +334,27 @@ The trace summarizes and tables the 10-frame pre-activation window and first 5 p
 - Whether the pilot hold matches the visible Hero pose.
 
 `__printHeroOverviewPilotCinematic?.()` also reports `lastWriterBeforePilotLock`, `lastHeroWriterBeforePilotLock`, `lastHeroOrbitPoseBeforePilotLock`, `lastAuthoritativeHeroPoseBeforePilotLock`, `distanceBetweenPilotHoldPoseAndHeroOrbit`, `distanceBetweenPilotHoldPoseAndAuthoritativeHero`, `doesPilotHoldMatchHeroOrbit`, and `doesPilotHoldMatchAuthoritativeHero`.
+
+## Milestone C follow-up: visible composition trace
+
+The previous visible-Hero-pose attempt still fell back to `first-active-pilot-write-live-camera-transform` in runtime diagnostics. The most likely implementation issue was that the recency check depended on `state.clock.frame`, which may be absent/unstable in React Three Fiber clock data, so a valid last rendered Hero pose could be rejected as not recent. The camera controller now keeps its own monotonically increasing `cameraFrameIndexRef` for pilot/trace windows and uses that for visible-Hero-pose recency.
+
+A new DEV-only visible composition trace has also been added:
+
+```js
+globalThis.__printHeroOverviewVisibleCompositionTrace?.();
+globalThis.__clearHeroOverviewVisibleCompositionTrace?.();
+```
+
+The trace records the 20 frames before Hero → Overview activation and the first 10 pilot frames. It compares raw camera pose, camera world pose, currentTarget, previousFramePose, the last recorded Hero-orbit state, camera parent world transform, and crystal scene transform snapshots published by `UnifiedCrystalScene`.
+
+The helper summarizes:
+- whether raw camera position moved during Hero orbit
+- whether camera world position moved during Hero orbit
+- whether camera quaternion changed during Hero orbit
+- whether filmOffset changed during Hero orbit
+- whether scene root / crystal group transforms moved during Hero orbit
+- the best visible Hero pose candidate relative to the pilot hold
+- whether the visible orbit appears camera-, scene-, or projection-based
+
+This pass intentionally keeps the fix narrow: it improves the visible-pose recency mechanism and adds evidence to identify whether the remaining visual snap is camera-based, scene/object-based, projection-based, or state-order based. It does not tune cinematic timing, object explosion timing, fragments, particles, materials, styling, About behavior, or other routes.

--- a/docs/camera-director-pilot-hero-overview.md
+++ b/docs/camera-director-pilot-hero-overview.md
@@ -302,3 +302,35 @@ The first active pilot write also forces camera travel progress to `0` for that 
 `globalThis.__printHeroOverviewPilotCinematic?.()` now reports the hold-pose source, lock phase/frame, start jump, first-write move distance, current-orbit-respect status, first travel phase, configured travel start, and per-phase camera distance totals.
 
 Rollback remains the same: disable `globalThis.__ENABLE_CAMERA_DIRECTOR_HERO_OVERVIEW__` or leave the default flag-off path active. No fragments, particles, materials, styling, About behavior, object explosion timing, or other routes are affected by this hold-pose lock.
+
+## Milestone C follow-up: pre-pilot hero writer trace and visible-pose source
+
+Follow-up diagnostics showed that the first-write live camera lock can still be too late if the live camera has already been reset by an upstream Hero writer before the pilot locks the hold pose. The pilot now keeps a DEV-only record of the last rendered Hero camera pose and prefers that last visible Hero pose when locking the Hero → Overview hold source.
+
+Current Hero writer finding:
+- The `AUTHORITATIVE_HERO` path is the active rendered Hero writer for the authoritative plain-Hero branch.
+- The previous `AUTHORITATIVE_HERO <> heroOrbit` CameraWriteGuard conflict was caused by duplicate DEV guard labels in the same authoritative Hero path, not by two independent rendered camera writers winning in the same frame.
+- The old `HERO_ORBIT` branch is still traced if it runs, but the pilot's safe source is now the last visible Hero pose recorded from whichever Hero writer actually rendered most recently.
+
+The pilot hold lock now uses this order:
+1. Last visible Hero pose recorded from the rendered Hero writer within the recent pre-pilot window.
+2. First-active-pilot-write live camera transform only as a fallback.
+
+This stored visible Hero pose includes position, lookAt, up, quaternion, fov, filmOffset, frame/time, writer id/reason, and hero orbit angle/polar metadata. It becomes the source for `fractureCharge`, `explosionImpulse`, `bulletTimeSlowdown`, and the start of `overviewTravel`.
+
+New helper:
+
+```js
+globalThis.__printHeroOverviewPrePilotHeroTrace?.();
+```
+
+The trace summarizes and tables the 10-frame pre-activation window and first 5 pilot frames, including:
+- Hero writer id/reason and pose after write.
+- Last visible Hero pose before pilot lock.
+- Last authoritative Hero pose before pilot lock.
+- Pilot locked hold pose.
+- Distance between Hero writer poses.
+- Distance between pilot hold and the last visible Hero pose.
+- Whether the pilot hold matches the visible Hero pose.
+
+`__printHeroOverviewPilotCinematic?.()` also reports `lastWriterBeforePilotLock`, `lastHeroWriterBeforePilotLock`, `lastHeroOrbitPoseBeforePilotLock`, `lastAuthoritativeHeroPoseBeforePilotLock`, `distanceBetweenPilotHoldPoseAndHeroOrbit`, `distanceBetweenPilotHoldPoseAndAuthoritativeHero`, `doesPilotHoldMatchHeroOrbit`, and `doesPilotHoldMatchAuthoritativeHero`.

--- a/src/components/three/UnifiedCameraController.jsx
+++ b/src/components/three/UnifiedCameraController.jsx
@@ -379,6 +379,15 @@ const UnifiedCameraController = ({
     viewMode: null,
     focusedProject: null,
   });
+  const lastVisibleHeroPoseRef = useRef(null);
+  const lastHeroOrbitRenderedPoseRef = useRef(null);
+  const lastAuthoritativeHeroRenderedPoseRef = useRef(null);
+  const heroOverviewPrePilotHeroTraceRef = useRef({
+    rows: [],
+    maxRows: 180,
+    pilotActivationFrame: null,
+    pilotFirstWriteFrame: null,
+  });
 
   const isOverviewToProjectPilotEnabled = () => {
     // WARNING: Experimental pilot only; not production-ready.
@@ -1630,6 +1639,7 @@ const UnifiedCameraController = ({
   const logCameraWrite = (state, branch, reason, lookAtTarget = null, projectionUpdated = false, returns = false) => {
     const writesByBranch = {
       AUTHORITATIVE_HERO: ["position", "lookAt", "filmOffset"],
+      HERO_ORBIT: ["position", "lookAt", "filmOffset"],
       FORCED_HERO_TO_OVERVIEW: ["position", "lookAt", "filmOffset", "currentTarget"],
       FORCED_OVERVIEW_TO_HERO: ["position", "lookAt", "filmOffset", "currentTarget"],
       TRANSITION: ["position", "lookAt", "filmOffset", "currentTarget"],
@@ -1749,7 +1759,7 @@ const UnifiedCameraController = ({
   const quaternionToPlain = (q) => ({ x: round4(q?.x), y: round4(q?.y), z: round4(q?.z), w: round4(q?.w) });
   const safeDistance = (a, b) => (a && b ? round4(a.distanceTo(b)) : null);
   const quaternionAngleDelta = (q1, q2) => (q1 && q2 ? round4(q1.angleTo(q2)) : null);
-  const cloneHeroOverviewLiveCameraPose = (source = 'live-camera-transform') => {
+  const cloneHeroOverviewLiveCameraPose = (source = 'live-camera-transform', meta = {}) => {
     const lookAt = getCameraLookAtFromTransform();
     return {
       position: camera.position.clone(),
@@ -1759,8 +1769,31 @@ const UnifiedCameraController = ({
       up: camera.up.clone(),
       quaternion: camera.quaternion.clone(),
       source,
+      ...meta,
     };
   };
+  const cloneHeroOverviewStoredPose = (pose, source = pose?.source ?? 'stored-hero-pose') => (pose ? {
+    ...pose,
+    position: pose.position?.clone?.() ?? null,
+    lookAt: pose.lookAt?.clone?.() ?? null,
+    up: pose.up?.clone?.() ?? null,
+    quaternion: pose.quaternion?.clone?.() ?? null,
+    source,
+  } : null);
+  const heroOverviewPoseToPlain = (pose) => (pose ? {
+    source: pose.source ?? null,
+    writerId: pose.writerId ?? null,
+    writerReason: pose.writerReason ?? null,
+    frame: pose.frame ?? null,
+    t: round4(pose.t),
+    position: vectorToPlain(pose.position),
+    lookAt: vectorToPlain(pose.lookAt),
+    fov: round4(pose.fov),
+    filmOffset: round4(pose.filmOffset),
+    heroOrbitAngle: round4(pose.heroOrbitAngle),
+    heroPolarAngle: round4(pose.heroPolarAngle),
+  } : null);
+  const distanceBetweenHeroOverviewPoses = (a, b) => (a?.position && b?.position ? a.position.distanceTo(b.position) : null);
   const getCanonicalCameraUp = () => new THREE.Vector3(0, 1, 0);
   const getUpDeltaFromWorldUp = (up = camera.up) => (up ? round4(up.clone().normalize().distanceTo(getCanonicalCameraUp())) : null);
   const getRollDeltaFromWorldUp = (up = camera.up) => {
@@ -2046,6 +2079,82 @@ const UnifiedCameraController = ({
     const store = getHeroOverviewPilotDiagnosticsStore();
     store.samples.push(sample);
     if (store.samples.length > store.maxSamples) store.samples.shift();
+  };
+
+  const getHeroOverviewPrePilotHeroTraceStore = () => {
+    if (typeof globalThis === 'undefined') return heroOverviewPrePilotHeroTraceRef.current;
+    if (!globalThis.__heroOverviewPrePilotHeroTraceStore) {
+      globalThis.__heroOverviewPrePilotHeroTraceStore = heroOverviewPrePilotHeroTraceRef.current;
+    }
+    if (globalThis.__heroOverviewPrePilotHeroTraceStore !== heroOverviewPrePilotHeroTraceRef.current) {
+      globalThis.__heroOverviewPrePilotHeroTraceStore = heroOverviewPrePilotHeroTraceRef.current;
+    }
+    return globalThis.__heroOverviewPrePilotHeroTraceStore;
+  };
+  const pushHeroOverviewPrePilotHeroTrace = (row) => {
+    if (!import.meta.env.DEV) return;
+    const store = getHeroOverviewPrePilotHeroTraceStore();
+    store.rows.push({ sampleIndex: store.rows.length, ...row });
+    if (store.rows.length > store.maxRows) {
+      const overflow = store.rows.length - store.maxRows;
+      store.rows.splice(0, overflow);
+      store.rows.forEach((entry, index) => { entry.sampleIndex = index; });
+    }
+  };
+  const markHeroOverviewPilotActivationTrace = (frame) => {
+    if (!import.meta.env.DEV) return;
+    getHeroOverviewPrePilotHeroTraceStore().pilotActivationFrame = frame;
+  };
+  const markHeroOverviewPilotFirstWriteTrace = (frame) => {
+    if (!import.meta.env.DEV) return;
+    const store = getHeroOverviewPrePilotHeroTraceStore();
+    if (store.pilotFirstWriteFrame == null) store.pilotFirstWriteFrame = frame;
+  };
+  const captureHeroOverviewRenderedHeroPose = ({ source, writerId, writerReason, state, lookAt = null, phase = 'hero' }) => {
+    const pose = cloneHeroOverviewLiveCameraPose(source, {
+      writerId,
+      writerReason,
+      frame: state.clock.frame,
+      t: state.clock.elapsedTime,
+      phase,
+      heroOrbitAngle: heroOrbitAngle.current,
+      heroPolarAngle: heroPolarAngleRef.current,
+      heroOrbitActive: Boolean(isOrbitingRef.current),
+      authoritativeHeroActive: writerId === 'AUTHORITATIVE_HERO',
+    });
+    if (lookAt?.isVector3) pose.lookAt = lookAt.clone();
+    if (writerId === 'AUTHORITATIVE_HERO') {
+      lastAuthoritativeHeroRenderedPoseRef.current = cloneHeroOverviewStoredPose(pose, source);
+    }
+    if (writerId === 'HERO_ORBIT' || writerId === 'AUTHORITATIVE_HERO') {
+      lastHeroOrbitRenderedPoseRef.current = cloneHeroOverviewStoredPose(pose, source);
+      lastVisibleHeroPoseRef.current = cloneHeroOverviewStoredPose(pose, source);
+    }
+    pushHeroOverviewPrePilotHeroTrace({
+      eventType: 'hero-writer-after-write',
+      frame: state.clock.frame,
+      t: round4(state.clock.elapsedTime),
+      state: animationData?.state ?? null,
+      cameraState: animationData?.cameraState ?? null,
+      viewMode: animationData?.viewMode ?? null,
+      phase,
+      selectedProject: animationData?.selectedProject ?? null,
+      writerId,
+      writerReason,
+      cameraPosition: vectorToPlain(pose.position),
+      cameraLookAt: vectorToPlain(pose.lookAt),
+      fov: round4(pose.fov),
+      filmOffset: round4(pose.filmOffset),
+      authoritativeHeroPose: heroOverviewPoseToPlain(lastAuthoritativeHeroRenderedPoseRef.current),
+      heroOrbitPose: heroOverviewPoseToPlain(lastHeroOrbitRenderedPoseRef.current),
+      finalCameraPoseAtEndOfFrame: heroOverviewPoseToPlain(pose),
+      distanceBetweenHeroOrbitAndAuthoritativeHero: round4(distanceBetweenHeroOverviewPoses(lastHeroOrbitRenderedPoseRef.current, lastAuthoritativeHeroRenderedPoseRef.current)),
+      heroOrbitAngle: round4(heroOrbitAngle.current),
+      heroPolarAngle: round4(heroPolarAngleRef.current),
+      heroOrbitActive: Boolean(isOrbitingRef.current),
+      authoritativeHeroActive: writerId === 'AUTHORITATIVE_HERO',
+    });
+    return pose;
   };
 
   const installOverviewProjectShadowHelpers = () => {
@@ -2476,6 +2585,10 @@ const UnifiedCameraController = ({
       const store = getHeroOverviewPilotDiagnosticsStore();
       store.samples = [];
       store.lastSummary = null;
+      const prePilotStore = getHeroOverviewPrePilotHeroTraceStore();
+      prePilotStore.rows = [];
+      prePilotStore.pilotActivationFrame = null;
+      prePilotStore.pilotFirstWriteFrame = null;
       heroOverviewPilotRef.current = {
         active: false,
         key: null,
@@ -2526,6 +2639,13 @@ const UnifiedCameraController = ({
         firstPilotWriteMoveDistance: latest?.firstPilotWriteMoveDistance ?? round4(heroOverviewPilotRef.current.transition?.firstPilotWriteMoveDistance),
         respectsCurrentHeroOrbitPose: latest?.respectsCurrentHeroOrbitPose ?? heroOverviewPilotRef.current.transition?.respectsCurrentHeroOrbitPose ?? null,
         orbitPhaseOrAngleAtCapture: latest?.orbitPhaseOrAngleAtCapture ?? heroOverviewPilotRef.current.transition?.orbitPhaseOrAngleAtCapture ?? null,
+        lastWriterBeforePilotLock: latest?.lastWriterBeforePilotLock ?? heroOverviewPilotRef.current.transition?.lastWriterBeforePilotLock ?? null,
+        lastHeroWriterBeforePilotLock: latest?.lastHeroWriterBeforePilotLock ?? heroOverviewPilotRef.current.transition?.lastHeroWriterBeforePilotLock ?? null,
+        distanceBetweenHeroOrbitAndAuthoritativeHero: latest?.distanceBetweenHeroOrbitAndAuthoritativeHero ?? round4(heroOverviewPilotRef.current.transition?.distanceBetweenHeroOrbitAndAuthoritativeHero),
+        distanceBetweenPilotHoldPoseAndHeroOrbit: latest?.distanceBetweenPilotHoldPoseAndHeroOrbit ?? round4(heroOverviewPilotRef.current.transition?.distanceBetweenPilotHoldPoseAndHeroOrbit),
+        distanceBetweenPilotHoldPoseAndAuthoritativeHero: latest?.distanceBetweenPilotHoldPoseAndAuthoritativeHero ?? round4(heroOverviewPilotRef.current.transition?.distanceBetweenPilotHoldPoseAndAuthoritativeHero),
+        doesPilotHoldMatchHeroOrbit: latest?.doesPilotHoldMatchHeroOrbit ?? heroOverviewPilotRef.current.transition?.doesPilotHoldMatchHeroOrbit ?? null,
+        doesPilotHoldMatchAuthoritativeHero: latest?.doesPilotHoldMatchAuthoritativeHero ?? heroOverviewPilotRef.current.transition?.doesPilotHoldMatchAuthoritativeHero ?? null,
         fromPoseSource: latest?.fromPoseSource ?? heroOverviewPilotRef.current.transition?.fromPoseSource ?? null,
         fromLookAtSource: latest?.fromLookAtSource ?? heroOverviewPilotRef.current.transition?.fromLookAtSource ?? null,
         targetResolved: Boolean(heroOverviewPilotRef.current.transition?.toPose),
@@ -2717,6 +2837,78 @@ const UnifiedCameraController = ({
       console.table(rows);
     };
 
+
+    globalThis.__clearHeroOverviewPrePilotHeroTrace = () => {
+      const store = getHeroOverviewPrePilotHeroTraceStore();
+      store.rows = [];
+      store.pilotActivationFrame = null;
+      store.pilotFirstWriteFrame = null;
+      console.log('[hero-overview-pre-pilot-trace] cleared');
+    };
+    globalThis.__printHeroOverviewPrePilotHeroTrace = () => {
+      const store = getHeroOverviewPrePilotHeroTraceStore();
+      const activationFrame = store.pilotActivationFrame;
+      const firstWriteFrame = store.pilotFirstWriteFrame;
+      const rows = store.rows.filter((row) => {
+        if (activationFrame == null && firstWriteFrame == null) return true;
+        const frame = row.frame ?? row.pilotFirstWriteFrame ?? row.pilotActivationFrame ?? null;
+        if (frame == null) return true;
+        const lower = activationFrame != null ? activationFrame - 10 : (firstWriteFrame != null ? firstWriteFrame - 10 : frame);
+        const upper = firstWriteFrame != null ? firstWriteFrame + 5 : (activationFrame != null ? activationFrame + 5 : frame);
+        return frame >= lower && frame <= upper;
+      });
+      const latestPilotSample = [...getHeroOverviewPilotDiagnosticsStore().samples].reverse()
+        .find((sample) => sample.type === 'pilot-frame' || sample.type === 'completion-handoff' || sample.type === 'pilot-completion-finalized') ?? null;
+      const summary = {
+        sampleCount: rows.length,
+        pilotActivationFrame: activationFrame,
+        pilotFirstWriteFrame: firstWriteFrame,
+        lastWriterBeforePilotLock: latestPilotSample?.holdPosePreviousWriter ?? null,
+        lastHeroWriterBeforePilotLock: latestPilotSample?.lastHeroWriterBeforePilotLock ?? null,
+        lastHeroOrbitPoseBeforePilotLock: latestPilotSample?.lastHeroOrbitPoseBeforePilotLock ?? null,
+        lastAuthoritativeHeroPoseBeforePilotLock: latestPilotSample?.lastAuthoritativeHeroPoseBeforePilotLock ?? null,
+        distanceBetweenHeroOrbitAndAuthoritativeHero: latestPilotSample?.distanceBetweenHeroOrbitAndAuthoritativeHero ?? null,
+        distanceBetweenPilotHoldPoseAndHeroOrbit: latestPilotSample?.distanceBetweenPilotHoldPoseAndHeroOrbit ?? null,
+        distanceBetweenPilotHoldPoseAndAuthoritativeHero: latestPilotSample?.distanceBetweenPilotHoldPoseAndAuthoritativeHero ?? null,
+        doesPilotHoldMatchHeroOrbit: latestPilotSample?.doesPilotHoldMatchHeroOrbit ?? null,
+        doesPilotHoldMatchAuthoritativeHero: latestPilotSample?.doesPilotHoldMatchAuthoritativeHero ?? null,
+        guardConflictExplanation: 'Previous AUTHORITATIVE_HERO <> heroOrbit conflicts were caused by duplicate DEV guard labels inside the AUTHORITATIVE_HERO path; the rendered hero pose trace now records actual writer poses and distances.',
+      };
+      console.log('[hero-overview-pre-pilot-trace] summary', summary);
+      console.table(rows.map((row) => ({
+        sampleIndex: row.sampleIndex,
+        eventType: row.eventType,
+        frame: row.frame,
+        t: row.t,
+        state: row.state,
+        cameraState: row.cameraState,
+        viewMode: row.viewMode,
+        phase: row.phase,
+        selectedProject: row.selectedProject,
+        writerId: row.writerId,
+        writerReason: row.writerReason,
+        cameraPosition: row.cameraPosition,
+        cameraLookAt: row.cameraLookAt,
+        fov: row.fov,
+        filmOffset: row.filmOffset,
+        authoritativeHeroPosition: row.authoritativeHeroPose?.position ?? null,
+        heroOrbitPosition: row.heroOrbitPose?.position ?? null,
+        finalCameraPosition: row.finalCameraPoseAtEndOfFrame?.position ?? null,
+        pilotActivationFrame: row.pilotActivationFrame ?? activationFrame,
+        pilotFirstWriteFrame: row.pilotFirstWriteFrame ?? firstWriteFrame,
+        pilotLockedHoldPose: row.pilotLockedHoldPose ?? null,
+        lastWriterBeforePilotLock: row.lastWriterBeforePilotLock ?? null,
+        lastHeroWriterBeforePilotLock: row.lastHeroWriterBeforePilotLock ?? null,
+        distanceBetweenHeroOrbitAndAuthoritativeHero: row.distanceBetweenHeroOrbitAndAuthoritativeHero,
+        distanceBetweenPilotHoldPoseAndHeroOrbit: row.distanceBetweenPilotHoldPoseAndHeroOrbit,
+        distanceBetweenPilotHoldPoseAndAuthoritativeHero: row.distanceBetweenPilotHoldPoseAndAuthoritativeHero,
+        doesPilotHoldMatchHeroOrbit: row.doesPilotHoldMatchHeroOrbit,
+        doesPilotHoldMatchAuthoritativeHero: row.doesPilotHoldMatchAuthoritativeHero,
+        heroOrbitAngle: row.heroOrbitAngle,
+        heroOrbitActive: row.heroOrbitActive,
+        authoritativeHeroActive: row.authoritativeHeroActive,
+      })));
+    };
     globalThis.__printHeroOverviewPilotCinematic = () => {
       const store = getHeroOverviewPilotDiagnosticsStore();
       const samples = store.samples.filter((sample) => sample.type === 'pilot-frame' || sample.type === 'completion-handoff' || sample.type === 'pilot-completion-finalized');
@@ -2755,9 +2947,20 @@ const UnifiedCameraController = ({
         startJumpDistance: latest?.startJumpDistance ?? null,
         startLookAtJumpDistance: latest?.startLookAtJumpDistance ?? null,
         firstPilotWriteMoveDistance: latest?.firstPilotWriteMoveDistance ?? null,
+        firstPilotWriteLiveCameraMoveDistance: latest?.firstPilotWriteLiveCameraMoveDistance ?? null,
+        firstPilotWriteMovedLiveCamera: latest?.firstPilotWriteMovedLiveCamera ?? null,
         firstPilotWriteMovedCamera: latest?.firstPilotWriteMovedCamera ?? null,
         respectsCurrentHeroOrbitPose: latest?.respectsCurrentHeroOrbitPose ?? null,
         orbitPhaseOrAngleAtCapture: latest?.orbitPhaseOrAngleAtCapture ?? null,
+        lastWriterBeforePilotLock: latest?.lastWriterBeforePilotLock ?? null,
+        lastHeroWriterBeforePilotLock: latest?.lastHeroWriterBeforePilotLock ?? null,
+        lastHeroOrbitPoseBeforePilotLock: latest?.lastHeroOrbitPoseBeforePilotLock ?? null,
+        lastAuthoritativeHeroPoseBeforePilotLock: latest?.lastAuthoritativeHeroPoseBeforePilotLock ?? null,
+        distanceBetweenHeroOrbitAndAuthoritativeHero: latest?.distanceBetweenHeroOrbitAndAuthoritativeHero ?? null,
+        distanceBetweenPilotHoldPoseAndHeroOrbit: latest?.distanceBetweenPilotHoldPoseAndHeroOrbit ?? null,
+        distanceBetweenPilotHoldPoseAndAuthoritativeHero: latest?.distanceBetweenPilotHoldPoseAndAuthoritativeHero ?? null,
+        doesPilotHoldMatchHeroOrbit: latest?.doesPilotHoldMatchHeroOrbit ?? null,
+        doesPilotHoldMatchAuthoritativeHero: latest?.doesPilotHoldMatchAuthoritativeHero ?? null,
         firstActualTravelPhase: firstTravelSample?.phase ?? null,
         firstActualTravelFrame: firstTravelSample?.frame ?? null,
         firstActualTravelGlobalProgress: firstTravelSample?.globalProgress ?? null,
@@ -2800,8 +3003,16 @@ const UnifiedCameraController = ({
         startJumpDistance: sample.startJumpDistance ?? null,
         startLookAtJumpDistance: sample.startLookAtJumpDistance ?? null,
         firstPilotWriteMoveDistance: sample.firstPilotWriteMoveDistance ?? null,
+        firstPilotWriteLiveCameraMoveDistance: sample.firstPilotWriteLiveCameraMoveDistance ?? null,
+        firstPilotWriteMovedLiveCamera: sample.firstPilotWriteMovedLiveCamera ?? null,
         firstPilotWriteMovedCamera: sample.firstPilotWriteMovedCamera ?? null,
         respectsCurrentHeroOrbitPose: sample.respectsCurrentHeroOrbitPose ?? null,
+        lastWriterBeforePilotLock: sample.lastWriterBeforePilotLock ?? null,
+        lastHeroWriterBeforePilotLock: sample.lastHeroWriterBeforePilotLock ?? null,
+        distanceBetweenPilotHoldPoseAndHeroOrbit: sample.distanceBetweenPilotHoldPoseAndHeroOrbit ?? null,
+        distanceBetweenPilotHoldPoseAndAuthoritativeHero: sample.distanceBetweenPilotHoldPoseAndAuthoritativeHero ?? null,
+        doesPilotHoldMatchHeroOrbit: sample.doesPilotHoldMatchHeroOrbit ?? null,
+        doesPilotHoldMatchAuthoritativeHero: sample.doesPilotHoldMatchAuthoritativeHero ?? null,
         globalProgress: sample.globalProgress ?? null,
         phaseLocalProgress: sample.phaseLocalProgress ?? null,
         cameraTravelProgress: sample.cameraTravelProgress ?? null,
@@ -3833,6 +4044,15 @@ const UnifiedCameraController = ({
           firstPilotWriteMoveDistance: null,
           respectsCurrentHeroOrbitPose: null,
           orbitPhaseOrAngleAtCapture: null,
+          lastWriterBeforePilotLock: null,
+          lastHeroWriterBeforePilotLock: null,
+          lastHeroOrbitPoseBeforePilotLock: null,
+          lastAuthoritativeHeroPoseBeforePilotLock: null,
+          distanceBetweenHeroOrbitAndAuthoritativeHero: null,
+          distanceBetweenPilotHoldPoseAndHeroOrbit: null,
+          distanceBetweenPilotHoldPoseAndAuthoritativeHero: null,
+          doesPilotHoldMatchHeroOrbit: null,
+          doesPilotHoldMatchAuthoritativeHero: null,
           firstTravelFrame: null,
           travelStartTime: null,
           travelStartProgress: HERO_OVERVIEW_PILOT_CAMERA_TIMELINE.overviewTravel.start,
@@ -3844,6 +4064,7 @@ const UnifiedCameraController = ({
           filmOffsetChangedDuringHold: false,
         },
       };
+      markHeroOverviewPilotActivationTrace(state.clock.frame);
       const pilotStore = getHeroOverviewPilotDiagnosticsStore();
       pilotStore.samples.push({
         type: 'milestone-a-scaffold-capture',
@@ -4749,44 +4970,123 @@ const UnifiedCameraController = ({
         let holdPoseLockedThisFrame = false;
         let livePoseBeforeFirstPilotWrite = null;
         if (!transition.holdPoseLocked) {
-          livePoseBeforeFirstPilotWrite = cloneHeroOverviewLiveCameraPose('live-camera-before-first-pilot-write');
-          const activeHoldPose = cloneHeroOverviewLiveCameraPose('first-active-pilot-write-live-camera-transform');
+          livePoseBeforeFirstPilotWrite = cloneHeroOverviewLiveCameraPose('live-camera-before-first-pilot-write', {
+            frame: state.clock.frame,
+            t: state.clock.elapsedTime,
+            writerId: 'LIVE_CAMERA_BEFORE_PILOT',
+            writerReason: 'before-first-active-pilot-write',
+          });
           const previousWriterBeforePilot = lastCameraWriterRef.current;
           const previousReasonBeforePilot = lastCameraWriteReasonRef.current;
+          const lastVisibleHeroPose = cloneHeroOverviewStoredPose(lastVisibleHeroPoseRef.current, lastVisibleHeroPoseRef.current?.source ?? 'last-visible-hero-pose');
+          const lastHeroOrbitPose = cloneHeroOverviewStoredPose(lastHeroOrbitRenderedPoseRef.current, lastHeroOrbitRenderedPoseRef.current?.source ?? 'last-hero-orbit-pose');
+          const lastAuthoritativeHeroPose = cloneHeroOverviewStoredPose(lastAuthoritativeHeroRenderedPoseRef.current, lastAuthoritativeHeroRenderedPoseRef.current?.source ?? 'last-authoritative-hero-pose');
+          const heroPoseFrameDelta = Number.isFinite(lastVisibleHeroPose?.frame)
+            ? state.clock.frame - lastVisibleHeroPose.frame
+            : Number.POSITIVE_INFINITY;
+          const canUseLastVisibleHeroPose = Boolean(
+            lastVisibleHeroPose?.position &&
+            lastVisibleHeroPose?.lookAt &&
+            heroPoseFrameDelta >= 0 &&
+            heroPoseFrameDelta <= 30
+          );
+          const activeHoldPose = canUseLastVisibleHeroPose
+            ? cloneHeroOverviewStoredPose(lastVisibleHeroPose, `last-visible-hero-orbit-pose:${lastVisibleHeroPose.writerId ?? lastVisibleHeroPose.source ?? 'unknown'}`)
+            : cloneHeroOverviewLiveCameraPose('first-active-pilot-write-live-camera-transform', {
+                frame: state.clock.frame,
+                t: state.clock.elapsedTime,
+                writerId: 'LIVE_CAMERA_AT_PILOT_LOCK',
+                writerReason: 'fallback-live-camera-transform',
+              });
           transition.activationFromPoseSource = transition.activationFromPoseSource ?? transition.fromPoseSource ?? 'activation-intent-live-camera-transform';
           transition.activeHoldPoseSource = activeHoldPose.source;
           transition.fromPoseSource = activeHoldPose.source;
-          transition.fromLookAtSource = 'camera-world-direction';
+          transition.fromLookAtSource = canUseLastVisibleHeroPose ? 'last-visible-hero-rendered-lookAt' : 'camera-world-direction';
           transition.fromPose = activeHoldPose;
           transition.holdPose = activeHoldPose;
           transition.holdPoseLocked = true;
           transition.holdPoseLockedAtFrame = state.clock.frame;
-          transition.holdPoseLockedAtPhase = 'first-active-pilot-write';
+          transition.holdPoseLockedAtPhase = canUseLastVisibleHeroPose ? 'first-active-pilot-write:last-visible-hero-pose' : 'first-active-pilot-write:live-camera-fallback';
           transition.holdPoseLockedAfterHeroOrbitWrite = previousWriterBeforePilot === 'AUTHORITATIVE_HERO' || previousWriterBeforePilot === 'HERO_ORBIT';
           transition.holdPosePreviousWriter = previousWriterBeforePilot;
           transition.holdPosePreviousWriterReason = previousReasonBeforePilot;
+          transition.lastWriterBeforePilotLock = previousWriterBeforePilot;
+          transition.lastHeroWriterBeforePilotLock = lastVisibleHeroPose?.writerId ?? null;
           transition.liveCameraBeforeFirstPilotWrite = livePoseBeforeFirstPilotWrite.position.clone();
           transition.liveLookAtBeforeFirstPilotWrite = livePoseBeforeFirstPilotWrite.lookAt.clone();
           transition.liveQuaternionBeforeFirstPilotWrite = livePoseBeforeFirstPilotWrite.quaternion.clone();
+          transition.lastHeroOrbitPoseBeforePilotLock = lastHeroOrbitPose;
+          transition.lastAuthoritativeHeroPoseBeforePilotLock = lastAuthoritativeHeroPose;
+          transition.distanceBetweenHeroOrbitAndAuthoritativeHero = distanceBetweenHeroOverviewPoses(lastHeroOrbitPose, lastAuthoritativeHeroPose);
+          transition.distanceBetweenPilotHoldPoseAndHeroOrbit = distanceBetweenHeroOverviewPoses(activeHoldPose, lastHeroOrbitPose);
+          transition.distanceBetweenPilotHoldPoseAndAuthoritativeHero = distanceBetweenHeroOverviewPoses(activeHoldPose, lastAuthoritativeHeroPose);
+          transition.doesPilotHoldMatchHeroOrbit = Number.isFinite(transition.distanceBetweenPilotHoldPoseAndHeroOrbit)
+            ? transition.distanceBetweenPilotHoldPoseAndHeroOrbit <= 0.001
+            : null;
+          transition.doesPilotHoldMatchAuthoritativeHero = Number.isFinite(transition.distanceBetweenPilotHoldPoseAndAuthoritativeHero)
+            ? transition.distanceBetweenPilotHoldPoseAndAuthoritativeHero <= 0.001
+            : null;
           transition.holdPosePositionDeltaFromLiveAtLock = activeHoldPose.position.distanceTo(livePoseBeforeFirstPilotWrite.position);
           transition.holdPoseLookAtDeltaFromLiveAtLock = activeHoldPose.lookAt.distanceTo(livePoseBeforeFirstPilotWrite.lookAt);
-          transition.holdPoseQuaternionDeltaFromLiveAtLock = activeHoldPose.quaternion.angleTo(livePoseBeforeFirstPilotWrite.quaternion);
-          transition.startJumpDistance = transition.holdPosePositionDeltaFromLiveAtLock;
-          transition.startLookAtJumpDistance = transition.holdPoseLookAtDeltaFromLiveAtLock;
+          transition.holdPoseQuaternionDeltaFromLiveAtLock = activeHoldPose.quaternion?.angleTo?.(livePoseBeforeFirstPilotWrite.quaternion) ?? null;
+          transition.startJumpDistance = Number.isFinite(transition.distanceBetweenPilotHoldPoseAndHeroOrbit)
+            ? transition.distanceBetweenPilotHoldPoseAndHeroOrbit
+            : transition.holdPosePositionDeltaFromLiveAtLock;
+          transition.startLookAtJumpDistance = Number.isFinite(transition.distanceBetweenPilotHoldPoseAndHeroOrbit)
+            ? (activeHoldPose.lookAt && lastHeroOrbitPose?.lookAt ? activeHoldPose.lookAt.distanceTo(lastHeroOrbitPose.lookAt) : null)
+            : transition.holdPoseLookAtDeltaFromLiveAtLock;
           transition.firstPilotWriteMovedCamera = false;
           transition.firstPilotWriteMoveDistance = 0;
-          transition.respectsCurrentHeroOrbitPose = true;
+          transition.respectsCurrentHeroOrbitPose = transition.doesPilotHoldMatchHeroOrbit !== false;
           transition.orbitPhaseOrAngleAtCapture = {
-            heroOrbitAngle: round4(heroOrbitAngle.current),
-            heroPolarAngle: round4(heroPolarAngleRef.current),
+            heroOrbitAngle: round4(activeHoldPose.heroOrbitAngle ?? heroOrbitAngle.current),
+            heroPolarAngle: round4(activeHoldPose.heroPolarAngle ?? heroPolarAngleRef.current),
             orbitElapsed: Number.isFinite(state.clock.elapsedTime - heroOrbitStartTimeRef.current)
               ? round4(state.clock.elapsedTime - heroOrbitStartTimeRef.current)
               : null,
             previousWriterBeforePilot,
             previousReasonBeforePilot,
+            lastVisibleHeroPoseFrame: lastVisibleHeroPose?.frame ?? null,
+            lastVisibleHeroPoseWriter: lastVisibleHeroPose?.writerId ?? null,
+            heroPoseFrameDelta: Number.isFinite(heroPoseFrameDelta) ? heroPoseFrameDelta : null,
             latestAuthoritativeHeroAngle: round4(latestAuthoritativeHeroSnapshotRef.current?.angle),
             latestAuthoritativeHeroOrbitElapsed: round4(latestAuthoritativeHeroSnapshotRef.current?.orbitElapsed),
           };
+          markHeroOverviewPilotFirstWriteTrace(state.clock.frame);
+          pushHeroOverviewPrePilotHeroTrace({
+            eventType: 'pilot-hold-pose-lock',
+            frame: state.clock.frame,
+            t: round4(state.clock.elapsedTime),
+            state: animationData?.state ?? null,
+            cameraState: animationData?.cameraState ?? null,
+            viewMode: animationData?.viewMode ?? null,
+            phase: 'hero->overview',
+            selectedProject: animationData?.selectedProject ?? null,
+            writerId: 'HERO_OVERVIEW_PILOT',
+            writerReason: 'first-active-pilot-write-hold-pose-lock',
+            cameraPosition: vectorToPlain(camera.position),
+            cameraLookAt: vectorToPlain(livePoseBeforeFirstPilotWrite.lookAt),
+            fov: round4(camera.fov),
+            filmOffset: round4(camera.filmOffset),
+            authoritativeHeroPose: heroOverviewPoseToPlain(lastAuthoritativeHeroPose),
+            heroOrbitPose: heroOverviewPoseToPlain(lastHeroOrbitPose),
+            finalCameraPoseAtEndOfFrame: null,
+            pilotActivationFrame: getHeroOverviewPrePilotHeroTraceStore().pilotActivationFrame,
+            pilotFirstWriteFrame: state.clock.frame,
+            pilotLockedHoldPose: heroOverviewPoseToPlain(activeHoldPose),
+            lastWriterBeforePilotLock: previousWriterBeforePilot,
+            lastHeroWriterBeforePilotLock: lastVisibleHeroPose?.writerId ?? null,
+            lastHeroOrbitPoseBeforePilotLock: heroOverviewPoseToPlain(lastHeroOrbitPose),
+            lastAuthoritativeHeroPoseBeforePilotLock: heroOverviewPoseToPlain(lastAuthoritativeHeroPose),
+            distanceBetweenHeroOrbitAndAuthoritativeHero: round4(transition.distanceBetweenHeroOrbitAndAuthoritativeHero),
+            distanceBetweenPilotHoldPoseAndHeroOrbit: round4(transition.distanceBetweenPilotHoldPoseAndHeroOrbit),
+            distanceBetweenPilotHoldPoseAndAuthoritativeHero: round4(transition.distanceBetweenPilotHoldPoseAndAuthoritativeHero),
+            doesPilotHoldMatchHeroOrbit: transition.doesPilotHoldMatchHeroOrbit,
+            doesPilotHoldMatchAuthoritativeHero: transition.doesPilotHoldMatchAuthoritativeHero,
+            heroOrbitAngle: round4(activeHoldPose.heroOrbitAngle ?? heroOrbitAngle.current),
+            heroOrbitActive: Boolean(lastVisibleHeroPose?.heroOrbitActive),
+            authoritativeHeroActive: lastVisibleHeroPose?.writerId === 'AUTHORITATIVE_HERO',
+          });
           transition.previousCinematicCameraPosition = activeHoldPose.position.clone();
           fromPose = transition.fromPose;
           holdPoseLockedThisFrame = true;
@@ -4869,13 +5169,19 @@ const UnifiedCameraController = ({
         camera.filmOffset = nextFilmOffset;
         camera.updateProjectionMatrix();
         if (holdPoseLockedThisFrame && livePoseBeforeFirstPilotWrite) {
-          const firstPilotWriteMoveDistance = camera.position.distanceTo(livePoseBeforeFirstPilotWrite.position);
-          const firstPilotWriteLookAtDistance = nextLookAt.distanceTo(livePoseBeforeFirstPilotWrite.lookAt);
-          transition.firstPilotWriteMoveDistance = firstPilotWriteMoveDistance;
-          transition.firstPilotWriteMovedCamera = firstPilotWriteMoveDistance > 0.001 || firstPilotWriteLookAtDistance > 0.001;
-          transition.startJumpDistance = firstPilotWriteMoveDistance;
-          transition.startLookAtJumpDistance = firstPilotWriteLookAtDistance;
-          transition.respectsCurrentHeroOrbitPose = !transition.firstPilotWriteMovedCamera;
+          const firstPilotWriteLiveCameraMoveDistance = camera.position.distanceTo(livePoseBeforeFirstPilotWrite.position);
+          const firstPilotWriteLiveLookAtMoveDistance = nextLookAt.distanceTo(livePoseBeforeFirstPilotWrite.lookAt);
+          transition.firstPilotWriteLiveCameraMoveDistance = firstPilotWriteLiveCameraMoveDistance;
+          transition.firstPilotWriteLiveLookAtMoveDistance = firstPilotWriteLiveLookAtMoveDistance;
+          transition.firstPilotWriteMovedLiveCamera = firstPilotWriteLiveCameraMoveDistance > 0.001 || firstPilotWriteLiveLookAtMoveDistance > 0.001;
+          transition.firstPilotWriteMoveDistance = Number.isFinite(transition.distanceBetweenPilotHoldPoseAndHeroOrbit)
+            ? transition.distanceBetweenPilotHoldPoseAndHeroOrbit
+            : firstPilotWriteLiveCameraMoveDistance;
+          transition.firstPilotWriteLookAtMoveDistance = Number.isFinite(transition.startLookAtJumpDistance)
+            ? transition.startLookAtJumpDistance
+            : firstPilotWriteLiveLookAtMoveDistance;
+          transition.firstPilotWriteMovedCamera = transition.firstPilotWriteMoveDistance > 0.001 || transition.firstPilotWriteLookAtMoveDistance > 0.001;
+          transition.respectsCurrentHeroOrbitPose = transition.doesPilotHoldMatchHeroOrbit !== false;
         }
         currentTarget.current.position.copy(nextPosition);
         currentTarget.current.lookAt.copy(nextLookAt);
@@ -4892,6 +5198,43 @@ const UnifiedCameraController = ({
         const distanceToTarget = safeDistance(camera.position, toPose.position);
         const lookAtDeltaToTarget = safeDistance(nextLookAt, toPose.lookAt);
         const filmOffsetDeltaToTarget = round4(Math.abs((camera.filmOffset ?? 0) - (toFilmOffset ?? 0)));
+        const prePilotTraceStore = getHeroOverviewPrePilotHeroTraceStore();
+        if (prePilotTraceStore.pilotFirstWriteFrame != null && state.clock.frame <= prePilotTraceStore.pilotFirstWriteFrame + 5) {
+          pushHeroOverviewPrePilotHeroTrace({
+            eventType: 'pilot-frame-after-write',
+            frame: state.clock.frame,
+            t: round4(state.clock.elapsedTime),
+            state: animationData?.state ?? null,
+            cameraState: animationData?.cameraState ?? null,
+            viewMode: animationData?.viewMode ?? null,
+            phase: pilotPhase,
+            selectedProject: animationData?.selectedProject ?? null,
+            writerId: 'HERO_OVERVIEW_PILOT',
+            writerReason: 'hero-overview-pilot-active',
+            cameraPosition: vectorToPlain(camera.position),
+            cameraLookAt: vectorToPlain(nextLookAt),
+            fov: round4(camera.fov),
+            filmOffset: round4(camera.filmOffset),
+            authoritativeHeroPose: heroOverviewPoseToPlain(transition.lastAuthoritativeHeroPoseBeforePilotLock),
+            heroOrbitPose: heroOverviewPoseToPlain(transition.lastHeroOrbitPoseBeforePilotLock),
+            finalCameraPoseAtEndOfFrame: heroOverviewPoseToPlain(cloneHeroOverviewLiveCameraPose('pilot-frame-after-write', { writerId: 'HERO_OVERVIEW_PILOT', writerReason: 'hero-overview-pilot-active', frame: state.clock.frame, t: state.clock.elapsedTime })),
+            pilotActivationFrame: prePilotTraceStore.pilotActivationFrame,
+            pilotFirstWriteFrame: prePilotTraceStore.pilotFirstWriteFrame,
+            pilotLockedHoldPose: heroOverviewPoseToPlain(transition.fromPose),
+            lastWriterBeforePilotLock: transition.lastWriterBeforePilotLock ?? null,
+            lastHeroWriterBeforePilotLock: transition.lastHeroWriterBeforePilotLock ?? null,
+            lastHeroOrbitPoseBeforePilotLock: heroOverviewPoseToPlain(transition.lastHeroOrbitPoseBeforePilotLock),
+            lastAuthoritativeHeroPoseBeforePilotLock: heroOverviewPoseToPlain(transition.lastAuthoritativeHeroPoseBeforePilotLock),
+            distanceBetweenHeroOrbitAndAuthoritativeHero: round4(transition.distanceBetweenHeroOrbitAndAuthoritativeHero),
+            distanceBetweenPilotHoldPoseAndHeroOrbit: round4(transition.distanceBetweenPilotHoldPoseAndHeroOrbit),
+            distanceBetweenPilotHoldPoseAndAuthoritativeHero: round4(transition.distanceBetweenPilotHoldPoseAndAuthoritativeHero),
+            doesPilotHoldMatchHeroOrbit: transition.doesPilotHoldMatchHeroOrbit,
+            doesPilotHoldMatchAuthoritativeHero: transition.doesPilotHoldMatchAuthoritativeHero,
+            heroOrbitAngle: round4(transition.fromPose?.heroOrbitAngle ?? heroOrbitAngle.current),
+            heroOrbitActive: Boolean(transition.lastHeroOrbitPoseBeforePilotLock?.heroOrbitActive),
+            authoritativeHeroActive: transition.lastHeroWriterBeforePilotLock === 'AUTHORITATIVE_HERO',
+          });
+        }
         pushHeroOverviewPilotSample({
           type: globalProgress >= 1 ? 'completion-handoff' : 'pilot-frame',
           pilotDiagnosticVersion: 'Milestone C live hold-pose lock',
@@ -4909,6 +5252,15 @@ const UnifiedCameraController = ({
           holdPosePreviousWriter: transition.holdPosePreviousWriter ?? null,
           holdPosePreviousWriterReason: transition.holdPosePreviousWriterReason ?? null,
           orbitPhaseOrAngleAtCapture: transition.orbitPhaseOrAngleAtCapture ?? null,
+          lastWriterBeforePilotLock: transition.lastWriterBeforePilotLock ?? null,
+          lastHeroWriterBeforePilotLock: transition.lastHeroWriterBeforePilotLock ?? null,
+          lastHeroOrbitPoseBeforePilotLock: heroOverviewPoseToPlain(transition.lastHeroOrbitPoseBeforePilotLock),
+          lastAuthoritativeHeroPoseBeforePilotLock: heroOverviewPoseToPlain(transition.lastAuthoritativeHeroPoseBeforePilotLock),
+          distanceBetweenHeroOrbitAndAuthoritativeHero: round4(transition.distanceBetweenHeroOrbitAndAuthoritativeHero),
+          distanceBetweenPilotHoldPoseAndHeroOrbit: round4(transition.distanceBetweenPilotHoldPoseAndHeroOrbit),
+          distanceBetweenPilotHoldPoseAndAuthoritativeHero: round4(transition.distanceBetweenPilotHoldPoseAndAuthoritativeHero),
+          doesPilotHoldMatchHeroOrbit: transition.doesPilotHoldMatchHeroOrbit,
+          doesPilotHoldMatchAuthoritativeHero: transition.doesPilotHoldMatchAuthoritativeHero,
           ...flattenVector('liveCameraBeforeFirstPilotWrite', transition.liveCameraBeforeFirstPilotWrite),
           ...flattenVector('liveLookAtBeforeFirstPilotWrite', transition.liveLookAtBeforeFirstPilotWrite),
           ...flattenVector('heldCamera', fromPose.position),
@@ -4920,6 +5272,8 @@ const UnifiedCameraController = ({
           startLookAtJumpDistance: round4(transition.startLookAtJumpDistance),
           firstPilotWriteMovedCamera: transition.firstPilotWriteMovedCamera,
           firstPilotWriteMoveDistance: round4(transition.firstPilotWriteMoveDistance),
+          firstPilotWriteLiveCameraMoveDistance: round4(transition.firstPilotWriteLiveCameraMoveDistance),
+          firstPilotWriteMovedLiveCamera: transition.firstPilotWriteMovedLiveCamera,
           respectsCurrentHeroOrbitPose: transition.respectsCurrentHeroOrbitPose,
           phase: pilotPhase,
           cameraMode: cinematicProgress.cameraMode,
@@ -5099,6 +5453,15 @@ const UnifiedCameraController = ({
             holdPosePreviousWriter: transition.holdPosePreviousWriter ?? null,
             holdPosePreviousWriterReason: transition.holdPosePreviousWriterReason ?? null,
             orbitPhaseOrAngleAtCapture: transition.orbitPhaseOrAngleAtCapture ?? null,
+            lastWriterBeforePilotLock: transition.lastWriterBeforePilotLock ?? null,
+            lastHeroWriterBeforePilotLock: transition.lastHeroWriterBeforePilotLock ?? null,
+            lastHeroOrbitPoseBeforePilotLock: heroOverviewPoseToPlain(transition.lastHeroOrbitPoseBeforePilotLock),
+            lastAuthoritativeHeroPoseBeforePilotLock: heroOverviewPoseToPlain(transition.lastAuthoritativeHeroPoseBeforePilotLock),
+            distanceBetweenHeroOrbitAndAuthoritativeHero: round4(transition.distanceBetweenHeroOrbitAndAuthoritativeHero),
+            distanceBetweenPilotHoldPoseAndHeroOrbit: round4(transition.distanceBetweenPilotHoldPoseAndHeroOrbit),
+            distanceBetweenPilotHoldPoseAndAuthoritativeHero: round4(transition.distanceBetweenPilotHoldPoseAndAuthoritativeHero),
+            doesPilotHoldMatchHeroOrbit: transition.doesPilotHoldMatchHeroOrbit,
+            doesPilotHoldMatchAuthoritativeHero: transition.doesPilotHoldMatchAuthoritativeHero,
             ...flattenVector('liveCameraBeforeFirstPilotWrite', transition.liveCameraBeforeFirstPilotWrite),
             ...flattenVector('liveLookAtBeforeFirstPilotWrite', transition.liveLookAtBeforeFirstPilotWrite),
             ...flattenVector('heldCamera', transition.fromPose?.position),
@@ -5110,6 +5473,8 @@ const UnifiedCameraController = ({
             startLookAtJumpDistance: round4(transition.startLookAtJumpDistance),
             firstPilotWriteMovedCamera: transition.firstPilotWriteMovedCamera,
             firstPilotWriteMoveDistance: round4(transition.firstPilotWriteMoveDistance),
+            firstPilotWriteLiveCameraMoveDistance: round4(transition.firstPilotWriteLiveCameraMoveDistance),
+            firstPilotWriteMovedLiveCamera: transition.firstPilotWriteMovedLiveCamera,
             respectsCurrentHeroOrbitPose: transition.respectsCurrentHeroOrbitPose,
             phase: 'complete',
             cameraMode: 'complete',
@@ -5714,7 +6079,14 @@ const UnifiedCameraController = ({
         tuning: { ...tuning },
         center: center.clone(),
       };
-      guardRecord("heroOrbit", ["position", "lookAt", "filmOffset"], "hero", "authoritative-hero-update");
+      captureHeroOverviewRenderedHeroPose({
+        source: 'authoritative-hero-rendered-pose',
+        writerId: 'AUTHORITATIVE_HERO',
+        writerReason: 'authoritative-hero-update',
+        state,
+        lookAt: snapshot.lookAtTarget,
+        phase: 'hero',
+      });
       logCameraWrite(state, "AUTHORITATIVE_HERO", "authoritative-hero-update", snapshot.lookAtTarget, true, true);
       if (shouldLogBranch) {
         console.log('[UCC AUTHORITATIVE HERO]', {
@@ -6797,6 +7169,15 @@ const UnifiedCameraController = ({
 
       animationData?.setCameraMoveProgress?.(1);
       animationData?.setCameraSettled?.(false);
+      captureHeroOverviewRenderedHeroPose({
+        source: 'hero-orbit-rendered-pose',
+        writerId: 'HERO_ORBIT',
+        writerReason: 'hero-orbit-active',
+        state,
+        lookAt: heroLookAtTarget,
+        phase: 'hero',
+      });
+      logCameraWrite(state, "HERO_ORBIT", "hero-orbit-active", heroLookAtTarget, true, true);
       console.log('[UCC EARLY RETURN]', { branch: "HERO_ORBIT", reason: "hero-orbit-active", finalCameraPosition: camera.position.toArray(), finalFilmOffset: camera.filmOffset, heroOrbitCenter: heroOrbitCenterRef.current.toArray(), lookAt: heroLookAtTarget.toArray() });
       if (shouldLogBranch) console.log('[UCC RETURN] reason: hero-orbit-active');
       return;

--- a/src/components/three/UnifiedCameraController.jsx
+++ b/src/components/three/UnifiedCameraController.jsx
@@ -1749,6 +1749,18 @@ const UnifiedCameraController = ({
   const quaternionToPlain = (q) => ({ x: round4(q?.x), y: round4(q?.y), z: round4(q?.z), w: round4(q?.w) });
   const safeDistance = (a, b) => (a && b ? round4(a.distanceTo(b)) : null);
   const quaternionAngleDelta = (q1, q2) => (q1 && q2 ? round4(q1.angleTo(q2)) : null);
+  const cloneHeroOverviewLiveCameraPose = (source = 'live-camera-transform') => {
+    const lookAt = getCameraLookAtFromTransform();
+    return {
+      position: camera.position.clone(),
+      lookAt,
+      fov: Number.isFinite(camera.fov) ? camera.fov : (currentTarget.current?.fov ?? 45),
+      filmOffset: Number.isFinite(camera.filmOffset) ? camera.filmOffset : 0,
+      up: camera.up.clone(),
+      quaternion: camera.quaternion.clone(),
+      source,
+    };
+  };
   const getCanonicalCameraUp = () => new THREE.Vector3(0, 1, 0);
   const getUpDeltaFromWorldUp = (up = camera.up) => (up ? round4(up.clone().normalize().distanceTo(getCanonicalCameraUp())) : null);
   const getRollDeltaFromWorldUp = (up = camera.up) => {
@@ -2484,8 +2496,8 @@ const UnifiedCameraController = ({
       const latest = store.samples[store.samples.length - 1] ?? null;
       const summary = {
         pilotEnabled: isHeroToOverviewPilotEnabled(),
-        pilotDiagnosticVersion: latest?.pilotDiagnosticVersion ?? 'Milestone C cinematic timeline',
-        pilotCinematicMilestone: latest?.pilotCinematicMilestone ?? heroOverviewPilotRef.current.transition?.pilotCinematicMilestone ?? 'Milestone C',
+        pilotDiagnosticVersion: latest?.pilotDiagnosticVersion ?? 'Milestone C live hold-pose lock',
+        pilotCinematicMilestone: latest?.pilotCinematicMilestone ?? heroOverviewPilotRef.current.transition?.pilotCinematicMilestone ?? 'Milestone C hold-pose lock',
         sampleCount: store.samples.length,
         captureAttempted: latest?.captureAttempted ?? false,
         captureSucceeded: latest?.captureSucceeded ?? false,
@@ -2501,6 +2513,19 @@ const UnifiedCameraController = ({
         phaseModel: HERO_OVERVIEW_PILOT_PHASES,
         phaseBehaviors: HERO_OVERVIEW_PILOT_PHASE_BEHAVIORS,
         cameraTimeline: HERO_OVERVIEW_PILOT_CAMERA_TIMELINE,
+        activationFromPoseSource: latest?.activationFromPoseSource ?? heroOverviewPilotRef.current.transition?.activationFromPoseSource ?? null,
+        activeHoldPoseSource: latest?.activeHoldPoseSource ?? heroOverviewPilotRef.current.transition?.activeHoldPoseSource ?? null,
+        holdPoseLockedAtFrame: latest?.holdPoseLockedAtFrame ?? heroOverviewPilotRef.current.transition?.holdPoseLockedAtFrame ?? null,
+        holdPoseLockedAtPhase: latest?.holdPoseLockedAtPhase ?? heroOverviewPilotRef.current.transition?.holdPoseLockedAtPhase ?? null,
+        holdPoseLockedAfterHeroOrbitWrite: latest?.holdPoseLockedAfterHeroOrbitWrite ?? heroOverviewPilotRef.current.transition?.holdPoseLockedAfterHeroOrbitWrite ?? null,
+        holdPosePositionDeltaFromLiveAtLock: latest?.holdPosePositionDeltaFromLiveAtLock ?? round4(heroOverviewPilotRef.current.transition?.holdPosePositionDeltaFromLiveAtLock),
+        holdPoseLookAtDeltaFromLiveAtLock: latest?.holdPoseLookAtDeltaFromLiveAtLock ?? round4(heroOverviewPilotRef.current.transition?.holdPoseLookAtDeltaFromLiveAtLock),
+        holdPoseQuaternionDeltaFromLiveAtLock: latest?.holdPoseQuaternionDeltaFromLiveAtLock ?? round4(heroOverviewPilotRef.current.transition?.holdPoseQuaternionDeltaFromLiveAtLock),
+        startLookAtJumpDistance: latest?.startLookAtJumpDistance ?? round4(heroOverviewPilotRef.current.transition?.startLookAtJumpDistance),
+        firstPilotWriteMovedCamera: latest?.firstPilotWriteMovedCamera ?? heroOverviewPilotRef.current.transition?.firstPilotWriteMovedCamera ?? null,
+        firstPilotWriteMoveDistance: latest?.firstPilotWriteMoveDistance ?? round4(heroOverviewPilotRef.current.transition?.firstPilotWriteMoveDistance),
+        respectsCurrentHeroOrbitPose: latest?.respectsCurrentHeroOrbitPose ?? heroOverviewPilotRef.current.transition?.respectsCurrentHeroOrbitPose ?? null,
+        orbitPhaseOrAngleAtCapture: latest?.orbitPhaseOrAngleAtCapture ?? heroOverviewPilotRef.current.transition?.orbitPhaseOrAngleAtCapture ?? null,
         fromPoseSource: latest?.fromPoseSource ?? heroOverviewPilotRef.current.transition?.fromPoseSource ?? null,
         fromLookAtSource: latest?.fromLookAtSource ?? heroOverviewPilotRef.current.transition?.fromLookAtSource ?? null,
         targetResolved: Boolean(heroOverviewPilotRef.current.transition?.toPose),
@@ -2566,7 +2591,7 @@ const UnifiedCameraController = ({
       const restored = (completion?.upDeltaFromWorldUp ?? Number.POSITIVE_INFINITY) <= 0.0001;
       const completionClearedTakeoverFlags = samples.some((sample) => sample.takeoverFlagsClearedAtCompletion === true);
       const postPilotFractureReentryDetected = samples.some((sample) => sample.postPilotFractureReentryDetected === true);
-      const liveFromPose = samples.some((sample) => sample.fromPoseSource === 'live-camera-transform' && sample.fromLookAtSource === 'camera-world-direction');
+      const liveFromPose = samples.some((sample) => (sample.fromPoseSource === 'first-active-pilot-write-live-camera-transform' || sample.activeHoldPoseSource === 'first-active-pilot-write-live-camera-transform') && sample.fromLookAtSource === 'camera-world-direction');
       const summary = {
         sampleCount: samples.length,
         fromPoseUsedLiveCameraTransform: liveFromPose,
@@ -2695,7 +2720,7 @@ const UnifiedCameraController = ({
     globalThis.__printHeroOverviewPilotCinematic = () => {
       const store = getHeroOverviewPilotDiagnosticsStore();
       const samples = store.samples.filter((sample) => sample.type === 'pilot-frame' || sample.type === 'completion-handoff' || sample.type === 'pilot-completion-finalized');
-      if (!samples.length) return console.log('[hero-overview-pilot] cinematic-summary', { sampleCount: 0, pilotCinematicMilestone: 'Milestone C' });
+      if (!samples.length) return console.log('[hero-overview-pilot] cinematic-summary', { sampleCount: 0, pilotCinematicMilestone: 'Milestone C hold-pose lock' });
       const latest = samples[samples.length - 1];
       const movementThreshold = 0.001;
       const phaseRows = (phase) => samples.filter((sample) => sample.phase === phase);
@@ -2718,10 +2743,21 @@ const UnifiedCameraController = ({
       const maxUpDelta = samples.reduce((max, sample) => Math.max(max, Number(sample.upDeltaFromWorldUp || 0)), 0);
       const competingWriterAppeared = samples.some((sample) => sample.competingWriterDetected === true);
       const summary = {
-        pilotCinematicMilestone: 'Milestone C',
+        pilotCinematicMilestone: 'Milestone C hold-pose lock',
         sampleCount: samples.length,
         cameraTimeline: HERO_OVERVIEW_PILOT_CAMERA_TIMELINE,
         holdPhases: HERO_OVERVIEW_PILOT_HOLD_PHASES,
+        holdPoseSource: latest?.activeHoldPoseSource ?? latest?.fromPoseSource ?? null,
+        activationFromPoseSource: latest?.activationFromPoseSource ?? null,
+        holdPoseLockedAtPhase: latest?.holdPoseLockedAtPhase ?? null,
+        holdPoseLockedAtFrame: latest?.holdPoseLockedAtFrame ?? null,
+        holdPoseLockedAfterHeroOrbitWrite: latest?.holdPoseLockedAfterHeroOrbitWrite ?? null,
+        startJumpDistance: latest?.startJumpDistance ?? null,
+        startLookAtJumpDistance: latest?.startLookAtJumpDistance ?? null,
+        firstPilotWriteMoveDistance: latest?.firstPilotWriteMoveDistance ?? null,
+        firstPilotWriteMovedCamera: latest?.firstPilotWriteMovedCamera ?? null,
+        respectsCurrentHeroOrbitPose: latest?.respectsCurrentHeroOrbitPose ?? null,
+        orbitPhaseOrAngleAtCapture: latest?.orbitPhaseOrAngleAtCapture ?? null,
         firstActualTravelPhase: firstTravelSample?.phase ?? null,
         firstActualTravelFrame: firstTravelSample?.frame ?? null,
         firstActualTravelGlobalProgress: firstTravelSample?.globalProgress ?? null,
@@ -2757,6 +2793,15 @@ const UnifiedCameraController = ({
         frame: sample.frame ?? null,
         phase: sample.phase ?? null,
         cameraMode: sample.cameraMode ?? null,
+        activationFromPoseSource: sample.activationFromPoseSource ?? null,
+        activeHoldPoseSource: sample.activeHoldPoseSource ?? null,
+        holdPoseLockedAtFrame: sample.holdPoseLockedAtFrame ?? null,
+        holdPoseLockedAtPhase: sample.holdPoseLockedAtPhase ?? null,
+        startJumpDistance: sample.startJumpDistance ?? null,
+        startLookAtJumpDistance: sample.startLookAtJumpDistance ?? null,
+        firstPilotWriteMoveDistance: sample.firstPilotWriteMoveDistance ?? null,
+        firstPilotWriteMovedCamera: sample.firstPilotWriteMovedCamera ?? null,
+        respectsCurrentHeroOrbitPose: sample.respectsCurrentHeroOrbitPose ?? null,
         globalProgress: sample.globalProgress ?? null,
         phaseLocalProgress: sample.phaseLocalProgress ?? null,
         cameraTravelProgress: sample.cameraTravelProgress ?? null,
@@ -3740,7 +3785,7 @@ const UnifiedCameraController = ({
           phaseModel: HERO_OVERVIEW_PILOT_PHASES,
           phaseBehaviors: HERO_OVERVIEW_PILOT_PHASE_BEHAVIORS,
           cameraTimeline: HERO_OVERVIEW_PILOT_CAMERA_TIMELINE,
-          pilotCinematicMilestone: 'Milestone C',
+          pilotCinematicMilestone: 'Milestone C hold-pose lock',
           ownsCameraInMilestoneA: false,
           ownsCameraInMilestoneB: Boolean(resolvedOverview),
           legacyForcedWriterBlocked: Boolean(resolvedOverview),
@@ -3749,7 +3794,9 @@ const UnifiedCameraController = ({
           completed: false,
           duration: 1.45,
           startJumpDistance: 0,
-          fromPoseSource: 'live-camera-transform',
+          activationFromPoseSource: 'activation-intent-live-camera-transform',
+          activeHoldPoseSource: null,
+          fromPoseSource: 'activation-intent-live-camera-transform',
           fromLookAtSource: 'camera-world-direction',
           fromPose: {
             position: camera.position.clone(),
@@ -3757,6 +3804,7 @@ const UnifiedCameraController = ({
             fov: Number.isFinite(camera.fov) ? camera.fov : (currentTarget.current?.fov ?? 45),
             filmOffset: Number.isFinite(camera.filmOffset) ? camera.filmOffset : 0,
             up: camera.up.clone(),
+            quaternion: camera.quaternion.clone(),
           },
           targetUp: getCanonicalCameraUp(),
           completionUp: null,
@@ -3768,6 +3816,23 @@ const UnifiedCameraController = ({
           monotonicGlobalProgress: 0,
           fromPoseRecaptured: false,
           targetPoseRecalculated: false,
+          holdPoseLocked: false,
+          holdPoseLockedAtFrame: null,
+          holdPoseLockedAtPhase: null,
+          holdPoseLockedAfterHeroOrbitWrite: null,
+          holdPosePreviousWriter: null,
+          holdPosePreviousWriterReason: null,
+          liveCameraBeforeFirstPilotWrite: null,
+          liveLookAtBeforeFirstPilotWrite: null,
+          liveQuaternionBeforeFirstPilotWrite: null,
+          holdPosePositionDeltaFromLiveAtLock: null,
+          holdPoseLookAtDeltaFromLiveAtLock: null,
+          holdPoseQuaternionDeltaFromLiveAtLock: null,
+          startLookAtJumpDistance: null,
+          firstPilotWriteMovedCamera: null,
+          firstPilotWriteMoveDistance: null,
+          respectsCurrentHeroOrbitPose: null,
+          orbitPhaseOrAngleAtCapture: null,
           firstTravelFrame: null,
           travelStartTime: null,
           travelStartProgress: HERO_OVERVIEW_PILOT_CAMERA_TIMELINE.overviewTravel.start,
@@ -3787,8 +3852,10 @@ const UnifiedCameraController = ({
         key: heroOverviewActivationKey,
         transitionKey: heroOverviewTransitionKey,
         pilotEnabled: isHeroToOverviewPilotEnabled(),
-        pilotDiagnosticVersion: 'Milestone C cinematic timeline',
-        pilotCinematicMilestone: 'Milestone C',
+        pilotDiagnosticVersion: 'Milestone C live hold-pose lock',
+        pilotCinematicMilestone: 'Milestone C hold-pose lock',
+        activationFromPoseSource: 'activation-intent-live-camera-transform',
+        activeHoldPoseSource: null,
         cameraTimeline: HERO_OVERVIEW_PILOT_CAMERA_TIMELINE,
         captureAttempted: true,
         captureSucceeded: Boolean(resolvedOverview),
@@ -3811,7 +3878,7 @@ const UnifiedCameraController = ({
         ownsCameraInMilestoneA: false,
         ownsCameraInMilestoneB: Boolean(resolvedOverview),
         phaseModel: HERO_OVERVIEW_PILOT_PHASES.join(' -> '),
-        fromPoseSource: 'live-camera-transform',
+        fromPoseSource: 'activation-intent-live-camera-transform',
         fromLookAtSource: 'camera-world-direction',
         fromPosition: vectorToPlain(camera.position),
         fromLookAt: vectorToPlain(fromLookAt),
@@ -3922,8 +3989,9 @@ const UnifiedCameraController = ({
           phaseModel: HERO_OVERVIEW_PILOT_PHASES,
           phaseBehaviors: HERO_OVERVIEW_PILOT_PHASE_BEHAVIORS,
           cameraTimeline: HERO_OVERVIEW_PILOT_CAMERA_TIMELINE,
-          pilotCinematicMilestone: 'Milestone C',
-          fromPoseSource: 'live-camera-transform',
+          pilotCinematicMilestone: 'Milestone C hold-pose lock',
+          fromPoseSource: 'activation-intent-live-camera-transform',
+          activeHoldPoseSource: null,
           ownsCameraInMilestoneA: false,
           ownsCameraInMilestoneB: Boolean(resolvedOverview),
           legacyForcedWriterBlocked: Boolean(resolvedOverview),
@@ -4672,12 +4740,63 @@ const UnifiedCameraController = ({
     if (heroOverviewPilotRef.current.active) {
       const pilot = heroOverviewPilotRef.current;
       const transition = pilot.transition;
-      const fromPose = transition?.fromPose;
+      let fromPose = transition?.fromPose;
       const ensuredTarget = ensureHeroOverviewPilotCameraWriteTarget(transition);
       const toPose = ensuredTarget.activeToPose;
-      if (!fromPose || !toPose) {
+      if (!transition || !toPose) {
         pilot.active = false;
       } else {
+        let holdPoseLockedThisFrame = false;
+        let livePoseBeforeFirstPilotWrite = null;
+        if (!transition.holdPoseLocked) {
+          livePoseBeforeFirstPilotWrite = cloneHeroOverviewLiveCameraPose('live-camera-before-first-pilot-write');
+          const activeHoldPose = cloneHeroOverviewLiveCameraPose('first-active-pilot-write-live-camera-transform');
+          const previousWriterBeforePilot = lastCameraWriterRef.current;
+          const previousReasonBeforePilot = lastCameraWriteReasonRef.current;
+          transition.activationFromPoseSource = transition.activationFromPoseSource ?? transition.fromPoseSource ?? 'activation-intent-live-camera-transform';
+          transition.activeHoldPoseSource = activeHoldPose.source;
+          transition.fromPoseSource = activeHoldPose.source;
+          transition.fromLookAtSource = 'camera-world-direction';
+          transition.fromPose = activeHoldPose;
+          transition.holdPose = activeHoldPose;
+          transition.holdPoseLocked = true;
+          transition.holdPoseLockedAtFrame = state.clock.frame;
+          transition.holdPoseLockedAtPhase = 'first-active-pilot-write';
+          transition.holdPoseLockedAfterHeroOrbitWrite = previousWriterBeforePilot === 'AUTHORITATIVE_HERO' || previousWriterBeforePilot === 'HERO_ORBIT';
+          transition.holdPosePreviousWriter = previousWriterBeforePilot;
+          transition.holdPosePreviousWriterReason = previousReasonBeforePilot;
+          transition.liveCameraBeforeFirstPilotWrite = livePoseBeforeFirstPilotWrite.position.clone();
+          transition.liveLookAtBeforeFirstPilotWrite = livePoseBeforeFirstPilotWrite.lookAt.clone();
+          transition.liveQuaternionBeforeFirstPilotWrite = livePoseBeforeFirstPilotWrite.quaternion.clone();
+          transition.holdPosePositionDeltaFromLiveAtLock = activeHoldPose.position.distanceTo(livePoseBeforeFirstPilotWrite.position);
+          transition.holdPoseLookAtDeltaFromLiveAtLock = activeHoldPose.lookAt.distanceTo(livePoseBeforeFirstPilotWrite.lookAt);
+          transition.holdPoseQuaternionDeltaFromLiveAtLock = activeHoldPose.quaternion.angleTo(livePoseBeforeFirstPilotWrite.quaternion);
+          transition.startJumpDistance = transition.holdPosePositionDeltaFromLiveAtLock;
+          transition.startLookAtJumpDistance = transition.holdPoseLookAtDeltaFromLiveAtLock;
+          transition.firstPilotWriteMovedCamera = false;
+          transition.firstPilotWriteMoveDistance = 0;
+          transition.respectsCurrentHeroOrbitPose = true;
+          transition.orbitPhaseOrAngleAtCapture = {
+            heroOrbitAngle: round4(heroOrbitAngle.current),
+            heroPolarAngle: round4(heroPolarAngleRef.current),
+            orbitElapsed: Number.isFinite(state.clock.elapsedTime - heroOrbitStartTimeRef.current)
+              ? round4(state.clock.elapsedTime - heroOrbitStartTimeRef.current)
+              : null,
+            previousWriterBeforePilot,
+            previousReasonBeforePilot,
+            latestAuthoritativeHeroAngle: round4(latestAuthoritativeHeroSnapshotRef.current?.angle),
+            latestAuthoritativeHeroOrbitElapsed: round4(latestAuthoritativeHeroSnapshotRef.current?.orbitElapsed),
+          };
+          transition.previousCinematicCameraPosition = activeHoldPose.position.clone();
+          fromPose = transition.fromPose;
+          holdPoseLockedThisFrame = true;
+        } else {
+          fromPose = transition.fromPose;
+        }
+        if (!fromPose) {
+          pilot.active = false;
+          return;
+        }
         const runtimeSnapshot = heroOverviewRuntime?.getSnapshot?.() ?? null;
         const explosionClock = heroOverviewExplosionClockRef?.current ?? null;
         const elapsedProgress = THREE.MathUtils.clamp(
@@ -4713,8 +4832,10 @@ const UnifiedCameraController = ({
         const toFov = Number.isFinite(toPose.fov) ? toPose.fov : fromFov;
         const fromFilmOffset = Number.isFinite(fromPose.filmOffset) ? fromPose.filmOffset : 0;
         const toFilmOffset = Number.isFinite(toPose.filmOffset) ? toPose.filmOffset : 0;
-        const isFinalPoseLocked = globalProgress >= 1 || pilotPhase === 'overviewSettle' || pilotPhase === 'complete';
-        const cameraTravelEasedProgress = isFinalPoseLocked ? 1 : cinematicProgress.cameraTravelEasedProgress;
+        const isFinalPoseLocked = !holdPoseLockedThisFrame && (globalProgress >= 1 || pilotPhase === 'overviewSettle' || pilotPhase === 'complete');
+        const cameraTravelEasedProgress = holdPoseLockedThisFrame
+          ? 0
+          : (isFinalPoseLocked ? 1 : cinematicProgress.cameraTravelEasedProgress);
         const nextPosition = isFinalPoseLocked
           ? toPose.position.clone()
           : new THREE.Vector3().lerpVectors(fromPose.position, toPose.position, cameraTravelEasedProgress);
@@ -4747,6 +4868,15 @@ const UnifiedCameraController = ({
         camera.fov = nextFov;
         camera.filmOffset = nextFilmOffset;
         camera.updateProjectionMatrix();
+        if (holdPoseLockedThisFrame && livePoseBeforeFirstPilotWrite) {
+          const firstPilotWriteMoveDistance = camera.position.distanceTo(livePoseBeforeFirstPilotWrite.position);
+          const firstPilotWriteLookAtDistance = nextLookAt.distanceTo(livePoseBeforeFirstPilotWrite.lookAt);
+          transition.firstPilotWriteMoveDistance = firstPilotWriteMoveDistance;
+          transition.firstPilotWriteMovedCamera = firstPilotWriteMoveDistance > 0.001 || firstPilotWriteLookAtDistance > 0.001;
+          transition.startJumpDistance = firstPilotWriteMoveDistance;
+          transition.startLookAtJumpDistance = firstPilotWriteLookAtDistance;
+          transition.respectsCurrentHeroOrbitPose = !transition.firstPilotWriteMovedCamera;
+        }
         currentTarget.current.position.copy(nextPosition);
         currentTarget.current.lookAt.copy(nextLookAt);
         currentTarget.current.fov = camera.fov;
@@ -4764,13 +4894,33 @@ const UnifiedCameraController = ({
         const filmOffsetDeltaToTarget = round4(Math.abs((camera.filmOffset ?? 0) - (toFilmOffset ?? 0)));
         pushHeroOverviewPilotSample({
           type: globalProgress >= 1 ? 'completion-handoff' : 'pilot-frame',
-          pilotDiagnosticVersion: 'Milestone C cinematic timeline',
-          pilotCinematicMilestone: 'Milestone C',
+          pilotDiagnosticVersion: 'Milestone C live hold-pose lock',
+          pilotCinematicMilestone: 'Milestone C hold-pose lock',
           t: round4(state.clock.elapsedTime),
           frame: state.clock.frame,
           key: pilot.key,
+          activationFromPoseSource: transition.activationFromPoseSource ?? null,
+          activeHoldPoseSource: transition.activeHoldPoseSource ?? null,
           fromPoseSource: transition.fromPoseSource ?? null,
           fromLookAtSource: transition.fromLookAtSource ?? null,
+          holdPoseLockedAtFrame: transition.holdPoseLockedAtFrame ?? null,
+          holdPoseLockedAtPhase: transition.holdPoseLockedAtPhase ?? null,
+          holdPoseLockedAfterHeroOrbitWrite: transition.holdPoseLockedAfterHeroOrbitWrite ?? null,
+          holdPosePreviousWriter: transition.holdPosePreviousWriter ?? null,
+          holdPosePreviousWriterReason: transition.holdPosePreviousWriterReason ?? null,
+          orbitPhaseOrAngleAtCapture: transition.orbitPhaseOrAngleAtCapture ?? null,
+          ...flattenVector('liveCameraBeforeFirstPilotWrite', transition.liveCameraBeforeFirstPilotWrite),
+          ...flattenVector('liveLookAtBeforeFirstPilotWrite', transition.liveLookAtBeforeFirstPilotWrite),
+          ...flattenVector('heldCamera', fromPose.position),
+          ...flattenVector('heldLookAt', fromPose.lookAt),
+          holdPosePositionDeltaFromLiveAtLock: round4(transition.holdPosePositionDeltaFromLiveAtLock),
+          holdPoseLookAtDeltaFromLiveAtLock: round4(transition.holdPoseLookAtDeltaFromLiveAtLock),
+          holdPoseQuaternionDeltaFromLiveAtLock: round4(transition.holdPoseQuaternionDeltaFromLiveAtLock),
+          startJumpDistance: round4(transition.startJumpDistance),
+          startLookAtJumpDistance: round4(transition.startLookAtJumpDistance),
+          firstPilotWriteMovedCamera: transition.firstPilotWriteMovedCamera,
+          firstPilotWriteMoveDistance: round4(transition.firstPilotWriteMoveDistance),
+          respectsCurrentHeroOrbitPose: transition.respectsCurrentHeroOrbitPose,
           phase: pilotPhase,
           cameraMode: cinematicProgress.cameraMode,
           phaseStart: round4(cinematicProgress.phaseStart),
@@ -4934,13 +5084,33 @@ const UnifiedCameraController = ({
           heroToOverviewHandoffLockFramesRef.current = HERO_TO_OVERVIEW_HANDOFF_LOCK_FRAMES;
           pushHeroOverviewPilotSample({
             type: 'pilot-completion-finalized',
-            pilotDiagnosticVersion: 'Milestone C cinematic timeline',
-            pilotCinematicMilestone: 'Milestone C',
+            pilotDiagnosticVersion: 'Milestone C live hold-pose lock',
+            pilotCinematicMilestone: 'Milestone C hold-pose lock',
             t: round4(state.clock.elapsedTime),
             frame: state.clock.frame,
             key: pilot.key,
+            activationFromPoseSource: transition.activationFromPoseSource ?? null,
+            activeHoldPoseSource: transition.activeHoldPoseSource ?? null,
             fromPoseSource: transition.fromPoseSource ?? null,
             fromLookAtSource: transition.fromLookAtSource ?? null,
+            holdPoseLockedAtFrame: transition.holdPoseLockedAtFrame ?? null,
+            holdPoseLockedAtPhase: transition.holdPoseLockedAtPhase ?? null,
+            holdPoseLockedAfterHeroOrbitWrite: transition.holdPoseLockedAfterHeroOrbitWrite ?? null,
+            holdPosePreviousWriter: transition.holdPosePreviousWriter ?? null,
+            holdPosePreviousWriterReason: transition.holdPosePreviousWriterReason ?? null,
+            orbitPhaseOrAngleAtCapture: transition.orbitPhaseOrAngleAtCapture ?? null,
+            ...flattenVector('liveCameraBeforeFirstPilotWrite', transition.liveCameraBeforeFirstPilotWrite),
+            ...flattenVector('liveLookAtBeforeFirstPilotWrite', transition.liveLookAtBeforeFirstPilotWrite),
+            ...flattenVector('heldCamera', transition.fromPose?.position),
+            ...flattenVector('heldLookAt', transition.fromPose?.lookAt),
+            holdPosePositionDeltaFromLiveAtLock: round4(transition.holdPosePositionDeltaFromLiveAtLock),
+            holdPoseLookAtDeltaFromLiveAtLock: round4(transition.holdPoseLookAtDeltaFromLiveAtLock),
+            holdPoseQuaternionDeltaFromLiveAtLock: round4(transition.holdPoseQuaternionDeltaFromLiveAtLock),
+            startJumpDistance: round4(transition.startJumpDistance),
+            startLookAtJumpDistance: round4(transition.startLookAtJumpDistance),
+            firstPilotWriteMovedCamera: transition.firstPilotWriteMovedCamera,
+            firstPilotWriteMoveDistance: round4(transition.firstPilotWriteMoveDistance),
+            respectsCurrentHeroOrbitPose: transition.respectsCurrentHeroOrbitPose,
             phase: 'complete',
             cameraMode: 'complete',
             phaseStart: 1,
@@ -6031,7 +6201,7 @@ const UnifiedCameraController = ({
         }
         pushHeroOverviewPilotSample({
           type: 'handoff-lock-frame',
-          pilotDiagnosticVersion: 'Milestone C cinematic timeline',
+          pilotDiagnosticVersion: 'Milestone C live hold-pose lock',
           t: round4(state.clock.elapsedTime),
           frame: state.clock.frame,
           key: heroOverviewPilotRef.current.key,

--- a/src/components/three/UnifiedCameraController.jsx
+++ b/src/components/three/UnifiedCameraController.jsx
@@ -388,6 +388,13 @@ const UnifiedCameraController = ({
     pilotActivationFrame: null,
     pilotFirstWriteFrame: null,
   });
+  const heroOverviewVisibleCompositionTraceRef = useRef({
+    rows: [],
+    maxRows: 240,
+    pilotActivationFrame: null,
+    pilotFirstWriteFrame: null,
+  });
+  const cameraFrameIndexRef = useRef(0);
 
   const isOverviewToProjectPilotEnabled = () => {
     // WARNING: Experimental pilot only; not production-ready.
@@ -2101,20 +2108,183 @@ const UnifiedCameraController = ({
       store.rows.forEach((entry, index) => { entry.sampleIndex = index; });
     }
   };
+
+  const getHeroOverviewVisibleCompositionTraceStore = () => {
+    if (typeof globalThis === 'undefined') return heroOverviewVisibleCompositionTraceRef.current;
+    if (!globalThis.__heroOverviewVisibleCompositionTraceStore) {
+      globalThis.__heroOverviewVisibleCompositionTraceStore = heroOverviewVisibleCompositionTraceRef.current;
+    }
+    if (globalThis.__heroOverviewVisibleCompositionTraceStore !== heroOverviewVisibleCompositionTraceRef.current) {
+      globalThis.__heroOverviewVisibleCompositionTraceStore = heroOverviewVisibleCompositionTraceRef.current;
+    }
+    return globalThis.__heroOverviewVisibleCompositionTraceStore;
+  };
+  const pushHeroOverviewVisibleCompositionTrace = (row) => {
+    if (!import.meta.env.DEV) return;
+    const store = getHeroOverviewVisibleCompositionTraceStore();
+    store.rows.push({ sampleIndex: store.rows.length, ...row });
+    if (store.rows.length > store.maxRows) {
+      const overflow = store.rows.length - store.maxRows;
+      store.rows.splice(0, overflow);
+      store.rows.forEach((entry, index) => { entry.sampleIndex = index; });
+    }
+  };
+
+  const getCameraWorldCompositionPose = () => {
+    camera.updateMatrixWorld?.(true);
+    const worldPosition = new THREE.Vector3();
+    const worldQuaternion = new THREE.Quaternion();
+    const worldScale = new THREE.Vector3();
+    camera.matrixWorld.decompose(worldPosition, worldQuaternion, worldScale);
+    const worldForward = new THREE.Vector3(0, 0, -1).applyQuaternion(worldQuaternion).normalize();
+    return {
+      position: worldPosition,
+      lookAt: worldPosition.clone().addScaledVector(worldForward, 10),
+      quaternion: worldQuaternion,
+      scale: worldScale,
+      fov: camera.fov,
+      filmOffset: camera.filmOffset,
+      up: camera.up.clone(),
+      source: 'camera-world',
+    };
+  };
+  const getObjectWorldTransformPlain = (object) => {
+    if (!object) return null;
+    object.updateMatrixWorld?.(true);
+    const worldPosition = new THREE.Vector3();
+    const worldQuaternion = new THREE.Quaternion();
+    const worldScale = new THREE.Vector3();
+    object.matrixWorld.decompose(worldPosition, worldQuaternion, worldScale);
+    return {
+      name: object.name || object.type || null,
+      worldPosition: vectorToPlain(worldPosition),
+      worldQuaternion: quaternionToPlain(worldQuaternion),
+      worldScale: vectorToPlain(worldScale),
+      localPosition: vectorToPlain(object.position),
+      localQuaternion: quaternionToPlain(object.quaternion),
+      localScale: vectorToPlain(object.scale),
+    };
+  };
+  const pushHeroOverviewVisibleCompositionSample = ({ eventType, state, phase = null, writerId = null, writerReason = null, pilotHoldPose = null } = {}) => {
+    if (!import.meta.env.DEV) return;
+    const frameId = cameraFrameIndexRef.current || state?.clock?.frame || null;
+    const rawPose = cloneHeroOverviewLiveCameraPose('rawCamera', { frame: frameId, t: state?.clock?.elapsedTime });
+    const worldPose = getCameraWorldCompositionPose();
+    const previousPose = previousFramePoseRef.current?.position ? {
+      position: previousFramePoseRef.current.position.clone(),
+      lookAt: previousFramePoseRef.current.lookAt?.clone?.() ?? null,
+      fov: previousFramePoseRef.current.fov,
+      filmOffset: previousFramePoseRef.current.filmOffset,
+      quaternion: previousFramePoseRef.current.quaternion?.clone?.() ?? null,
+      source: 'previousFramePose',
+    } : null;
+    const currentTargetPose = currentTarget.current?.position ? {
+      position: currentTarget.current.position.clone(),
+      lookAt: currentTarget.current.lookAt?.clone?.() ?? null,
+      fov: currentTarget.current.fov,
+      filmOffset: currentTarget.current.filmOffset,
+      source: 'currentTarget',
+    } : null;
+    const heroOrbitStatePose = lastVisibleHeroPoseRef.current ? cloneHeroOverviewStoredPose(lastVisibleHeroPoseRef.current, 'heroOrbitState') : null;
+    const candidates = {
+      rawCamera: rawPose,
+      worldCamera: worldPose,
+      currentTarget: currentTargetPose,
+      previousFramePose: previousPose,
+      heroOrbitState: heroOrbitStatePose,
+    };
+    let bestVisibleHeroPoseCandidate = null;
+    let distancePilotHoldToBestCandidate = null;
+    if (pilotHoldPose?.position) {
+      Object.entries(candidates).forEach(([name, candidate]) => {
+        const distance = candidate?.position ? pilotHoldPose.position.distanceTo(candidate.position) : null;
+        if (Number.isFinite(distance) && (distancePilotHoldToBestCandidate == null || distance < distancePilotHoldToBestCandidate)) {
+          bestVisibleHeroPoseCandidate = name;
+          distancePilotHoldToBestCandidate = distance;
+        }
+      });
+    }
+    const sceneSnapshot = typeof globalThis !== 'undefined' ? globalThis.__crystalSceneVisibleCompositionSnapshot : null;
+    pushHeroOverviewVisibleCompositionTrace({
+      eventType,
+      frame: frameId,
+      t: round4(state?.clock?.elapsedTime),
+      state: animationData?.state ?? null,
+      cameraState: animationData?.cameraState ?? null,
+      viewMode: animationData?.viewMode ?? null,
+      phase,
+      selectedProject: animationData?.selectedProject ?? null,
+      writerId,
+      writerReason,
+      rawCameraX: round4(rawPose.position.x), rawCameraY: round4(rawPose.position.y), rawCameraZ: round4(rawPose.position.z),
+      rawLookAtX: round4(rawPose.lookAt.x), rawLookAtY: round4(rawPose.lookAt.y), rawLookAtZ: round4(rawPose.lookAt.z),
+      rawQuatX: round4(rawPose.quaternion.x), rawQuatY: round4(rawPose.quaternion.y), rawQuatZ: round4(rawPose.quaternion.z), rawQuatW: round4(rawPose.quaternion.w),
+      rawUpX: round4(rawPose.up.x), rawUpY: round4(rawPose.up.y), rawUpZ: round4(rawPose.up.z),
+      rawFov: round4(rawPose.fov), rawFilmOffset: round4(rawPose.filmOffset),
+      cameraParentName: camera.parent?.name || camera.parent?.type || null,
+      cameraParentWorldPosition: getObjectWorldTransformPlain(camera.parent)?.worldPosition ?? null,
+      cameraParentWorldQuaternion: getObjectWorldTransformPlain(camera.parent)?.worldQuaternion ?? null,
+      cameraParentWorldScale: getObjectWorldTransformPlain(camera.parent)?.worldScale ?? null,
+      worldCameraX: round4(worldPose.position.x), worldCameraY: round4(worldPose.position.y), worldCameraZ: round4(worldPose.position.z),
+      worldQuatX: round4(worldPose.quaternion.x), worldQuatY: round4(worldPose.quaternion.y), worldQuatZ: round4(worldPose.quaternion.z), worldQuatW: round4(worldPose.quaternion.w),
+      currentTargetX: round4(currentTargetPose?.position?.x), currentTargetY: round4(currentTargetPose?.position?.y), currentTargetZ: round4(currentTargetPose?.position?.z),
+      currentTargetLookAtX: round4(currentTargetPose?.lookAt?.x), currentTargetLookAtY: round4(currentTargetPose?.lookAt?.y), currentTargetLookAtZ: round4(currentTargetPose?.lookAt?.z),
+      currentTargetFov: round4(currentTargetPose?.fov), currentTargetFilmOffset: round4(currentTargetPose?.filmOffset),
+      previousFrameX: round4(previousPose?.position?.x), previousFrameY: round4(previousPose?.position?.y), previousFrameZ: round4(previousPose?.position?.z),
+      previousFrameLookAtX: round4(previousPose?.lookAt?.x), previousFrameLookAtY: round4(previousPose?.lookAt?.y), previousFrameLookAtZ: round4(previousPose?.lookAt?.z),
+      sceneRootPosition: sceneSnapshot?.crystalGroup?.worldPosition ?? null,
+      sceneRootQuaternion: sceneSnapshot?.crystalGroup?.worldQuaternion ?? null,
+      sceneRootScale: sceneSnapshot?.crystalGroup?.worldScale ?? null,
+      crystalGroupPosition: sceneSnapshot?.wholeCrystal?.worldPosition ?? null,
+      crystalGroupQuaternion: sceneSnapshot?.wholeCrystal?.worldQuaternion ?? null,
+      crystalGroupScale: sceneSnapshot?.wholeCrystal?.worldScale ?? null,
+      heroGroupPosition: sceneSnapshot?.facetsGroup?.worldPosition ?? null,
+      heroGroupQuaternion: sceneSnapshot?.facetsGroup?.worldQuaternion ?? null,
+      heroGroupScale: sceneSnapshot?.facetsGroup?.worldScale ?? null,
+      sceneSnapshotState: sceneSnapshot?.state ?? null,
+      sceneSnapshotCrystalForm: sceneSnapshot?.crystalForm ?? null,
+      sceneShowWholeCrystal: sceneSnapshot?.showWholeCrystal ?? null,
+      sceneShowFacets: sceneSnapshot?.showFacets ?? null,
+      heroOrbitAngle: round4(heroOrbitAngle.current),
+      heroPolarAngle: round4(heroPolarAngleRef.current),
+      heroOrbitActive: Boolean(isOrbitingRef.current),
+      compositionOffsetX: round4(heroCompositionOffsetRef.current?.x),
+      compositionOffsetY: round4(heroCompositionOffsetRef.current?.y),
+      compositionOffsetZ: round4(heroCompositionOffsetRef.current?.z),
+      heroVerticalOffset: round4(heroVerticalOffsetRef.current),
+      pilotHoldX: round4(pilotHoldPose?.position?.x), pilotHoldY: round4(pilotHoldPose?.position?.y), pilotHoldZ: round4(pilotHoldPose?.position?.z),
+      pilotHoldLookAtX: round4(pilotHoldPose?.lookAt?.x), pilotHoldLookAtY: round4(pilotHoldPose?.lookAt?.y), pilotHoldLookAtZ: round4(pilotHoldPose?.lookAt?.z),
+      distancePilotHoldToRawCamera: round4(pilotHoldPose?.position ? pilotHoldPose.position.distanceTo(rawPose.position) : null),
+      distancePilotHoldToWorldCamera: round4(pilotHoldPose?.position ? pilotHoldPose.position.distanceTo(worldPose.position) : null),
+      distancePilotHoldToCurrentTarget: round4(pilotHoldPose?.position && currentTargetPose?.position ? pilotHoldPose.position.distanceTo(currentTargetPose.position) : null),
+      distancePilotHoldToPreviousFramePose: round4(pilotHoldPose?.position && previousPose?.position ? pilotHoldPose.position.distanceTo(previousPose.position) : null),
+      distancePilotHoldToHeroOrbitState: round4(pilotHoldPose?.position && heroOrbitStatePose?.position ? pilotHoldPose.position.distanceTo(heroOrbitStatePose.position) : null),
+      lookAtDeltaPilotHoldToRawCamera: round4(pilotHoldPose?.lookAt ? pilotHoldPose.lookAt.distanceTo(rawPose.lookAt) : null),
+      lookAtDeltaPilotHoldToCurrentTarget: round4(pilotHoldPose?.lookAt && currentTargetPose?.lookAt ? pilotHoldPose.lookAt.distanceTo(currentTargetPose.lookAt) : null),
+      lookAtDeltaPilotHoldToPreviousFramePose: round4(pilotHoldPose?.lookAt && previousPose?.lookAt ? pilotHoldPose.lookAt.distanceTo(previousPose.lookAt) : null),
+      bestVisibleHeroPoseCandidate,
+      distancePilotHoldToBestCandidate: round4(distancePilotHoldToBestCandidate),
+      pilotHoldMatchesBestCandidate: Number.isFinite(distancePilotHoldToBestCandidate) ? distancePilotHoldToBestCandidate <= 0.001 : null,
+    });
+  };
   const markHeroOverviewPilotActivationTrace = (frame) => {
     if (!import.meta.env.DEV) return;
     getHeroOverviewPrePilotHeroTraceStore().pilotActivationFrame = frame;
+    getHeroOverviewVisibleCompositionTraceStore().pilotActivationFrame = frame;
   };
   const markHeroOverviewPilotFirstWriteTrace = (frame) => {
     if (!import.meta.env.DEV) return;
     const store = getHeroOverviewPrePilotHeroTraceStore();
     if (store.pilotFirstWriteFrame == null) store.pilotFirstWriteFrame = frame;
+    const visibleStore = getHeroOverviewVisibleCompositionTraceStore();
+    if (visibleStore.pilotFirstWriteFrame == null) visibleStore.pilotFirstWriteFrame = frame;
   };
   const captureHeroOverviewRenderedHeroPose = ({ source, writerId, writerReason, state, lookAt = null, phase = 'hero' }) => {
+    const frameId = cameraFrameIndexRef.current || state.clock.frame || null;
     const pose = cloneHeroOverviewLiveCameraPose(source, {
       writerId,
       writerReason,
-      frame: state.clock.frame,
+      frame: frameId,
       t: state.clock.elapsedTime,
       phase,
       heroOrbitAngle: heroOrbitAngle.current,
@@ -2132,7 +2302,7 @@ const UnifiedCameraController = ({
     }
     pushHeroOverviewPrePilotHeroTrace({
       eventType: 'hero-writer-after-write',
-      frame: state.clock.frame,
+      frame: frameId,
       t: round4(state.clock.elapsedTime),
       state: animationData?.state ?? null,
       cameraState: animationData?.cameraState ?? null,
@@ -2154,6 +2324,7 @@ const UnifiedCameraController = ({
       heroOrbitActive: Boolean(isOrbitingRef.current),
       authoritativeHeroActive: writerId === 'AUTHORITATIVE_HERO',
     });
+    pushHeroOverviewVisibleCompositionSample({ eventType: 'hero-writer-after-write', state, phase, writerId, writerReason });
     return pose;
   };
 
@@ -2589,6 +2760,10 @@ const UnifiedCameraController = ({
       prePilotStore.rows = [];
       prePilotStore.pilotActivationFrame = null;
       prePilotStore.pilotFirstWriteFrame = null;
+      const visibleStore = getHeroOverviewVisibleCompositionTraceStore();
+      visibleStore.rows = [];
+      visibleStore.pilotActivationFrame = null;
+      visibleStore.pilotFirstWriteFrame = null;
       heroOverviewPilotRef.current = {
         active: false,
         key: null,
@@ -2844,6 +3019,128 @@ const UnifiedCameraController = ({
       store.pilotActivationFrame = null;
       store.pilotFirstWriteFrame = null;
       console.log('[hero-overview-pre-pilot-trace] cleared');
+    };
+
+    globalThis.__clearHeroOverviewVisibleCompositionTrace = () => {
+      const store = getHeroOverviewVisibleCompositionTraceStore();
+      store.rows = [];
+      store.pilotActivationFrame = null;
+      store.pilotFirstWriteFrame = null;
+      console.log('[hero-overview-visible-composition] cleared');
+    };
+    globalThis.__printHeroOverviewVisibleCompositionTrace = () => {
+      const store = getHeroOverviewVisibleCompositionTraceStore();
+      const activationFrame = store.pilotActivationFrame;
+      const firstWriteFrame = store.pilotFirstWriteFrame;
+      const rows = store.rows.filter((row) => {
+        if (activationFrame == null && firstWriteFrame == null) return true;
+        const frame = row.frame ?? null;
+        if (frame == null) return true;
+        const lower = activationFrame != null ? activationFrame - 20 : (firstWriteFrame != null ? firstWriteFrame - 20 : frame);
+        const upper = firstWriteFrame != null ? firstWriteFrame + 10 : (activationFrame != null ? activationFrame + 10 : frame);
+        return frame >= lower && frame <= upper;
+      });
+      const vectorFromRow = (row, prefix) => {
+        const x = row?.[`${prefix}X`];
+        const y = row?.[`${prefix}Y`];
+        const z = row?.[`${prefix}Z`];
+        return Number.isFinite(x) && Number.isFinite(y) && Number.isFinite(z) ? new THREE.Vector3(x, y, z) : null;
+      };
+      const distanceBetweenRows = (first, last, prefix) => {
+        const a = vectorFromRow(first, prefix);
+        const b = vectorFromRow(last, prefix);
+        return a && b ? round4(a.distanceTo(b)) : null;
+      };
+      const heroRows = rows.filter((row) => row.eventType === 'hero-writer-after-write');
+      const firstHero = heroRows[0] ?? null;
+      const lastHero = heroRows[heroRows.length - 1] ?? null;
+      const latestPilot = [...rows].reverse().find((row) => row.pilotHoldX != null || row.eventType === 'pilot-frame-after-write' || row.eventType === 'pilot-hold-pose-lock') ?? null;
+      const rawMove = distanceBetweenRows(firstHero, lastHero, 'rawCamera');
+      const worldMove = distanceBetweenRows(firstHero, lastHero, 'worldCamera');
+      const quaternionMove = firstHero && lastHero && Number.isFinite(firstHero.rawQuatX) && Number.isFinite(lastHero.rawQuatX)
+        ? round4(Math.abs(firstHero.rawQuatX - lastHero.rawQuatX) + Math.abs(firstHero.rawQuatY - lastHero.rawQuatY) + Math.abs(firstHero.rawQuatZ - lastHero.rawQuatZ) + Math.abs(firstHero.rawQuatW - lastHero.rawQuatW))
+        : null;
+      const filmOffsetMove = firstHero && lastHero && Number.isFinite(firstHero.rawFilmOffset) && Number.isFinite(lastHero.rawFilmOffset)
+        ? round4(Math.abs(firstHero.rawFilmOffset - lastHero.rawFilmOffset))
+        : null;
+      const nestedDistance = (a, b, field) => {
+        const av = a?.[field];
+        const bv = b?.[field];
+        if (!av || !bv) return null;
+        return round4(new THREE.Vector3(av.x, av.y, av.z).distanceTo(new THREE.Vector3(bv.x, bv.y, bv.z)));
+      };
+      const sceneRootMove = nestedDistance(firstHero, lastHero, 'sceneRootPosition');
+      const crystalGroupMove = nestedDistance(firstHero, lastHero, 'crystalGroupPosition');
+      const summary = {
+        sampleCount: rows.length,
+        pilotActivationFrame: activationFrame,
+        pilotFirstWriteFrame: firstWriteFrame,
+        rawCameraMovedDuringHeroOrbit: rawMove != null ? rawMove > 0.001 : null,
+        cameraWorldMovedDuringHeroOrbit: worldMove != null ? worldMove > 0.001 : null,
+        cameraQuaternionChangedDuringHeroOrbit: quaternionMove != null ? quaternionMove > 0.001 : null,
+        filmOffsetChangedDuringHeroOrbit: filmOffsetMove != null ? filmOffsetMove > 0.001 : null,
+        sceneRootMovedDuringHeroOrbit: sceneRootMove != null ? sceneRootMove > 0.001 : null,
+        crystalGroupMovedDuringHeroOrbit: crystalGroupMove != null ? crystalGroupMove > 0.001 : null,
+        rawCameraMoveDistanceDuringHeroOrbit: rawMove,
+        cameraWorldMoveDistanceDuringHeroOrbit: worldMove,
+        sceneRootMoveDistanceDuringHeroOrbit: sceneRootMove,
+        crystalGroupMoveDistanceDuringHeroOrbit: crystalGroupMove,
+        bestVisibleHeroPoseCandidate: latestPilot?.bestVisibleHeroPoseCandidate ?? null,
+        distancePilotHoldToBestCandidate: latestPilot?.distancePilotHoldToBestCandidate ?? null,
+        pilotHoldMatchesBestCandidate: latestPilot?.pilotHoldMatchesBestCandidate ?? null,
+        visibleOrbitLikelyCameraBased: (worldMove ?? rawMove ?? 0) > 0.001,
+        visibleOrbitLikelySceneBased: (sceneRootMove ?? 0) > 0.001 || (crystalGroupMove ?? 0) > 0.001,
+        visibleOrbitLikelyProjectionBased: (filmOffsetMove ?? 0) > 0.001,
+      };
+      console.log('[hero-overview-visible-composition] summary', summary);
+      console.table(rows.map((row) => ({
+        sampleIndex: row.sampleIndex,
+        eventType: row.eventType,
+        frame: row.frame,
+        t: row.t,
+        state: row.state,
+        cameraState: row.cameraState,
+        viewMode: row.viewMode,
+        phase: row.phase,
+        writerId: row.writerId,
+        writerReason: row.writerReason,
+        rawCameraX: row.rawCameraX,
+        rawCameraY: row.rawCameraY,
+        rawCameraZ: row.rawCameraZ,
+        worldCameraX: row.worldCameraX,
+        worldCameraY: row.worldCameraY,
+        worldCameraZ: row.worldCameraZ,
+        rawQuatX: row.rawQuatX,
+        rawQuatY: row.rawQuatY,
+        rawQuatZ: row.rawQuatZ,
+        rawQuatW: row.rawQuatW,
+        rawFov: row.rawFov,
+        rawFilmOffset: row.rawFilmOffset,
+        cameraParentName: row.cameraParentName,
+        cameraParentWorldPosition: row.cameraParentWorldPosition,
+        sceneRootPosition: row.sceneRootPosition,
+        crystalGroupPosition: row.crystalGroupPosition,
+        heroGroupPosition: row.heroGroupPosition,
+        heroOrbitAngle: row.heroOrbitAngle,
+        heroOrbitActive: row.heroOrbitActive,
+        currentTargetX: row.currentTargetX,
+        currentTargetY: row.currentTargetY,
+        currentTargetZ: row.currentTargetZ,
+        previousFrameX: row.previousFrameX,
+        previousFrameY: row.previousFrameY,
+        previousFrameZ: row.previousFrameZ,
+        pilotHoldX: row.pilotHoldX,
+        pilotHoldY: row.pilotHoldY,
+        pilotHoldZ: row.pilotHoldZ,
+        distancePilotHoldToRawCamera: row.distancePilotHoldToRawCamera,
+        distancePilotHoldToWorldCamera: row.distancePilotHoldToWorldCamera,
+        distancePilotHoldToCurrentTarget: row.distancePilotHoldToCurrentTarget,
+        distancePilotHoldToPreviousFramePose: row.distancePilotHoldToPreviousFramePose,
+        distancePilotHoldToHeroOrbitState: row.distancePilotHoldToHeroOrbitState,
+        bestVisibleHeroPoseCandidate: row.bestVisibleHeroPoseCandidate,
+        distancePilotHoldToBestCandidate: row.distancePilotHoldToBestCandidate,
+        pilotHoldMatchesBestCandidate: row.pilotHoldMatchesBestCandidate,
+      })));
     };
     globalThis.__printHeroOverviewPrePilotHeroTrace = () => {
       const store = getHeroOverviewPrePilotHeroTraceStore();
@@ -3611,8 +3908,10 @@ const UnifiedCameraController = ({
   };
 
   useFrame((state, delta) => {
+    cameraFrameIndexRef.current += 1;
+    const cameraFrameId = cameraFrameIndexRef.current;
     syncFractureTiltState(state.clock.elapsedTime);
-    beginCameraFrame(state.clock.frame, { elapsed: state.clock.elapsedTime, phase: animationData?.cameraState ?? null });
+    beginCameraFrame(cameraFrameId, { elapsed: state.clock.elapsedTime, phase: animationData?.cameraState ?? null });
 
     const debugSecond = Math.floor(state.clock.elapsedTime);
 
@@ -3722,7 +4021,7 @@ const UnifiedCameraController = ({
       pushHeroOverviewPilotSample({
         type: shouldStartHeroOverviewPilotScaffold ? 'activation-eligible' : 'activation-blocked',
         t: round4(state.clock.elapsedTime),
-        frame: state.clock.frame,
+        frame: cameraFrameIndexRef.current,
         activationKey: heroOverviewActivationKey,
         transitionKey: heroOverviewTransitionKey,
         pilotEnabled: true,
@@ -4064,12 +4363,12 @@ const UnifiedCameraController = ({
           filmOffsetChangedDuringHold: false,
         },
       };
-      markHeroOverviewPilotActivationTrace(state.clock.frame);
+      markHeroOverviewPilotActivationTrace(cameraFrameIndexRef.current);
       const pilotStore = getHeroOverviewPilotDiagnosticsStore();
       pilotStore.samples.push({
         type: 'milestone-a-scaffold-capture',
         t: round4(state.clock.elapsedTime),
-        frame: state.clock.frame,
+        frame: cameraFrameIndexRef.current,
         key: heroOverviewActivationKey,
         transitionKey: heroOverviewTransitionKey,
         pilotEnabled: isHeroToOverviewPilotEnabled(),
@@ -4971,7 +5270,7 @@ const UnifiedCameraController = ({
         let livePoseBeforeFirstPilotWrite = null;
         if (!transition.holdPoseLocked) {
           livePoseBeforeFirstPilotWrite = cloneHeroOverviewLiveCameraPose('live-camera-before-first-pilot-write', {
-            frame: state.clock.frame,
+            frame: cameraFrameIndexRef.current,
             t: state.clock.elapsedTime,
             writerId: 'LIVE_CAMERA_BEFORE_PILOT',
             writerReason: 'before-first-active-pilot-write',
@@ -4982,7 +5281,7 @@ const UnifiedCameraController = ({
           const lastHeroOrbitPose = cloneHeroOverviewStoredPose(lastHeroOrbitRenderedPoseRef.current, lastHeroOrbitRenderedPoseRef.current?.source ?? 'last-hero-orbit-pose');
           const lastAuthoritativeHeroPose = cloneHeroOverviewStoredPose(lastAuthoritativeHeroRenderedPoseRef.current, lastAuthoritativeHeroRenderedPoseRef.current?.source ?? 'last-authoritative-hero-pose');
           const heroPoseFrameDelta = Number.isFinite(lastVisibleHeroPose?.frame)
-            ? state.clock.frame - lastVisibleHeroPose.frame
+            ? cameraFrameIndexRef.current - lastVisibleHeroPose.frame
             : Number.POSITIVE_INFINITY;
           const canUseLastVisibleHeroPose = Boolean(
             lastVisibleHeroPose?.position &&
@@ -4993,7 +5292,7 @@ const UnifiedCameraController = ({
           const activeHoldPose = canUseLastVisibleHeroPose
             ? cloneHeroOverviewStoredPose(lastVisibleHeroPose, `last-visible-hero-orbit-pose:${lastVisibleHeroPose.writerId ?? lastVisibleHeroPose.source ?? 'unknown'}`)
             : cloneHeroOverviewLiveCameraPose('first-active-pilot-write-live-camera-transform', {
-                frame: state.clock.frame,
+                frame: cameraFrameIndexRef.current,
                 t: state.clock.elapsedTime,
                 writerId: 'LIVE_CAMERA_AT_PILOT_LOCK',
                 writerReason: 'fallback-live-camera-transform',
@@ -5005,7 +5304,7 @@ const UnifiedCameraController = ({
           transition.fromPose = activeHoldPose;
           transition.holdPose = activeHoldPose;
           transition.holdPoseLocked = true;
-          transition.holdPoseLockedAtFrame = state.clock.frame;
+          transition.holdPoseLockedAtFrame = cameraFrameIndexRef.current;
           transition.holdPoseLockedAtPhase = canUseLastVisibleHeroPose ? 'first-active-pilot-write:last-visible-hero-pose' : 'first-active-pilot-write:live-camera-fallback';
           transition.holdPoseLockedAfterHeroOrbitWrite = previousWriterBeforePilot === 'AUTHORITATIVE_HERO' || previousWriterBeforePilot === 'HERO_ORBIT';
           transition.holdPosePreviousWriter = previousWriterBeforePilot;
@@ -5052,10 +5351,18 @@ const UnifiedCameraController = ({
             latestAuthoritativeHeroAngle: round4(latestAuthoritativeHeroSnapshotRef.current?.angle),
             latestAuthoritativeHeroOrbitElapsed: round4(latestAuthoritativeHeroSnapshotRef.current?.orbitElapsed),
           };
-          markHeroOverviewPilotFirstWriteTrace(state.clock.frame);
+          markHeroOverviewPilotFirstWriteTrace(cameraFrameIndexRef.current);
+          pushHeroOverviewVisibleCompositionSample({
+            eventType: 'pilot-hold-pose-lock',
+            state,
+            phase: 'hero->overview',
+            writerId: 'HERO_OVERVIEW_PILOT',
+            writerReason: 'first-active-pilot-write-hold-pose-lock',
+            pilotHoldPose: activeHoldPose,
+          });
           pushHeroOverviewPrePilotHeroTrace({
             eventType: 'pilot-hold-pose-lock',
-            frame: state.clock.frame,
+            frame: cameraFrameIndexRef.current,
             t: round4(state.clock.elapsedTime),
             state: animationData?.state ?? null,
             cameraState: animationData?.cameraState ?? null,
@@ -5072,7 +5379,7 @@ const UnifiedCameraController = ({
             heroOrbitPose: heroOverviewPoseToPlain(lastHeroOrbitPose),
             finalCameraPoseAtEndOfFrame: null,
             pilotActivationFrame: getHeroOverviewPrePilotHeroTraceStore().pilotActivationFrame,
-            pilotFirstWriteFrame: state.clock.frame,
+            pilotFirstWriteFrame: cameraFrameIndexRef.current,
             pilotLockedHoldPose: heroOverviewPoseToPlain(activeHoldPose),
             lastWriterBeforePilotLock: previousWriterBeforePilot,
             lastHeroWriterBeforePilotLock: lastVisibleHeroPose?.writerId ?? null,
@@ -5145,7 +5452,7 @@ const UnifiedCameraController = ({
         const nextFov = isFinalPoseLocked ? toFov : THREE.MathUtils.lerp(fromFov, toFov, cameraTravelEasedProgress);
         const nextFilmOffset = isFinalPoseLocked ? toFilmOffset : THREE.MathUtils.lerp(fromFilmOffset, toFilmOffset, cameraTravelEasedProgress);
         if (transition.firstTravelFrame == null && cameraTravelEasedProgress > 0.0001) {
-          transition.firstTravelFrame = state.clock.frame;
+          transition.firstTravelFrame = cameraFrameIndexRef.current;
           transition.travelStartTime = state.clock.elapsedTime;
           transition.travelStartProgress = globalProgress;
         }
@@ -5199,10 +5506,10 @@ const UnifiedCameraController = ({
         const lookAtDeltaToTarget = safeDistance(nextLookAt, toPose.lookAt);
         const filmOffsetDeltaToTarget = round4(Math.abs((camera.filmOffset ?? 0) - (toFilmOffset ?? 0)));
         const prePilotTraceStore = getHeroOverviewPrePilotHeroTraceStore();
-        if (prePilotTraceStore.pilotFirstWriteFrame != null && state.clock.frame <= prePilotTraceStore.pilotFirstWriteFrame + 5) {
+        if (prePilotTraceStore.pilotFirstWriteFrame != null && cameraFrameIndexRef.current <= prePilotTraceStore.pilotFirstWriteFrame + 5) {
           pushHeroOverviewPrePilotHeroTrace({
             eventType: 'pilot-frame-after-write',
-            frame: state.clock.frame,
+            frame: cameraFrameIndexRef.current,
             t: round4(state.clock.elapsedTime),
             state: animationData?.state ?? null,
             cameraState: animationData?.cameraState ?? null,
@@ -5217,7 +5524,7 @@ const UnifiedCameraController = ({
             filmOffset: round4(camera.filmOffset),
             authoritativeHeroPose: heroOverviewPoseToPlain(transition.lastAuthoritativeHeroPoseBeforePilotLock),
             heroOrbitPose: heroOverviewPoseToPlain(transition.lastHeroOrbitPoseBeforePilotLock),
-            finalCameraPoseAtEndOfFrame: heroOverviewPoseToPlain(cloneHeroOverviewLiveCameraPose('pilot-frame-after-write', { writerId: 'HERO_OVERVIEW_PILOT', writerReason: 'hero-overview-pilot-active', frame: state.clock.frame, t: state.clock.elapsedTime })),
+            finalCameraPoseAtEndOfFrame: heroOverviewPoseToPlain(cloneHeroOverviewLiveCameraPose('pilot-frame-after-write', { writerId: 'HERO_OVERVIEW_PILOT', writerReason: 'hero-overview-pilot-active', frame: cameraFrameIndexRef.current, t: state.clock.elapsedTime })),
             pilotActivationFrame: prePilotTraceStore.pilotActivationFrame,
             pilotFirstWriteFrame: prePilotTraceStore.pilotFirstWriteFrame,
             pilotLockedHoldPose: heroOverviewPoseToPlain(transition.fromPose),
@@ -5234,13 +5541,21 @@ const UnifiedCameraController = ({
             heroOrbitActive: Boolean(transition.lastHeroOrbitPoseBeforePilotLock?.heroOrbitActive),
             authoritativeHeroActive: transition.lastHeroWriterBeforePilotLock === 'AUTHORITATIVE_HERO',
           });
+          pushHeroOverviewVisibleCompositionSample({
+            eventType: 'pilot-frame-after-write',
+            state,
+            phase: pilotPhase,
+            writerId: 'HERO_OVERVIEW_PILOT',
+            writerReason: 'hero-overview-pilot-active',
+            pilotHoldPose: transition.fromPose,
+          });
         }
         pushHeroOverviewPilotSample({
           type: globalProgress >= 1 ? 'completion-handoff' : 'pilot-frame',
           pilotDiagnosticVersion: 'Milestone C live hold-pose lock',
           pilotCinematicMilestone: 'Milestone C hold-pose lock',
           t: round4(state.clock.elapsedTime),
-          frame: state.clock.frame,
+          frame: cameraFrameIndexRef.current,
           key: pilot.key,
           activationFromPoseSource: transition.activationFromPoseSource ?? null,
           activeHoldPoseSource: transition.activeHoldPoseSource ?? null,
@@ -5441,7 +5756,7 @@ const UnifiedCameraController = ({
             pilotDiagnosticVersion: 'Milestone C live hold-pose lock',
             pilotCinematicMilestone: 'Milestone C hold-pose lock',
             t: round4(state.clock.elapsedTime),
-            frame: state.clock.frame,
+            frame: cameraFrameIndexRef.current,
             key: pilot.key,
             activationFromPoseSource: transition.activationFromPoseSource ?? null,
             activeHoldPoseSource: transition.activeHoldPoseSource ?? null,
@@ -6575,7 +6890,7 @@ const UnifiedCameraController = ({
           type: 'handoff-lock-frame',
           pilotDiagnosticVersion: 'Milestone C live hold-pose lock',
           t: round4(state.clock.elapsedTime),
-          frame: state.clock.frame,
+          frame: cameraFrameIndexRef.current,
           key: heroOverviewPilotRef.current.key,
           phase: 'handoffLock',
           globalProgress: 1,
@@ -7269,7 +7584,7 @@ const UnifiedCameraController = ({
     if (import.meta.env.DEV && forcedRecentlyCompleted) {
       const seamRows = heroToOverviewHandoffSeamRowsRef.current;
       seamRows.push({
-        frame: state.clock.frame,
+        frame: cameraFrameIndexRef.current,
         framesSinceForcedCompletion,
         activeWriter: lastCameraWriterRef.current,
         activeWriterReason: lastCameraWriteReasonRef.current,

--- a/src/components/three/UnifiedCameraController.jsx
+++ b/src/components/three/UnifiedCameraController.jsx
@@ -19,8 +19,38 @@ const PROJECT_OVERVIEW_POSITION_SETTLE_EPSILON = 0.01;
 const PROJECT_OVERVIEW_LOOKAT_SETTLE_EPSILON = 0.01;
 const PROJECT_OVERVIEW_FOV_SETTLE_EPSILON = 0.02;
 const PROJECT_OVERVIEW_PROGRESS_SETTLE_MIN = 0.99;
-const HERO_OVERVIEW_PHASE_ORDER = ['fractureCharge', 'explosionImpulse', 'bulletTimeSlowdown', 'overviewSettle', 'complete'];
+const HERO_OVERVIEW_PHASE_ORDER = ['fractureCharge', 'explosionImpulse', 'bulletTimeSlowdown', 'overviewTravel', 'overviewSettle', 'complete'];
 const HERO_OVERVIEW_PILOT_PHASES = ['fractureCharge', 'explosionImpulse', 'bulletTimeSlowdown', 'overviewTravel', 'overviewSettle', 'complete'];
+const HERO_OVERVIEW_PILOT_CAMERA_TIMELINE = {
+  fractureCharge: {
+    start: 0,
+    end: 0.16,
+    cameraMode: 'hold',
+  },
+  explosionImpulse: {
+    start: 0.16,
+    end: 0.26,
+    cameraMode: 'impactHold',
+  },
+  bulletTimeSlowdown: {
+    start: 0.26,
+    end: 0.42,
+    cameraMode: 'suspendedHold',
+  },
+  overviewTravel: {
+    start: 0.42,
+    end: 0.88,
+    cameraMode: 'travel',
+    easing: 'expoOut',
+  },
+  overviewSettle: {
+    start: 0.88,
+    end: 1,
+    cameraMode: 'settle',
+    easing: 'smoothSettle',
+  },
+};
+const HERO_OVERVIEW_PILOT_HOLD_PHASES = ['fractureCharge', 'explosionImpulse', 'bulletTimeSlowdown'];
 const HERO_OVERVIEW_PILOT_PHASE_BEHAVIORS = {
   fractureCharge: { cameraOwner: 'pilot', behavior: 'hold-live-captured-hero-pose', writesCamera: true },
   explosionImpulse: { cameraOwner: 'pilot', behavior: 'baseline-equivalent-fracture-influence-or-hold', writesCamera: true },
@@ -1864,6 +1894,61 @@ const UnifiedCameraController = ({
   };
 
 
+
+  const getHeroOverviewPilotPhaseMetrics = () => HERO_OVERVIEW_PILOT_PHASES.reduce((acc, phase) => {
+    acc[phase] = 0;
+    return acc;
+  }, {});
+  const getHeroOverviewPilotTimelinePhase = (progress) => {
+    const clampedProgress = THREE.MathUtils.clamp(Number.isFinite(progress) ? progress : 0, 0, 1);
+    const phaseName = HERO_OVERVIEW_PILOT_PHASES.find((name) => {
+      if (name === 'complete') return clampedProgress >= 1;
+      const phase = HERO_OVERVIEW_PILOT_CAMERA_TIMELINE[name];
+      if (!phase) return false;
+      return clampedProgress >= phase.start && clampedProgress < phase.end;
+    }) ?? (clampedProgress >= 1 ? 'complete' : 'overviewSettle');
+    const phase = HERO_OVERVIEW_PILOT_CAMERA_TIMELINE[phaseName] ?? { start: 1, end: 1, cameraMode: 'complete' };
+    const phaseLocalProgress = phase.end > phase.start
+      ? THREE.MathUtils.clamp((clampedProgress - phase.start) / (phase.end - phase.start), 0, 1)
+      : 1;
+    return { phaseName, phase, phaseLocalProgress };
+  };
+  const easeHeroOverviewPilotProgress = (progress, easing = 'linear') => {
+    const t = THREE.MathUtils.clamp(Number.isFinite(progress) ? progress : 0, 0, 1);
+    if (easing === 'expoOut') return t >= 1 ? 1 : THREE.MathUtils.clamp(1 - (2 ** (-10 * t)), 0, 1);
+    if (easing === 'smoothSettle') return t * t * (3 - 2 * t);
+    return t;
+  };
+  const getHeroOverviewPilotCameraProgress = (globalProgress) => {
+    const { phaseName, phase, phaseLocalProgress } = getHeroOverviewPilotTimelinePhase(globalProgress);
+    const travelPhase = HERO_OVERVIEW_PILOT_CAMERA_TIMELINE.overviewTravel;
+    let cameraTravelProgress = 0;
+    let cameraTravelEasedProgress = 0;
+    let cameraTravelEasing = phase.easing ?? 'none';
+    if (phaseName === 'overviewTravel') {
+      cameraTravelProgress = phaseLocalProgress;
+      cameraTravelEasedProgress = easeHeroOverviewPilotProgress(cameraTravelProgress, phase.easing ?? 'expoOut');
+    } else if (phaseName === 'overviewSettle' || phaseName === 'complete' || globalProgress >= travelPhase.end) {
+      cameraTravelProgress = 1;
+      cameraTravelEasedProgress = 1;
+      cameraTravelEasing = phase.easing ?? 'smoothSettle';
+    }
+    return {
+      phaseName,
+      cameraMode: phase.cameraMode ?? 'unknown',
+      phaseStart: phase.start ?? null,
+      phaseEnd: phase.end ?? null,
+      phaseLocalProgress,
+      cameraTravelProgress,
+      cameraTravelEasedProgress,
+      cameraTravelEasing,
+      isHoldingCamera: HERO_OVERVIEW_PILOT_HOLD_PHASES.includes(phaseName),
+      travelStartProgress: travelPhase.start,
+      travelDuration: travelPhase.end - travelPhase.start,
+      settleStartProgress: HERO_OVERVIEW_PILOT_CAMERA_TIMELINE.overviewSettle.start,
+    };
+  };
+
   const getOverviewProjectShadowStore = () => {
     if (typeof globalThis === 'undefined') return overviewProjectShadowRef.current;
     if (!globalThis.__overviewProjectShadowStore) {
@@ -2399,7 +2484,8 @@ const UnifiedCameraController = ({
       const latest = store.samples[store.samples.length - 1] ?? null;
       const summary = {
         pilotEnabled: isHeroToOverviewPilotEnabled(),
-        pilotDiagnosticVersion: latest?.pilotDiagnosticVersion ?? 'PR-25-live-lookat-takeover-clear',
+        pilotDiagnosticVersion: latest?.pilotDiagnosticVersion ?? 'Milestone C cinematic timeline',
+        pilotCinematicMilestone: latest?.pilotCinematicMilestone ?? heroOverviewPilotRef.current.transition?.pilotCinematicMilestone ?? 'Milestone C',
         sampleCount: store.samples.length,
         captureAttempted: latest?.captureAttempted ?? false,
         captureSucceeded: latest?.captureSucceeded ?? false,
@@ -2414,6 +2500,7 @@ const UnifiedCameraController = ({
         ownsCameraInMilestoneB: latest?.ownsCameraInMilestoneB ?? heroOverviewPilotRef.current.transition?.ownsCameraInMilestoneB ?? false,
         phaseModel: HERO_OVERVIEW_PILOT_PHASES,
         phaseBehaviors: HERO_OVERVIEW_PILOT_PHASE_BEHAVIORS,
+        cameraTimeline: HERO_OVERVIEW_PILOT_CAMERA_TIMELINE,
         fromPoseSource: latest?.fromPoseSource ?? heroOverviewPilotRef.current.transition?.fromPoseSource ?? null,
         fromLookAtSource: latest?.fromLookAtSource ?? heroOverviewPilotRef.current.transition?.fromLookAtSource ?? null,
         targetResolved: Boolean(heroOverviewPilotRef.current.transition?.toPose),
@@ -2604,6 +2691,95 @@ const UnifiedCameraController = ({
       });
       console.table(rows);
     };
+
+    globalThis.__printHeroOverviewPilotCinematic = () => {
+      const store = getHeroOverviewPilotDiagnosticsStore();
+      const samples = store.samples.filter((sample) => sample.type === 'pilot-frame' || sample.type === 'completion-handoff' || sample.type === 'pilot-completion-finalized');
+      if (!samples.length) return console.log('[hero-overview-pilot] cinematic-summary', { sampleCount: 0, pilotCinematicMilestone: 'Milestone C' });
+      const latest = samples[samples.length - 1];
+      const movementThreshold = 0.001;
+      const phaseRows = (phase) => samples.filter((sample) => sample.phase === phase);
+      const distanceFromLatest = (phase, field) => latest?.[field] ?? phaseRows(phase).reduce((sum, sample) => sum + Number(sample.distanceMovedSincePreviousSample || 0), 0);
+      const firstTravelSample = samples.find((sample) => (sample.cameraTravelEasedProgress ?? 0) > 0.0001) ?? null;
+      const travelBeginsInOverviewTravel = firstTravelSample?.phase === 'overviewTravel';
+      const fractureChargeDistance = Number(distanceFromLatest('fractureCharge', 'distanceMovedDuringFractureCharge') ?? 0);
+      const explosionImpulseDistance = Number(distanceFromLatest('explosionImpulse', 'distanceMovedDuringExplosionImpulse') ?? 0);
+      const bulletTimeDistance = Number(distanceFromLatest('bulletTimeSlowdown', 'distanceMovedDuringBulletTimeSlowdown') ?? 0);
+      const overviewTravelDistance = Number(distanceFromLatest('overviewTravel', 'distanceMovedDuringOverviewTravel') ?? 0);
+      const overviewSettleDistance = Number(distanceFromLatest('overviewSettle', 'distanceMovedDuringOverviewSettle') ?? 0);
+      const pilotToLegacy = getPoseParityDeltas(heroOverviewPilotRef.current.transition?.toPose, getHeroOverviewLegacyFinalPose());
+      const finalTargetParityPasses = Boolean(
+        pilotToLegacy.positionDelta !== null && pilotToLegacy.positionDelta <= 0.001 &&
+        pilotToLegacy.lookAtDelta !== null && pilotToLegacy.lookAtDelta <= 0.001 &&
+        pilotToLegacy.fovDelta !== null && pilotToLegacy.fovDelta <= 0.001 &&
+        pilotToLegacy.filmOffsetDelta !== null && pilotToLegacy.filmOffsetDelta <= 0.001
+      );
+      const maxRollDelta = samples.reduce((max, sample) => Math.max(max, Number(sample.rollDeltaFromWorldUp || 0)), 0);
+      const maxUpDelta = samples.reduce((max, sample) => Math.max(max, Number(sample.upDeltaFromWorldUp || 0)), 0);
+      const competingWriterAppeared = samples.some((sample) => sample.competingWriterDetected === true);
+      const summary = {
+        pilotCinematicMilestone: 'Milestone C',
+        sampleCount: samples.length,
+        cameraTimeline: HERO_OVERVIEW_PILOT_CAMERA_TIMELINE,
+        holdPhases: HERO_OVERVIEW_PILOT_HOLD_PHASES,
+        firstActualTravelPhase: firstTravelSample?.phase ?? null,
+        firstActualTravelFrame: firstTravelSample?.frame ?? null,
+        firstActualTravelGlobalProgress: firstTravelSample?.globalProgress ?? null,
+        configuredTravelStartProgress: HERO_OVERVIEW_PILOT_CAMERA_TIMELINE.overviewTravel.start,
+        transitionTravelStartProgress: latest?.travelStartProgress ?? null,
+        transitionTravelStartTime: latest?.travelStartTime ?? null,
+        travelDuration: latest?.travelDuration ?? round4(HERO_OVERVIEW_PILOT_CAMERA_TIMELINE.overviewTravel.end - HERO_OVERVIEW_PILOT_CAMERA_TIMELINE.overviewTravel.start),
+        settleStartProgress: latest?.settleStartProgress ?? HERO_OVERVIEW_PILOT_CAMERA_TIMELINE.overviewSettle.start,
+        cameraDistanceMovedByPhase: {
+          fractureCharge: round4(fractureChargeDistance),
+          explosionImpulse: round4(explosionImpulseDistance),
+          bulletTimeSlowdown: round4(bulletTimeDistance),
+          overviewTravel: round4(overviewTravelDistance),
+          overviewSettle: round4(overviewSettleDistance),
+        },
+        fractureChargeStayedStill: fractureChargeDistance <= movementThreshold,
+        explosionImpulseStayedStill: explosionImpulseDistance <= movementThreshold,
+        bulletTimeSlowdownStayedStill: bulletTimeDistance <= movementThreshold,
+        travelBeginsInOverviewTravel,
+        finalTargetParityPasses,
+        rollUpGuardClean: maxRollDelta <= 0.0001 && maxUpDelta <= 0.0001,
+        maxRollDeltaDuringPilot: round4(maxRollDelta),
+        maxUpDeltaDuringPilot: round4(maxUpDelta),
+        competingWriterAppeared,
+        legacyForcedWriterBlocked: samples.some((sample) => sample.legacyForcedWriterBlocked === true),
+        fovChangedDuringHold: samples.some((sample) => sample.fovChangedDuringHold === true),
+        filmOffsetChangedDuringHold: samples.some((sample) => sample.filmOffsetChangedDuringHold === true),
+        finalPoseLocked: latest?.finalPoseLocked ?? false,
+      };
+      console.log('[hero-overview-pilot] cinematic-summary', summary);
+      console.table(samples.map((sample) => ({
+        type: sample.type ?? null,
+        frame: sample.frame ?? null,
+        phase: sample.phase ?? null,
+        cameraMode: sample.cameraMode ?? null,
+        globalProgress: sample.globalProgress ?? null,
+        phaseLocalProgress: sample.phaseLocalProgress ?? null,
+        cameraTravelProgress: sample.cameraTravelProgress ?? null,
+        cameraTravelEasedProgress: sample.cameraTravelEasedProgress ?? null,
+        cameraTravelEasing: sample.cameraTravelEasing ?? null,
+        isHoldingCamera: sample.isHoldingCamera ?? null,
+        finalPoseLocked: sample.finalPoseLocked ?? null,
+        distanceMovedDuringFractureCharge: sample.distanceMovedDuringFractureCharge ?? null,
+        distanceMovedDuringExplosionImpulse: sample.distanceMovedDuringExplosionImpulse ?? null,
+        distanceMovedDuringBulletTimeSlowdown: sample.distanceMovedDuringBulletTimeSlowdown ?? null,
+        distanceMovedDuringOverviewTravel: sample.distanceMovedDuringOverviewTravel ?? null,
+        distanceMovedDuringOverviewSettle: sample.distanceMovedDuringOverviewSettle ?? null,
+        fovChangedDuringHold: sample.fovChangedDuringHold ?? null,
+        filmOffsetChangedDuringHold: sample.filmOffsetChangedDuringHold ?? null,
+        activeToPoseSource: sample.activeToPoseSource ?? null,
+        activeToPoseFov: sample.activeToPoseFov ?? null,
+        activeToPoseFilmOffset: sample.activeToPoseFilmOffset ?? null,
+        rollDeltaFromWorldUp: sample.rollDeltaFromWorldUp ?? null,
+        upDeltaFromWorldUp: sample.upDeltaFromWorldUp ?? null,
+        competingWriterDetected: sample.competingWriterDetected ?? null,
+      })));
+    };
+
     globalThis.__markHeroOverviewVisualIssue = (description = 'visual-issue') => {
       const store = getHeroOverviewFullTimelineStore();
       store.markers.push({ t: round4(performance.now() / 1000), frame: null, description });
@@ -3563,6 +3739,8 @@ const UnifiedCameraController = ({
           startedAt: state.clock.elapsedTime,
           phaseModel: HERO_OVERVIEW_PILOT_PHASES,
           phaseBehaviors: HERO_OVERVIEW_PILOT_PHASE_BEHAVIORS,
+          cameraTimeline: HERO_OVERVIEW_PILOT_CAMERA_TIMELINE,
+          pilotCinematicMilestone: 'Milestone C',
           ownsCameraInMilestoneA: false,
           ownsCameraInMilestoneB: Boolean(resolvedOverview),
           legacyForcedWriterBlocked: Boolean(resolvedOverview),
@@ -3590,6 +3768,15 @@ const UnifiedCameraController = ({
           monotonicGlobalProgress: 0,
           fromPoseRecaptured: false,
           targetPoseRecalculated: false,
+          firstTravelFrame: null,
+          travelStartTime: null,
+          travelStartProgress: HERO_OVERVIEW_PILOT_CAMERA_TIMELINE.overviewTravel.start,
+          travelDuration: HERO_OVERVIEW_PILOT_CAMERA_TIMELINE.overviewTravel.end - HERO_OVERVIEW_PILOT_CAMERA_TIMELINE.overviewTravel.start,
+          settleStartProgress: HERO_OVERVIEW_PILOT_CAMERA_TIMELINE.overviewSettle.start,
+          phaseDistanceMoved: getHeroOverviewPilotPhaseMetrics(),
+          previousCinematicCameraPosition: camera.position.clone(),
+          fovChangedDuringHold: false,
+          filmOffsetChangedDuringHold: false,
         },
       };
       const pilotStore = getHeroOverviewPilotDiagnosticsStore();
@@ -3600,7 +3787,9 @@ const UnifiedCameraController = ({
         key: heroOverviewActivationKey,
         transitionKey: heroOverviewTransitionKey,
         pilotEnabled: isHeroToOverviewPilotEnabled(),
-        pilotDiagnosticVersion: 'PR-25-live-lookat-takeover-clear',
+        pilotDiagnosticVersion: 'Milestone C cinematic timeline',
+        pilotCinematicMilestone: 'Milestone C',
+        cameraTimeline: HERO_OVERVIEW_PILOT_CAMERA_TIMELINE,
         captureAttempted: true,
         captureSucceeded: Boolean(resolvedOverview),
         activationConditionMatched: true,
@@ -3663,7 +3852,31 @@ const UnifiedCameraController = ({
         targetCameraToLookAtDistance: resolvedOverview ? safeDistance(resolvedOverview.position, resolvedOverview.lookAt) : null,
         globalProgress: 0,
         monotonicGlobalProgress: 0,
+        phase: 'fractureCharge',
+        cameraMode: 'hold',
+        phaseStart: HERO_OVERVIEW_PILOT_CAMERA_TIMELINE.fractureCharge.start,
+        phaseEnd: HERO_OVERVIEW_PILOT_CAMERA_TIMELINE.fractureCharge.end,
         phaseProgress: 0,
+        phaseLocalProgress: 0,
+        cameraTravelProgress: 0,
+        cameraTravelEasedProgress: 0,
+        cameraTravelEasing: 'none',
+        heldCameraPosition: vectorToPlain(camera.position),
+        heldLookAt: vectorToPlain(fromLookAt),
+        isHoldingCamera: true,
+        firstTravelFrame: null,
+        travelStartTime: null,
+        travelStartProgress: HERO_OVERVIEW_PILOT_CAMERA_TIMELINE.overviewTravel.start,
+        travelDuration: round4(HERO_OVERVIEW_PILOT_CAMERA_TIMELINE.overviewTravel.end - HERO_OVERVIEW_PILOT_CAMERA_TIMELINE.overviewTravel.start),
+        settleStartProgress: HERO_OVERVIEW_PILOT_CAMERA_TIMELINE.overviewSettle.start,
+        finalPoseLocked: false,
+        distanceMovedDuringFractureCharge: 0,
+        distanceMovedDuringExplosionImpulse: 0,
+        distanceMovedDuringBulletTimeSlowdown: 0,
+        distanceMovedDuringOverviewTravel: 0,
+        distanceMovedDuringOverviewSettle: 0,
+        fovChangedDuringHold: false,
+        filmOffsetChangedDuringHold: false,
         runtimePhase: heroOverviewObservedPhase,
         progressSource: 'monotonic-run-progress:max(elapsed,runtime,explosion)',
         progressSourceUsedForCameraWrite: 'not-writing-on-capture-row',
@@ -3708,6 +3921,8 @@ const UnifiedCameraController = ({
             : null,
           phaseModel: HERO_OVERVIEW_PILOT_PHASES,
           phaseBehaviors: HERO_OVERVIEW_PILOT_PHASE_BEHAVIORS,
+          cameraTimeline: HERO_OVERVIEW_PILOT_CAMERA_TIMELINE,
+          pilotCinematicMilestone: 'Milestone C',
           fromPoseSource: 'live-camera-transform',
           ownsCameraInMilestoneA: false,
           ownsCameraInMilestoneB: Boolean(resolvedOverview),
@@ -4486,29 +4701,51 @@ const UnifiedCameraController = ({
         const monotonicGlobalProgress = Math.max(previousMonotonicProgress, progressCandidate);
         transition.monotonicGlobalProgress = monotonicGlobalProgress;
         const globalProgress = THREE.MathUtils.clamp(monotonicGlobalProgress, 0, 1);
-        const easedProgress = THREE.MathUtils.clamp(globalProgress >= 1 ? 1 : 1 - (2 ** (-10 * globalProgress)), 0, 1);
         const runtimePhase = runtimeSnapshot?.phase ?? null;
-        const pilotPhase = globalProgress >= 1
-          ? 'complete'
-          : (runtimePhase === 'fractureCharge' || runtimePhase === 'explosionImpulse' || runtimePhase === 'bulletTimeSlowdown'
-              ? runtimePhase
-              : (globalProgress < 0.94 ? 'overviewTravel' : 'overviewSettle'));
-        const phaseProgress = pilotPhase === 'complete' ? 1 : easedProgress;
+        const cinematicProgress = getHeroOverviewPilotCameraProgress(globalProgress);
+        const pilotPhase = globalProgress >= 1 ? 'complete' : cinematicProgress.phaseName;
+        const phaseProgress = cinematicProgress.phaseLocalProgress;
         if (authoritativeHeroToOverviewTransitionRef.current.active) {
           authoritativeHeroToOverviewTransitionRef.current.active = false;
           transition.blockedLegacyWriterCount = (transition.blockedLegacyWriterCount ?? 0) + 1;
         }
-        const nextPosition = new THREE.Vector3().lerpVectors(fromPose.position, toPose.position, easedProgress);
-        const nextLookAt = introLookAtTempRef.current.lerpVectors(fromPose.lookAt, toPose.lookAt, easedProgress);
         const fromFov = Number.isFinite(fromPose.fov) ? fromPose.fov : camera.fov;
         const toFov = Number.isFinite(toPose.fov) ? toPose.fov : fromFov;
         const fromFilmOffset = Number.isFinite(fromPose.filmOffset) ? fromPose.filmOffset : 0;
         const toFilmOffset = Number.isFinite(toPose.filmOffset) ? toPose.filmOffset : 0;
+        const isFinalPoseLocked = globalProgress >= 1 || pilotPhase === 'overviewSettle' || pilotPhase === 'complete';
+        const cameraTravelEasedProgress = isFinalPoseLocked ? 1 : cinematicProgress.cameraTravelEasedProgress;
+        const nextPosition = isFinalPoseLocked
+          ? toPose.position.clone()
+          : new THREE.Vector3().lerpVectors(fromPose.position, toPose.position, cameraTravelEasedProgress);
+        const nextLookAt = isFinalPoseLocked
+          ? toPose.lookAt.clone()
+          : introLookAtTempRef.current.lerpVectors(fromPose.lookAt, toPose.lookAt, cameraTravelEasedProgress);
+        const nextFov = isFinalPoseLocked ? toFov : THREE.MathUtils.lerp(fromFov, toFov, cameraTravelEasedProgress);
+        const nextFilmOffset = isFinalPoseLocked ? toFilmOffset : THREE.MathUtils.lerp(fromFilmOffset, toFilmOffset, cameraTravelEasedProgress);
+        if (transition.firstTravelFrame == null && cameraTravelEasedProgress > 0.0001) {
+          transition.firstTravelFrame = state.clock.frame;
+          transition.travelStartTime = state.clock.elapsedTime;
+          transition.travelStartProgress = globalProgress;
+        }
+        if (cinematicProgress.isHoldingCamera) {
+          if (Math.abs(nextFov - fromFov) > 0.0001) transition.fovChangedDuringHold = true;
+          if (Math.abs((nextFilmOffset ?? 0) - (fromFilmOffset ?? 0)) > 0.0001) transition.filmOffsetChangedDuringHold = true;
+        }
+        const movedThisFrame = transition.previousCinematicCameraPosition
+          ? nextPosition.distanceTo(transition.previousCinematicCameraPosition)
+          : 0;
+        const distancePhase = pilotPhase === 'complete' ? 'overviewSettle' : pilotPhase;
+        transition.phaseDistanceMoved = transition.phaseDistanceMoved ?? getHeroOverviewPilotPhaseMetrics();
+        if (transition.phaseDistanceMoved[distancePhase] != null) {
+          transition.phaseDistanceMoved[distancePhase] += movedThisFrame;
+        }
+        transition.previousCinematicCameraPosition = nextPosition.clone();
         const upCorrection = applyCanonicalCameraUp();
         camera.position.copy(nextPosition);
         camera.lookAt(nextLookAt);
-        camera.fov = THREE.MathUtils.lerp(fromFov, toFov, easedProgress);
-        camera.filmOffset = THREE.MathUtils.lerp(fromFilmOffset, toFilmOffset, easedProgress);
+        camera.fov = nextFov;
+        camera.filmOffset = nextFilmOffset;
         camera.updateProjectionMatrix();
         currentTarget.current.position.copy(nextPosition);
         currentTarget.current.lookAt.copy(nextLookAt);
@@ -4527,14 +4764,38 @@ const UnifiedCameraController = ({
         const filmOffsetDeltaToTarget = round4(Math.abs((camera.filmOffset ?? 0) - (toFilmOffset ?? 0)));
         pushHeroOverviewPilotSample({
           type: globalProgress >= 1 ? 'completion-handoff' : 'pilot-frame',
-          pilotDiagnosticVersion: 'PR-25-live-lookat-takeover-clear',
+          pilotDiagnosticVersion: 'Milestone C cinematic timeline',
+          pilotCinematicMilestone: 'Milestone C',
           t: round4(state.clock.elapsedTime),
           frame: state.clock.frame,
           key: pilot.key,
           fromPoseSource: transition.fromPoseSource ?? null,
           fromLookAtSource: transition.fromLookAtSource ?? null,
           phase: pilotPhase,
+          cameraMode: cinematicProgress.cameraMode,
+          phaseStart: round4(cinematicProgress.phaseStart),
+          phaseEnd: round4(cinematicProgress.phaseEnd),
           phaseProgress: round4(phaseProgress),
+          phaseLocalProgress: round4(cinematicProgress.phaseLocalProgress),
+          cameraTravelProgress: round4(cinematicProgress.cameraTravelProgress),
+          cameraTravelEasedProgress: round4(cameraTravelEasedProgress),
+          cameraTravelEasing: cinematicProgress.cameraTravelEasing,
+          heldCameraPosition: cinematicProgress.isHoldingCamera ? vectorToPlain(fromPose.position) : null,
+          heldLookAt: cinematicProgress.isHoldingCamera ? vectorToPlain(fromPose.lookAt) : null,
+          isHoldingCamera: cinematicProgress.isHoldingCamera,
+          firstTravelFrame: transition.firstTravelFrame,
+          travelStartTime: round4(transition.travelStartTime),
+          travelStartProgress: round4(transition.travelStartProgress),
+          travelDuration: round4(transition.travelDuration),
+          settleStartProgress: round4(transition.settleStartProgress),
+          finalPoseLocked: isFinalPoseLocked,
+          distanceMovedDuringFractureCharge: round4(transition.phaseDistanceMoved?.fractureCharge ?? 0),
+          distanceMovedDuringExplosionImpulse: round4(transition.phaseDistanceMoved?.explosionImpulse ?? 0),
+          distanceMovedDuringBulletTimeSlowdown: round4(transition.phaseDistanceMoved?.bulletTimeSlowdown ?? 0),
+          distanceMovedDuringOverviewTravel: round4(transition.phaseDistanceMoved?.overviewTravel ?? 0),
+          distanceMovedDuringOverviewSettle: round4(transition.phaseDistanceMoved?.overviewSettle ?? 0),
+          fovChangedDuringHold: Boolean(transition.fovChangedDuringHold),
+          filmOffsetChangedDuringHold: Boolean(transition.filmOffsetChangedDuringHold),
           globalProgress: round4(globalProgress),
           monotonicGlobalProgress: round4(monotonicGlobalProgress),
           rawSharedProgress: round4(rawSharedProgress),
@@ -4673,13 +4934,37 @@ const UnifiedCameraController = ({
           heroToOverviewHandoffLockFramesRef.current = HERO_TO_OVERVIEW_HANDOFF_LOCK_FRAMES;
           pushHeroOverviewPilotSample({
             type: 'pilot-completion-finalized',
-            pilotDiagnosticVersion: 'PR-25-live-lookat-takeover-clear',
+            pilotDiagnosticVersion: 'Milestone C cinematic timeline',
+            pilotCinematicMilestone: 'Milestone C',
             t: round4(state.clock.elapsedTime),
             frame: state.clock.frame,
             key: pilot.key,
             fromPoseSource: transition.fromPoseSource ?? null,
             fromLookAtSource: transition.fromLookAtSource ?? null,
             phase: 'complete',
+            cameraMode: 'complete',
+            phaseStart: 1,
+            phaseEnd: 1,
+            phaseLocalProgress: 1,
+            cameraTravelProgress: 1,
+            cameraTravelEasedProgress: 1,
+            cameraTravelEasing: 'complete',
+            heldCameraPosition: null,
+            heldLookAt: null,
+            isHoldingCamera: false,
+            firstTravelFrame: transition.firstTravelFrame,
+            travelStartTime: round4(transition.travelStartTime),
+            travelStartProgress: round4(transition.travelStartProgress),
+            travelDuration: round4(transition.travelDuration),
+            settleStartProgress: round4(transition.settleStartProgress),
+            finalPoseLocked: true,
+            distanceMovedDuringFractureCharge: round4(transition.phaseDistanceMoved?.fractureCharge ?? 0),
+            distanceMovedDuringExplosionImpulse: round4(transition.phaseDistanceMoved?.explosionImpulse ?? 0),
+            distanceMovedDuringBulletTimeSlowdown: round4(transition.phaseDistanceMoved?.bulletTimeSlowdown ?? 0),
+            distanceMovedDuringOverviewTravel: round4(transition.phaseDistanceMoved?.overviewTravel ?? 0),
+            distanceMovedDuringOverviewSettle: round4(transition.phaseDistanceMoved?.overviewSettle ?? 0),
+            fovChangedDuringHold: Boolean(transition.fovChangedDuringHold),
+            filmOffsetChangedDuringHold: Boolean(transition.filmOffsetChangedDuringHold),
             globalProgress: 1,
             monotonicGlobalProgress: 1,
             activeWriter: 'HERO_OVERVIEW_PILOT',
@@ -5746,7 +6031,7 @@ const UnifiedCameraController = ({
         }
         pushHeroOverviewPilotSample({
           type: 'handoff-lock-frame',
-          pilotDiagnosticVersion: 'PR-25-live-lookat-takeover-clear',
+          pilotDiagnosticVersion: 'Milestone C cinematic timeline',
           t: round4(state.clock.elapsedTime),
           frame: state.clock.frame,
           key: heroOverviewPilotRef.current.key,

--- a/src/components/three/UnifiedCrystalScene.jsx
+++ b/src/components/three/UnifiedCrystalScene.jsx
@@ -47,6 +47,25 @@ const REFORM_SWAP_OVERLAP_MS = 100
 const ENABLE_OVERVIEW_ALL_CONNECTORS = true
 
 const logger = createLogger('unified-crystal-scene');
+const vectorToPlain = (v) => v ? ({ x: Number(v.x?.toFixed?.(4) ?? v.x), y: Number(v.y?.toFixed?.(4) ?? v.y), z: Number(v.z?.toFixed?.(4) ?? v.z) }) : null;
+const quaternionToPlain = (q) => q ? ({ x: Number(q.x?.toFixed?.(4) ?? q.x), y: Number(q.y?.toFixed?.(4) ?? q.y), z: Number(q.z?.toFixed?.(4) ?? q.z), w: Number(q.w?.toFixed?.(4) ?? q.w) }) : null;
+const objectTransformSnapshot = (object) => {
+  if (!object) return null;
+  object.updateMatrixWorld?.(true);
+  const worldPosition = new THREE.Vector3();
+  const worldQuaternion = new THREE.Quaternion();
+  const worldScale = new THREE.Vector3();
+  object.matrixWorld.decompose(worldPosition, worldQuaternion, worldScale);
+  return {
+    name: object.name || object.type || null,
+    localPosition: vectorToPlain(object.position),
+    localQuaternion: quaternionToPlain(object.quaternion),
+    localScale: vectorToPlain(object.scale),
+    worldPosition: vectorToPlain(worldPosition),
+    worldQuaternion: quaternionToPlain(worldQuaternion),
+    worldScale: vectorToPlain(worldScale),
+  };
+};
 
 const UnifiedCrystalScene = forwardRef(({ 
   animationData,
@@ -1647,6 +1666,21 @@ const UnifiedCrystalScene = forwardRef(({
   useFrame((state, deltaTime) => {
     if (!animationData || !facetRefs.current.length || simplifiedAnimations) return;
     const now = performance.now();
+    if (import.meta.env.DEV && typeof globalThis !== 'undefined') {
+      globalThis.__crystalSceneVisibleCompositionSnapshot = {
+        frame: state.clock?.frame ?? null,
+        t: Number(state.clock?.elapsedTime?.toFixed?.(4) ?? state.clock?.elapsedTime ?? 0),
+        state: animationData?.state ?? null,
+        cameraState: animationData?.cameraState ?? null,
+        viewMode: animationData?.viewMode ?? null,
+        crystalForm: animationData?.crystalForm ?? null,
+        showWholeCrystal,
+        showFacets,
+        crystalGroup: objectTransformSnapshot(crystalGroupRef.current),
+        wholeCrystal: objectTransformSnapshot(wholeCrystalRef.current),
+        facetsGroup: objectTransformSnapshot(facetsGroupRef.current),
+      };
+    }
 
     if (
       animationData.crystalForm === 'exploded' &&


### PR DESCRIPTION
### Motivation
- Provide an initial cinematic refinement pass that creates a clear phase-separated Hero → Overview transition (hold → impact → bullet-time → travel → settle) while preserving the ownership and parity guardrails from prior milestones. 
- Make camera choreography tunable via a small declarative timeline so designers can iterate timing/easing without touching core ownership logic.

### Description
- Add a configurable `HERO_OVERVIEW_PILOT_CAMERA_TIMELINE` and helpers (`getHeroOverviewPilotTimelinePhase`, `getHeroOverviewPilotCameraProgress`, `easeHeroOverviewPilotProgress`) to `UnifiedCameraController.jsx` to expose phase windows, per-phase local progress, and eased travel progress. 
- Implement conservative Milestone C behavior where `fractureCharge`, `explosionImpulse`, and `bulletTimeSlowdown` hold the live `fromPose`, `overviewTravel` performs the main interpolated dolly (default `start: 0.42, end: 0.88`, `easing: expoOut`), and `overviewSettle` locks final pose with canonical `up`, `fov: 44`, and `filmOffset: 0`. 
- Expand the owning-pilot runtime state and diagnostics to record cinematic fields (phase name, `phaseLocalProgress`, `cameraTravelProgress`, `cameraTravelEasedProgress`, `firstTravelFrame`, `travelStartTime`, per-phase distance counters, `fovChangedDuringHold`, `filmOffsetChangedDuringHold`, `finalPoseLocked`, etc.) and add `globalThis.__printHeroOverviewPilotCinematic?.()` for a summarized cinematic report. 
- Update docs at `docs/camera-director-pilot-hero-overview.md` with a Milestone C section describing the timeline, tuning guidance, rollback safety, and visual test checklist; keep the pilot feature-flagged and disabled by default to preserve legacy flag-off behavior.

### Testing
- Ran the production build via `npm run build` and the build completed successfully with no runtime build errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b10f3afd883288009ca6ac0766441)